### PR TITLE
dashboard: Restore minimized experiments when trying to open them again

### DIFF
--- a/artiq/dashboard/experiments.py
+++ b/artiq/dashboard/experiments.py
@@ -551,6 +551,8 @@ class ExperimentManager:
     def open_experiment(self, expurl):
         if expurl in self.open_experiments:
             dock = self.open_experiments[expurl]
+            if dock.isMinimized():
+                dock.showNormal()
             self.main_window.centralWidget().setActiveSubWindow(dock)
             return dock
         try:


### PR DESCRIPTION
When the user tried to open an experiment from the explorer that
already existed, previously "nothing would happen" (focus change
without the window being restored).