### PR TITLE
compiler: Clarify recv_rpc value names and documentation [nfc]

### DIFF
--- a/artiq/compiler/transforms/llvm_ir_generator.py
+++ b/artiq/compiler/transforms/llvm_ir_generator.py
@@ -1265,10 +1265,12 @@ class LLVMIRGenerator:
             return ll.Undefined
 
         # T result = {
-        #   void *ptr = NULL;
-        #   loop: int size = rpc_recv("tag", ptr);
+        #   void *ret_ptr = alloca(sizeof(T));
+        #   void *ptr = ret_ptr;
+        #   loop: int size = recv_rpc(ptr);
+        #   // Non-zero: Provide `size` bytes of extra storage for variable-length data.
         #   if(size) { ptr = alloca(size); goto loop; }
-        #   else *(T*)ptr
+        #   else *(T*)ret_ptr
         # }
         llprehead   = self.llbuilder.basic_block
         llhead      = self.llbuilder.append_basic_block(name="rpc.head")
@@ -1283,7 +1285,7 @@ class LLVMIRGenerator:
         self.llbuilder.branch(llhead)
 
         self.llbuilder.position_at_end(llhead)
-        llphi = self.llbuilder.phi(llslotgen.type, name="rpc.size")
+        llphi = self.llbuilder.phi(llslotgen.type, name="rpc.ptr")
         llphi.add_incoming(llslotgen, llprehead)
         if llunwindblock:
             llsize = self.llbuilder.invoke(self.llbuiltin("recv_rpc"), [llphi],


### PR DESCRIPTION
Previously, the phi emitted for the pointer parameter to recv_rpc was –
rather confusingly – called "size", and the pseudo-code in the comment
had bit-rotted.