### PR TITLE
master: rotate logs at midnight, rather than on log size

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -51,6 +51,7 @@ Release notes
 * The PDQ(2/3) driver has been removed and is now being maintained out-of tree
   at https://github.com/m-labs/pdq. All SPI/USB driver layers, Mediator,
   CompoundPDQ and examples/documentation has been moved.
+* The master now rotates log files at midnight, rather than based on log size.
 
 
 2.4

--- a/artiq/master/log.py
+++ b/artiq/master/log.py
@@ -29,7 +29,7 @@ def log_args(parser):
                             "base filename")
     group.add_argument("--log-backup-count", type=int, default=0,
                        help="number of old log files to keep, or 0 to keep "
-                            "all log files. '.<yy>-<mm>-<dd>' is added "
+                            "all log files. '.<yyyy>-<mm>-<dd>' is added "
                             "to the base filename (default: %(default)d)")
 
 

--- a/artiq/master/log.py
+++ b/artiq/master/log.py
@@ -27,11 +27,9 @@ def log_args(parser):
     group.add_argument("--log-file", default="",
                        help="store logs in rotated files; set the "
                             "base filename")
-    group.add_argument("--log-max-size", type=int, default=1024,
-                       help="maximum size of each log file in KiB "
-                            "(default: %(default)d)")
-    group.add_argument("--log-backup-count", type=int, default=6,
-                       help="number of old log files to keep (.<n> is added "
+    group.add_argument("--log-backup-count", type=int, default=0,
+                       help="number of old log files to keep, or 0 to keep "
+                            "all log files. '.<yy>-<mm>-<dd>' is added "
                             "to the base filename (default: %(default)d)")
 
 
@@ -47,9 +45,9 @@ def init_log(args):
     handlers.append(console_handler)
 
     if args.log_file:
-        file_handler = logging.handlers.RotatingFileHandler(
+        file_handler = logging.handlers.TimedRotatingFileHandler(
             args.log_file,
-            maxBytes=args.log_max_size*1024,
+            when="midnight",
             backupCount=args.log_backup_count)
         file_handler.setFormatter(logging.Formatter(
             "%(asctime)s %(levelname)s:%(source)s:%(name)s:%(message)s"))


### PR DESCRIPTION
Currently the master rotates logs based on file size, with numeric postfixes indicating the log age - this means that it is hard to determine which log file contains the output from a given experiment.

This patch changes the log rotation to occur at midnight. This means that after the log rolls over there is an easy to understand and immutable relationship between the experiment and the log file containing its output.