### PR TITLE
Add experiment repository to experiment PYTHONPATH

### DIFF
--- a/artiq/master/scheduler.py
+++ b/artiq/master/scheduler.py
@@ -45,7 +45,7 @@ def _mk_worker_method(name):
 
 class Run:
     def __init__(self, rid, pipeline_name,
-                 wd, expid, priority, due_date, flush,
+                 wd, repo_path, expid, priority, due_date, flush,
                  pool, **kwargs):
         # called through pool
         self.rid = rid
@@ -56,7 +56,7 @@ class Run:
         self.due_date = due_date
         self.flush = flush
 
-        self.worker = Worker(pool.worker_handlers)
+        self.worker = Worker(pool.worker_handlers, repo_path=repo_path)
         self.termination_requested = False
 
         self._status = RunStatus.pending
@@ -135,10 +135,12 @@ class RunPool:
                 expid["repo_rev"] = self.experiment_db.cur_rev
             wd, repo_msg = self.experiment_db.repo_backend.request_rev(
                 expid["repo_rev"])
+            repo_path = wd
         else:
             wd, repo_msg = None, None
-        run = Run(rid, pipeline_name, wd, expid, priority, due_date, flush,
-                  self, repo_msg=repo_msg)
+            repo_path = self.experiment_db.repo_backend.request_rev(None)
+        run = Run(rid, pipeline_name, wd, repo_path, expid, priority, due_date, 
+                  flush, self, repo_msg=repo_msg)
         self.runs[rid] = run
         self.state_changed.notify()
         return rid


### PR DESCRIPTION
This implements #648.

If the git backend is used the repository is checked out as 'repository' into a clean temporary directory, which is added to the worker PYTHONPATH. If the filesystem backend is used, the parent of the repository directory is added to the worker PYTHONPATH. So long as the repository is a valid python module it can then be imported as 'repository' (using git backend) or whatever the repository directory name is (using filesystem backend). 

A potential nasty is adding things to the PYTHONPATH unintentionally when using the filesystem backend, but this can be avoided by putting the repository directory in an (otherwise) empty directory. In any case, I assume all serious work will be done out of a git repository.

At the moment artiq_browser does not know about the experiment repository, hence absolute imports in experiments will not work unless the user manually appends to PYTHONPATH. I don't see a neat solution to this - one option is a 'repository' command line argument that is added to the worker PYTHONPATH.

If everyone is happy with this implementation I will document it.