### PR TITLE
conda: use anaconda default pyqt (fixes #670)

### DIFF
--- a/conda/artiq-dev/meta.yaml
+++ b/conda/artiq-dev/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - sphinx_rtd_theme
     - h5py
     - dateutil
-    - pyqt5
+    - pyqt
     - quamash
     - pyqtgraph
     - pygit2

--- a/conda/artiq/meta.yaml
+++ b/conda/artiq/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - asyncserial
     - h5py
     - dateutil
-    - pyqt5
+    - pyqt
     - quamash
     - pyqtgraph
     - pygit2


### PR DESCRIPTION
The anaconda default anaconda pyqt (currently at 5.6.0) now works. 
If the m-labs pyqt5 package is installed alongside the anaconda pyqt package neither works - there are companion PRs to ensure m-labs/pyqtgraph and m-labs/quamash use the anaconda default pyqt. 
Tested on Windows and Linux: there are nothing obvious broken.