### PR TITLE
ttl: Stop tracking function call cursor positions

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -53,7 +53,7 @@ ARTIQ-4
 * The ``proxy`` action of ``artiq_flash`` is determined automatically and should
   not be specified manually anymore.
 * ``kc705_dds`` has been renamed ``kc705``.
-* the ``-H/--hw-adapter`` option of ``kc705`` has ben renamed ``-V/--variant``.
+* The ``-H/--hw-adapter`` option of ``kc705`` has been renamed ``-V/--variant``.
 * SPI masters have been switched from misoc-spi to misoc-spi2. This affects
   all out-of-tree RTIO core device drivers using those buses. See the various
   commits on e.g. the ``ad53xx`` driver for an example how to port from the old

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -9,6 +9,32 @@ ARTIQ-4
 4.0
 ***
 
+* The ``artiq.coredevice.ttl`` drivers no longer track the timestamps of 
+  submitted events in software, requiring the user to explicitly specify the
+  timeout for ``count()``/``timestamp_mu()``. Support for ``sync()`` has been dropped.
+
+  Now that RTIO has gained DMA support, there is no longer a reliable way for
+  the kernel CPU to track the individual events submitted on any one channel.
+  Requiring the timeouts to be specified explicitly ensures consistent API
+  behavior. To make this more convenient, the ``TTLInOut.gate_*()`` functions
+  now return the cursor position at the end of the gate, e.g.::
+
+    ttl_input.count(ttl_input.gate_rising(100 * us))
+
+  In most situations – that is, unless the timeline cursor is rewound after the
+  respective ``gate_*()`` call – simply passing ``now_mu()`` is also a valid
+  upgrade path::
+
+    ttl_input.count(now_mu())
+
+  The latter might use up more timeline slack than necessary, though.
+
+  In place of ``TTL(In)Out.sync``, the new ``Core.wait_until_mu()`` method can
+  be used, which blocks execution until the hardware RTIO cursor reaches the
+  given timestamp::
+
+    ttl_output.pulse(10 * us)
+    self.core.wait_until_mu(now_mu())
 * RTIO outputs use a new architecture called Scalable Event Dispatcher (SED),
   which allows building systems with large number of RTIO channels more
   efficiently.

--- a/artiq/coredevice/core.py
+++ b/artiq/coredevice/core.py
@@ -151,6 +151,15 @@ class Core:
 
     @kernel
     def get_rtio_counter_mu(self):
+        """Retrieve the current value of the hardware RTIO timeline counter.
+
+        As the timing of kernel code executed on the CPU is inherently
+        non-deterministic, the return value is by necessity only a lower bound
+        for the actual value of the hardware register at the instant when
+        execution resumes in the caller.
+
+        For a more detailed description of these concepts, see :doc:`/rtio`.
+        """
         return rtio_get_counter()
 
     @kernel

--- a/artiq/coredevice/core.py
+++ b/artiq/coredevice/core.py
@@ -154,6 +154,17 @@ class Core:
         return rtio_get_counter()
 
     @kernel
+    def wait_until_mu(self, cursor_mu):
+        """Block execution until the hardware RTIO counter reaches the given
+        value (see :meth:`get_rtio_counter_mu`).
+
+        If the hardware counter has already passed the given time, the function
+        returns immediately.
+        """
+        while self.get_rtio_counter_mu() < cursor_mu:
+            pass
+
+    @kernel
     def get_drtio_link_status(self, linkno):
         """Returns whether the specified DRTIO link is up.
 

--- a/artiq/coredevice/core.py
+++ b/artiq/coredevice/core.py
@@ -134,7 +134,7 @@ class Core:
 
     @portable
     def seconds_to_mu(self, seconds):
-        """Converts seconds to the corresponding number of machine units
+        """Convert seconds to the corresponding number of machine units
         (RTIO cycles).
 
         :param seconds: time (in seconds) to convert.
@@ -143,7 +143,7 @@ class Core:
 
     @portable
     def mu_to_seconds(self, mu):
-        """Converts machine units (RTIO cycles) to seconds.
+        """Convert machine units (RTIO cycles) to seconds.
 
         :param mu: cycle count to convert.
         """
@@ -166,7 +166,7 @@ class Core:
 
     @kernel
     def get_drtio_link_status(self, linkno):
-        """Returns whether the specified DRTIO link is up.
+        """Return whether the specified DRTIO link is up.
 
         This is particularly useful in startup kernels to delay
         startup until certain DRTIO links are up."""

--- a/artiq/coredevice/ttl.py
+++ b/artiq/coredevice/ttl.py
@@ -35,9 +35,6 @@ class TTLOut:
         self.core = dmgr.get(core_device)
         self.channel = channel
 
-        # in RTIO cycles
-        self.o_previous_timestamp = numpy.int64(0)
-
     @kernel
     def output(self):
         pass
@@ -45,14 +42,6 @@ class TTLOut:
     @kernel
     def set_o(self, o):
         rtio_output(now_mu(), self.channel, 0, 1 if o else 0)
-        self.o_previous_timestamp = now_mu()
-
-    @kernel
-    def sync(self):
-        """Busy-wait until all programmed level switches have been
-        effected."""
-        while self.core.get_rtio_counter_mu() < self.o_previous_timestamp:
-            pass
 
     @kernel
     def on(self):
@@ -123,8 +112,6 @@ class TTLInOut:
         self.core = dmgr.get(core_device)
         self.channel = channel
 
-        # in RTIO cycles
-        self.o_previous_timestamp = numpy.int64(0)
         self.i_previous_timestamp = numpy.int64(0)
         self.queued_samples = 0
 
@@ -153,14 +140,6 @@ class TTLInOut:
     @kernel
     def set_o(self, o):
         rtio_output(now_mu(), self.channel, 0, 1 if o else 0)
-        self.o_previous_timestamp = now_mu()
-
-    @kernel
-    def sync(self):
-        """Busy-wait until all programmed level switches have been
-        effected."""
-        while self.core.get_rtio_counter_mu() < self.o_previous_timestamp:
-            pass
 
     @kernel
     def on(self):

--- a/artiq/coredevice/ttl.py
+++ b/artiq/coredevice/ttl.py
@@ -113,7 +113,6 @@ class TTLInOut:
         self.channel = channel
 
         self.i_previous_timestamp = numpy.int64(0)
-        self.queued_samples = 0
 
     @kernel
     def set_oe(self, oe):

--- a/artiq/coredevice/ttl.py
+++ b/artiq/coredevice/ttl.py
@@ -378,8 +378,6 @@ class TTLClockGen:
         self.core = dmgr.get(core_device)
         self.channel = channel
 
-        # in RTIO cycles
-        self.previous_timestamp = numpy.int64(0)
         self.acc_width = numpy.int64(24)
 
     @portable
@@ -415,7 +413,6 @@ class TTLClockGen:
         that are not powers of two cause jitter of one RTIO clock cycle at the
         output."""
         rtio_output(now_mu(), self.channel, 0, frequency)
-        self.previous_timestamp = now_mu()
 
     @kernel
     def set(self, frequency):
@@ -426,10 +423,3 @@ class TTLClockGen:
     def stop(self):
         """Stop the toggling of the clock and set the output level to 0."""
         self.set_mu(0)
-
-    @kernel
-    def sync(self):
-        """Busy-wait until all programmed frequency switches and stops have
-        been effected."""
-        while self.core.get_rtio_counter_mu() < self.o_previous_timestamp:
-            pass

--- a/artiq/examples/kasli_basic/repository/kasli_tester.py
+++ b/artiq/examples/kasli_basic/repository/kasli_tester.py
@@ -152,7 +152,7 @@ class KasliTester(EnvExperiment):
                 for _ in range(n):
                     ttl_out.pulse(2*us)
                     delay(2*us)
-        return ttl_in.count() == n
+        return ttl_in.count(now_mu()) == n
 
     def test_ttl_ins(self):
         print("*** Testing TTL inputs.")

--- a/artiq/examples/kc705_nist_clock/repository/photon_histogram.py
+++ b/artiq/examples/kc705_nist_clock/repository/photon_histogram.py
@@ -38,13 +38,13 @@ class PhotonHistogram(EnvExperiment):
         self.bd_dds.set(self.detect_f)
         with parallel:
             self.bd_sw.pulse(self.detect_t)
-            self.pmt.gate_rising(self.detect_t)
+            gate_end_mu = self.pmt.gate_rising(self.detect_t)
 
         self.program_cooling()
         self.bd_sw.on()
         self.bdd_sw.on()
 
-        return self.pmt.count()
+        return self.pmt.count(gate_end_mu)
 
     @kernel
     def run(self):

--- a/artiq/examples/kc705_nist_clock/repository/tdr.py
+++ b/artiq/examples/kc705_nist_clock/repository/tdr.py
@@ -66,8 +66,8 @@ class TDR(EnvExperiment):
             self.pmt0.gate_both_mu(2*p)
             self.ttl2.pulse_mu(p)
         for i in range(len(self.t)):
-            ti = self.pmt0.timestamp_mu()
+            ti = self.pmt0.timestamp_mu(now_mu())
             if ti <= 0:
                 raise PulseNotReceivedError()
             self.t[i] = int(self.t[i] + ti - t0)
-        self.pmt0.count()  # flush
+        self.pmt0.count(now_mu())  # flush

--- a/artiq/examples/no_hardware/repository/al_spectroscopy.py
+++ b/artiq/examples/no_hardware/repository/al_spectroscopy.py
@@ -21,7 +21,7 @@ class AluminumSpectroscopy(EnvExperiment):
         state_0_count = 0
         for count in range(100):
             self.mains_sync.gate_rising(1*s/60)
-            at_mu(self.mains_sync.timestamp_mu() + 100*us)
+            at_mu(self.mains_sync.timestamp_mu(now_mu()) + 100*us)
             delay(10*us)
             self.laser_cooling.pulse(100*MHz, 100*us)
             delay(5*us)
@@ -35,8 +35,7 @@ class AluminumSpectroscopy(EnvExperiment):
                 delay(5*us)
                 with parallel:
                     self.state_detection.pulse(100*MHz, 10*us)
-                    self.pmt.gate_rising(10*us)
-                photon_count = self.pmt.count()
+                    photon_count = self.pmt.count(self.pmt.gate_rising(10*us))
                 if (photon_count < self.photon_limit_low or
                         photon_count > self.photon_limit_high):
                     break

--- a/artiq/language/core.py
+++ b/artiq/language/core.py
@@ -199,7 +199,12 @@ def delay_mu(duration):
 
 
 def now_mu():
-    """Retrieves the current RTIO time, in machine units."""
+    """Retrieve the current RTIO timeline cursor, in machine units.
+
+    Note the conceptual difference between this and the current value of the
+    hardware RTIO counter; see e.g.
+    :meth:`artiq.coredevice.core.Core.get_rtio_counter_mu` for the latter.
+    """
     return _time_manager.get_time_mu()
 
 

--- a/artiq/sim/devices.py
+++ b/artiq/sim/devices.py
@@ -49,13 +49,13 @@ class Input:
         delay(duration)
 
     @kernel
-    def count(self):
+    def count(self, up_to_timestamp_mu):
         result = self.prng.randrange(0, 100)
         time.manager.event(("count", self.name, result))
         return result
 
     @kernel
-    def timestamp_mu(self):
+    def timestamp_mu(self, up_to_timestamp_mu):
         result = time.manager.get_time_mu()
         result += self.prng.randrange(100, 1000)
         time.manager.event(("timestamp_mu", self.name, result))

--- a/artiq/test/coredevice/test_analyzer.py
+++ b/artiq/test/coredevice/test_analyzer.py
@@ -21,11 +21,10 @@ class CreateTTLPulse(EnvExperiment):
     def run(self):
         self.core.break_realtime()
         with parallel:
-            self.loop_in.gate_both_mu(1200)
             with sequential:
                 delay_mu(100)
                 self.loop_out.pulse_mu(1000)
-        self.loop_in.count()
+            self.loop_in.count(self.loop_in.gate_both_mu(1200))
 
 
 class WriteLog(EnvExperiment):

--- a/artiq/test/coredevice/test_rtio.py
+++ b/artiq/test/coredevice/test_rtio.py
@@ -68,7 +68,7 @@ class RTT(EnvExperiment):
                 delay(1*us)
                 t0 = now_mu()
                 self.ttl_inout.pulse(1*us)
-        t1 = self.ttl_inout.timestamp_mu()
+        t1 = self.ttl_inout.timestamp_mu(now_mu())
         if t1 < 0:
             raise PulseNotReceived()
         self.set_dataset("rtt", self.core.mu_to_seconds(t1 - t0))
@@ -92,7 +92,7 @@ class Loopback(EnvExperiment):
                 delay(1*us)
                 t0 = now_mu()
                 self.loop_out.pulse(1*us)
-        t1 = self.loop_in.timestamp_mu()
+        t1 = self.loop_in.timestamp_mu(now_mu())
         if t1 < 0:
             raise PulseNotReceived()
         self.set_dataset("rtt", self.core.mu_to_seconds(t1 - t0))
@@ -115,7 +115,7 @@ class ClockGeneratorLoopback(EnvExperiment):
             with sequential:
                 delay(200*ns)
                 self.loop_clock_out.set(1*MHz)
-        self.set_dataset("count", self.loop_clock_in.count())
+        self.set_dataset("count", self.loop_clock_in.count(now_mu()))
 
 
 class PulseRate(EnvExperiment):
@@ -203,7 +203,7 @@ class LoopbackCount(EnvExperiment):
                 for i in range(self.npulses):
                     delay(25*ns)
                     self.loop_out.pulse(25*ns)
-        self.set_dataset("count", self.loop_in.count())
+        self.set_dataset("count", self.loop_in.count(now_mu()))
 
 
 class IncorrectLevel(Exception):

--- a/doc/manual/rtio.rst
+++ b/doc/manual/rtio.rst
@@ -159,8 +159,7 @@ Input channels detect events, timestamp them, and place them in a buffer for the
 The following example counts the rising edges occurring during a precisely timed 500 ns interval.
 If more than 20 rising edges were received it outputs a pulse::
 
-  input.gate_rising(500*ns)
-  if input.count() > 20:
+  if input.count(input.gate_rising(500*ns)) > 20:
       delay(2*us)
       output.pulse(500*ns)
 

--- a/doc/slides/artiq_overview.tex
+++ b/doc/slides/artiq_overview.tex
@@ -90,8 +90,8 @@ inner sep=.3mm] at (current page.south east) {%
   \footnotesize
 
   \begin{minted}[frame=leftline]{python}
-trigger.sync()                # wait for trigger input
-start = now_mu()              # capture trigger time
+# wait for trigger input and capture timestamp
+start = trigger.timestamp_mu(trigger.gate_rising(100*ms))
 for i in range(3):
     delay(5*us)
     dds.pulse(900*MHz, 7*us)  # first pulse 5 µs after trigger

--- a/doc/slides/taaccs.tex
+++ b/doc/slides/taaccs.tex
@@ -106,8 +106,8 @@ inner sep=.3mm] at (current page.south east) {%
   \footnotesize
 
   \begin{minted}[frame=leftline]{python}
-trigger.sync()                # wait for trigger input
-start = now_mu()              # capture trigger time
+# wait for trigger input and capture timestamp
+start = trigger.timestamp_mu(trigger.gate_rising(100*ms))
 for i in range(3):
     delay(5*us)
     dds.pulse(900*MHz, 7*us)  # first pulse 5 µs after trigger


### PR DESCRIPTION
The motivation behind this change is that the current API doesn't play well with DMA as detailed in #1113 – RTIO events generated by DMA can't set the timestamp attributes.

The only part of the change strictly necessary to fix this are the optional timestamp arguments, so that code using DMA can manually specify these. However, as pointed out in #1113, the current API is unnecessarily error-prone, especially as DMA is deployed more and more widely (and possibly hidden behind layers of abstraction).

Hence, I removed `TTLOut.sync` altogether, since it seems to be used only very rarely (there are zero uses in `artiq`, as well as all our experiment code). The input methods, on the other hand, are used much more often, so 67fe87a makes them default to `now_mu()` when no timestamps are passed explicitly. Requiring explicit timestamps might well be the cleaner design, but this seems to be a sensible choice in terms of backwards compatibility for now.

There are also two commits adding convenience functions/return values as suggested by @jordens.

Since this is a very central piece of the realtime API, I'd appreciate comments on the design – I'll update the tests once a design has been agreed on.
