### PR TITLE
Sayma RTM: hold hmc7043 in reset/mute state during init.

### DIFF
--- a/artiq/firmware/libboard_artiq/hmc830_7043.rs
+++ b/artiq/firmware/libboard_artiq/hmc830_7043.rs
@@ -146,6 +146,7 @@ pub mod hmc7043 {
     const DAC_CLK_DIV: u32 = 2;
     const FPGA_CLK_DIV: u32 = 8;
     const SYSREF_DIV: u32 = 128;
+    const HMC_SYSREF_DIV: u32 = SYSREF_DIV*8; // Must be <= 4MHz
 
     // enabled, divider, analog phase shift, digital phase shift
     const OUTPUT_CONFIG: [(bool, u32, u8, u8); 14] = [
@@ -243,7 +244,6 @@ pub mod hmc7043 {
         spi_setup();
         info!("loading configuration...");
 
-        write(0x3, 0x10);  // Disable SYSREF timer
         write(0xA, 0x06);  // Disable the REFSYNCIN input
         write(0xB, 0x07);  // Enable the CLKIN input as LVPECL
         write(0x50, 0x1f); // Disable GPO pin
@@ -257,14 +257,17 @@ pub mod hmc7043 {
                    (1 << 4) |
                    (1 << 5));
 
+        write(0x5c, (HMC_SYSREF_DIV & 0xff) as u8);  // Set SYSREF timer divider
+        write(0x5d, ((HMC_SYSREF_DIV & 0x0f) >> 8) as u8);
+
         for channel in 0..14 {
             let channel_base = 0xc8 + 0x0a*(channel as u16);
             let (enabled, divider, aphase, dphase) = OUTPUT_CONFIG[channel];
 
             if enabled {
                 // Only clock channels need to be high-performance
-                if (channel % 2) == 0 { write(channel_base, 0x91); }
-                else { write(channel_base, 0x11); }
+                if (channel % 2) == 0 { write(channel_base, 0xd1); }
+                else { write(channel_base, 0x51); }
             }
             else { write(channel_base, 0x10); }
             write(channel_base + 0x1, (divider & 0x0ff) as u8);
@@ -279,7 +282,11 @@ pub mod hmc7043 {
             write(channel_base + 0x8, 0x08)
         }
 
+        write(0x1, 0x4a);  // Reset dividers and FSMs
+        write(0x1, 0x48);
+        write(0x1, 0xc8);  // Synchronize dividers
         write(0x1, 0x40);  // Unmute, high-performace/low-noise mode
+
         info!("  ...done");
 
         Ok(())

--- a/artiq/firmware/libboard_artiq/hmc830_7043.rs
+++ b/artiq/firmware/libboard_artiq/hmc830_7043.rs
@@ -270,8 +270,8 @@ pub mod hmc7043 {
                 else { write(channel_base, 0x51); }
             }
             else { write(channel_base, 0x10); }
-            write(channel_base + 0x1, (divider & 0x0ff) as u8);
-            write(channel_base + 0x2, ((divider & 0x700) >> 8) as u8);
+            write(channel_base + 0x1, (divider & 0xff) as u8);
+            write(channel_base + 0x2, ((divider & 0x0f) >> 8) as u8);
             write(channel_base + 0x3, aphase & 0x1f);
             write(channel_base + 0x4, dphase & 0x1f);
 


### PR DESCRIPTION
Tested on my Sayma. Since implementing this fix, I haven't seen any more runtime crashes (although, serwb still seems unreliable on my board).

This requires the HMC7043 RESET line to be connected in hardware. My board had been reworked to short this to GND. NB connecting the HMC7043 RESET line breaks the Si5324 because they share a reset line.