### PR TITLE
monkey-patch Python 3.5.3 asyncio.base_events._ipaddr_info

### DIFF
--- a/artiq/monkey_patches.py
+++ b/artiq/monkey_patches.py
@@ -4,7 +4,7 @@ import sys
 __all__ = []
 
 
-if sys.version_info[:3] == (3, 5, 2):
+if sys.version_info[:2] == (3, 5) and sys.version_info[2] in (2, 3):
     import asyncio
 
     # See https://github.com/m-labs/artiq/issues/506


### PR DESCRIPTION
#506 / #508 appear again on Python 3.5.3 (see #670)