### PR TITLE
Label masters with friendly name, store dashboard config per master (closes #848)

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -7,6 +7,10 @@ Release notes
 ----------------
 
 * The DDS channel number for the NIST CLOCK target has changed.
+* The dashboard configuration files are now stored one-per-master, keyed by the
+  server address argument and the notify port.
+* The master now has a ``--name`` argument. If given, the dashboard is labelled
+  with this name rather than the server address.
 
 
 3.0

--- a/artiq/frontend/artiq_dashboard.py
+++ b/artiq/frontend/artiq_dashboard.py
@@ -218,8 +218,11 @@ def main():
     if d_log0 is not None:
         main_window.tabifyDockWidget(d_schedule, d_log0)
 
+    server_description = server_name
+    if server_name != args.server:
+        server_description += " ({})".format(args.server)
     logging.info("ARTIQ dashboard %s connected to %s",
-                 artiq_version, server_name)
+                 artiq_version, server_description)
 
     # run
     main_window.show()

--- a/artiq/frontend/artiq_dashboard.py
+++ b/artiq/frontend/artiq_dashboard.py
@@ -21,9 +21,6 @@ from artiq.dashboard import (experiments, shortcuts, explorer,
 
 
 def get_argparser():
-    default_db_file = os.path.join(get_user_config_dir(),
-                                   "artiq_dashboard.pyon")
-
     parser = argparse.ArgumentParser(description="ARTIQ Dashboard")
     parser.add_argument(
         "-s", "--server", default="::1",
@@ -38,9 +35,8 @@ def get_argparser():
         "--port-broadcast", default=1067, type=int,
         help="TCP port to connect to for broadcasts")
     parser.add_argument(
-        "--db-file", default=default_db_file,
-        help="database file for local GUI settings "
-             "(default: %(default)s)")
+        "--db-file", default=None,
+        help="database file for local GUI settings")
     verbosity_args(parser)
     return parser
 
@@ -92,6 +88,12 @@ def main():
     # initialize application
     args = get_argparser().parse_args()
     widget_log_handler = log.init_log(args, "dashboard")
+
+    if args.db_file is None:
+        args.db_file = os.path.join(get_user_config_dir(),
+                           "artiq_dashboard_{server}_{port}.pyon".format(
+                            server=args.server.replace(":","."),
+                            port=args.port_notify))
 
     app = QtWidgets.QApplication(["ARTIQ Dashboard"])
     loop = QEventLoop(app)

--- a/artiq/frontend/artiq_dashboard.py
+++ b/artiq/frontend/artiq_dashboard.py
@@ -12,7 +12,7 @@ from quamash import QEventLoop
 from artiq import __artiq_dir__ as artiq_dir, __version__ as artiq_version
 from artiq.tools import (atexit_register_coroutine, verbosity_args,
                          get_user_config_dir)
-from artiq.protocols.pc_rpc import AsyncioClient
+from artiq.protocols.pc_rpc import AsyncioClient, Client
 from artiq.protocols.broadcast import Receiver
 from artiq.gui.models import ModelSubscriber
 from artiq.gui import state, log
@@ -110,6 +110,11 @@ def main():
         atexit.register(client.close_rpc)
         rpc_clients[target] = client
 
+    config = Client(args.server, args.port_control, "master_config")
+    server_name = config.get_name()
+    if server_name is None:
+        server_name = args.server
+
     disconnect_reported = False
     def report_disconnect():
         nonlocal disconnect_reported
@@ -139,7 +144,7 @@ def main():
         broadcast_clients[target] = client
 
     # initialize main window
-    main_window = MainWindow(args.server)
+    main_window = MainWindow(server_name)
     smgr.register(main_window)
     mdi_area = MdiArea()
     mdi_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
@@ -211,7 +216,7 @@ def main():
         main_window.tabifyDockWidget(d_schedule, d_log0)
 
     logging.info("ARTIQ dashboard %s connected to %s",
-                 artiq_version, args.server)
+                 artiq_version, server_name)
 
     # run
     main_window.show()

--- a/artiq/frontend/artiq_dashboard.py
+++ b/artiq/frontend/artiq_dashboard.py
@@ -113,6 +113,7 @@ def main():
         rpc_clients[target] = client
 
     config = Client(args.server, args.port_control, "master_config")
+    atexit.register(config.close_rpc)
     server_name = config.get_name()
     if server_name is None:
         server_name = args.server

--- a/artiq/frontend/artiq_dashboard.py
+++ b/artiq/frontend/artiq_dashboard.py
@@ -36,7 +36,9 @@ def get_argparser():
         help="TCP port to connect to for broadcasts")
     parser.add_argument(
         "--db-file", default=None,
-        help="database file for local GUI settings")
+        help="database file for local GUI settings, "
+             "by default in {} and dependant on master hostname".format(
+                                                        get_user_config_dir()))
     verbosity_args(parser)
     return parser
 

--- a/artiq/frontend/artiq_dashboard.py
+++ b/artiq/frontend/artiq_dashboard.py
@@ -113,10 +113,10 @@ def main():
         rpc_clients[target] = client
 
     config = Client(args.server, args.port_control, "master_config")
-    atexit.register(config.close_rpc)
-    server_name = config.get_name()
-    if server_name is None:
-        server_name = args.server
+    try:
+        server_name = config.get_name()
+    finally:
+        config.close_rpc()
 
     disconnect_reported = False
     def report_disconnect():
@@ -147,7 +147,7 @@ def main():
         broadcast_clients[target] = client
 
     # initialize main window
-    main_window = MainWindow(server_name)
+    main_window = MainWindow(args.server if server_name is None else server_name)
     smgr.register(main_window)
     mdi_area = MdiArea()
     mdi_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
@@ -218,9 +218,11 @@ def main():
     if d_log0 is not None:
         main_window.tabifyDockWidget(d_schedule, d_log0)
 
-    server_description = server_name
-    if server_name != args.server:
-        server_description += " ({})".format(args.server)
+
+    if server_name is not None:
+        server_description = server_name + " ({})".format(args.server)
+    else:
+        server_description = args.server
     logging.info("ARTIQ dashboard %s connected to %s",
                  artiq_version, server_description)
 

--- a/artiq/frontend/artiq_master.py
+++ b/artiq/frontend/artiq_master.py
@@ -55,6 +55,14 @@ def get_argparser():
     return parser
 
 
+class MasterConfig:
+    def __init__(self, name):
+        self.name = name
+
+    def get_name(self):
+        return self.name
+
+
 def main():
     args = get_argparser().parse_args()
     log_forwarder = init_log(args)
@@ -98,11 +106,7 @@ def main():
     scheduler.start()
     atexit_register_coroutine(scheduler.stop)
 
-    class MasterConfig:
-        def get_name(self):
-            return args.name
-    config = MasterConfig()
-
+    config = MasterConfig(args.name)
 
     worker_handlers.update({
         "get_device_db": device_db.get_device_db,
@@ -119,11 +123,11 @@ def main():
     experiment_db.scan_repository_async()
 
     server_control = RPCServer({
+        "master_config": config,
         "master_device_db": device_db,
         "master_dataset_db": dataset_db,
         "master_schedule": scheduler,
-        "master_experiment_db": experiment_db,
-        "master_config": config
+        "master_experiment_db": experiment_db
     }, allow_parallel=True)
     loop.run_until_complete(server_control.start(
         bind, args.port_control))

--- a/artiq/frontend/artiq_master.py
+++ b/artiq/frontend/artiq_master.py
@@ -48,6 +48,8 @@ def get_argparser():
 
     log_args(parser)
 
+    parser.add_argument("--name", help="friendly name")
+
     return parser
 
 
@@ -94,6 +96,12 @@ def main():
     scheduler.start()
     atexit_register_coroutine(scheduler.stop)
 
+    class MasterConfig:
+        def get_name(self):
+            return args.name
+    config = MasterConfig()
+
+
     worker_handlers.update({
         "get_device_db": device_db.get_device_db,
         "get_device": device_db.get,
@@ -112,7 +120,8 @@ def main():
         "master_device_db": device_db,
         "master_dataset_db": dataset_db,
         "master_schedule": scheduler,
-        "master_experiment_db": experiment_db
+        "master_experiment_db": experiment_db,
+        "master_config": config
     }, allow_parallel=True)
     loop.run_until_complete(server_control.start(
         bind, args.port_control))

--- a/artiq/frontend/artiq_master.py
+++ b/artiq/frontend/artiq_master.py
@@ -48,7 +48,9 @@ def get_argparser():
 
     log_args(parser)
 
-    parser.add_argument("--name", help="friendly name")
+    parser.add_argument("--name",
+        help="friendly name, displayed in dashboards "
+             "to identify master instead of server address")
 
     return parser
 


### PR DESCRIPTION
This PR implements two features which make Artiq more pleasant to use when connecting to multiple masters:
1) The dashboard config is (by default) stored separately for each different master, keyed by server address and port. This means that applets and experiment arguments don't mix between different masters.
2) The master can be labelled with a friendly name. If this is present, the dashboard displays this rather than the server address - this is particularly useful when connect to two masters on the same server (distinguished only by port).