### PR TITLE
worker_db: Only warn on repeated archive read if dataset changed

### DIFF
--- a/artiq/master/worker_db.py
+++ b/artiq/master/worker_db.py
@@ -227,9 +227,9 @@ class DatasetManager:
         else:
             data = self.ddb.get(key)
             if archive:
-                if key in self.archive:
-                    logger.warning("Dataset '%s' is already in archive, "
-                                   "overwriting", key, stack_info=True)
+                if self.archive.get(key, data) != data:
+                    logger.warning("Older value of dataset '%s' is already in "
+                                   "archive, overwriting", key, stack_info=True)
                 self.archive[key] = data
             return data
 


### PR DESCRIPTION
In larger experiments, it is quite natural for the same dataset
to be read from multiple unrelated components. The only situation
where multiple reads from an archived dataset are problematic is
when the valeu actually changes between reads. Hence, this commit
restricts the warning to the latter situation.