### PR TITLE
firmware: make read leveling robust for KUS SDRAM

### DIFF
--- a/artiq/firmware/libboard/sdram.rs
+++ b/artiq/firmware/libboard/sdram.rs
@@ -207,7 +207,7 @@ mod ddr {
 
             // Get a bit further into the working zone
             #[cfg(kusddrphy)]
-            for _ in 0..8 {
+            for _ in 0..16 {
                 delay.set(delay.get() + 1);
                 ddrphy::rdly_dq_inc_write(1);
             }


### PR DESCRIPTION
Increases the initial delay step into the valid read window from 8 -> 16 as with the original delay I was not getting out of the noisy transition window, as evidenced by seeing read delay windows of only 8 LSB ~10% of the time, leading to failing memory tests.

See discussion on https://irclog.whitequark.org/m-labs/2018-01-11