### PR TITLE
Add tooltips to experiment arguments

### DIFF
--- a/artiq/browser/experiments.py
+++ b/artiq/browser/experiments.py
@@ -64,7 +64,7 @@ class _ArgumentEditor(QtWidgets.QTreeWidget):
 
             entry = procdesc_to_entry(argument["desc"])(argument)
             widget_item = QtWidgets.QTreeWidgetItem([name])
-            if argument.get("tooltip", None):
+            if argument["tooltip"]:
                 widget_item.setToolTip(0, argument["tooltip"])
             widgets["entry"] = entry
             widgets["widget_item"] = widget_item

--- a/artiq/browser/experiments.py
+++ b/artiq/browser/experiments.py
@@ -64,6 +64,8 @@ class _ArgumentEditor(QtWidgets.QTreeWidget):
 
             entry = procdesc_to_entry(argument["desc"])(argument)
             widget_item = QtWidgets.QTreeWidgetItem([name])
+            if argument.get("tooltip", None):
+                widget_item.setToolTip(0, argument["tooltip"])
             widgets["entry"] = entry
             widgets["widget_item"] = widget_item
 
@@ -469,11 +471,12 @@ class ExperimentsArea(QtWidgets.QMdiArea):
 
     def initialize_submission_arguments(self, arginfo):
         arguments = OrderedDict()
-        for name, (procdesc, group) in arginfo.items():
+        for name, (procdesc, group, tooltip) in arginfo.items():
             state = procdesc_to_entry(procdesc).default_state(procdesc)
             arguments[name] = {
                 "desc": procdesc,
                 "group": group,
+                "tooltip": tooltip,
                 "state": state  # mutated by entries
             }
         return arguments

--- a/artiq/dashboard/experiments.py
+++ b/artiq/dashboard/experiments.py
@@ -73,6 +73,8 @@ class _ArgumentEditor(QtWidgets.QTreeWidget):
 
             entry = procdesc_to_entry(argument["desc"])(argument)
             widget_item = QtWidgets.QTreeWidgetItem([name])
+            if argument["tooltip"]:
+                widget_item.setToolTip(0, argument["tooltip"])
             widgets["entry"] = entry
             widgets["widget_item"] = widget_item
 
@@ -523,12 +525,13 @@ class ExperimentManager:
 
     def initialize_submission_arguments(self, expurl, arginfo):
         arguments = OrderedDict()
-        for name, (procdesc, group) in arginfo.items():
+        for name, (procdesc, group, tooltip) in arginfo.items():
             state = procdesc_to_entry(procdesc).default_state(procdesc)
             arguments[name] = {
                 "desc": procdesc,
                 "group": group,
-                "state": state  # mutated by entries
+                "tooltip": tooltip,
+                "state": state,  # mutated by entries
             }
         self.submission_arguments[expurl] = arguments
         return arguments

--- a/artiq/language/environment.py
+++ b/artiq/language/environment.py
@@ -174,8 +174,8 @@ class TraceArgumentManager:
     def __init__(self):
         self.requested_args = OrderedDict()
 
-    def get(self, key, processor, group):
-        self.requested_args[key] = processor, group
+    def get(self, key, processor, group, tooltip):
+        self.requested_args[key] = processor, group, tooltip
         return None
 
 
@@ -183,7 +183,7 @@ class ProcessArgumentManager:
     def __init__(self, unprocessed_arguments):
         self.unprocessed_arguments = unprocessed_arguments
 
-    def get(self, key, processor, group):
+    def get(self, key, processor, group, tooltip):
         if key in self.unprocessed_arguments:
             r = processor.process(self.unprocessed_arguments[key])
         else:
@@ -233,7 +233,7 @@ class HasEnvironment:
         only meant to be executed programmatically (not from the GUI)."""
         pass
 
-    def get_argument(self, key, processor, group=None):
+    def get_argument(self, key, processor, group=None, tooltip=None):
         """Retrieves and returns the value of an argument.
 
         This function should only be called from ``build``.
@@ -243,18 +243,21 @@ class HasEnvironment:
             as instances of ``BooleanValue`` and ``NumberValue``.
         :param group: An optional string that defines what group the argument
             belongs to, for user interface purposes.
+        :param tooltip: An optional string to describe the argument in more
+            detail, applied as a tooltip to the argument name in the user
+            interface.
         """
         if not self.__in_build:
             raise TypeError("get_argument() should only "
                             "be called from build()")
-        return self.__argument_mgr.get(key, processor, group)
+        return self.__argument_mgr.get(key, processor, group, tooltip)
 
-    def setattr_argument(self, key, processor=None, group=None):
+    def setattr_argument(self, key, processor=None, group=None, tooltip=None):
         """Sets an argument as attribute. The names of the argument and of the
         attribute are the same.
 
         The key is added to the instance's kernel invariants."""
-        setattr(self, key, self.get_argument(key, processor, group))
+        setattr(self, key, self.get_argument(key, processor, group, tooltip))
         kernel_invariants = getattr(self, "kernel_invariants", set())
         self.kernel_invariants = kernel_invariants | {key}
 

--- a/artiq/master/worker_impl.py
+++ b/artiq/master/worker_impl.py
@@ -166,8 +166,8 @@ def examine(device_mgr, dataset_mgr, file):
             argument_mgr = TraceArgumentManager()
             exp_class((device_mgr, dataset_mgr, argument_mgr))
             arginfo = OrderedDict(
-                (k, (proc.describe(), group))
-                for k, (proc, group) in argument_mgr.requested_args.items())
+                (k, (proc.describe(), group, tooltip))
+                for k, (proc, group, tooltip) in argument_mgr.requested_args.items())
             register_experiment(class_name, name, arginfo)
 
 


### PR DESCRIPTION
This adds optional tooltips to experiment arguments in the Artiq Dashboard and Browser. 

This is useful as the ArgumentEditor gets unwieldy for long argument names - this allows one to use short argument names and add extra context as a tooltip.