### PR TITLE
share moninj injection state between dashboards

### DIFF
--- a/artiq/coredevice/comm_moninj.py
+++ b/artiq/coredevice/comm_moninj.py
@@ -56,15 +56,15 @@ class CommMonInj:
         self._writer.write(packet)
 
     def monitor_injection(self, enable, channel, overrd):
-        packet = struct.pack(">bblb", 1, enable, channel, overrd)
+        packet = struct.pack(">bblb", 3, enable, channel, overrd)
         self._writer.write(packet)
 
     def inject(self, channel, override, value):
-        packet = struct.pack(">blbb", 2, channel, override, value)
+        packet = struct.pack(">blbb", 1, channel, override, value)
         self._writer.write(packet)
 
     def get_injection_status(self, channel, override):
-        packet = struct.pack(">blb", 3, channel, override)
+        packet = struct.pack(">blb", 2, channel, override)
         self._writer.write(packet)
 
     async def _receive_cr(self):

--- a/artiq/coredevice/comm_moninj.py
+++ b/artiq/coredevice/comm_moninj.py
@@ -51,16 +51,20 @@ class CommMonInj:
             del self._reader
             del self._writer
 
-    def monitor(self, enable, channel, probe):
+    def monitor_probe(self, enable, channel, probe):
         packet = struct.pack(">bblb", 0, enable, channel, probe)
         self._writer.write(packet)
 
+    def monitor_injection(self, enable, channel, overrd):
+        packet = struct.pack(">bblb", 1, enable, channel, overrd)
+        self._writer.write(packet)
+
     def inject(self, channel, override, value):
-        packet = struct.pack(">blbb", 1, channel, override, value)
+        packet = struct.pack(">blbb", 2, channel, override, value)
         self._writer.write(packet)
 
     def get_injection_status(self, channel, override):
-        packet = struct.pack(">blb", 2, channel, override)
+        packet = struct.pack(">blb", 3, channel, override)
         self._writer.write(packet)
 
     async def _receive_cr(self):

--- a/artiq/dashboard/moninj.py
+++ b/artiq/dashboard/moninj.py
@@ -339,18 +339,20 @@ class _DeviceManager:
 
     def setup_ttl_monitoring(self, enable, channel):
         if self.core_connection is not None:
-            self.core_connection.monitor(enable, channel, TTLProbe.level.value)
-            self.core_connection.monitor(enable, channel, TTLProbe.oe.value)
+            self.core_connection.monitor_probe(enable, channel, TTLProbe.level.value)
+            self.core_connection.monitor_probe(enable, channel, TTLProbe.oe.value)
+            self.core_connection.monitor_injection(enable, channel, TTLOverride.en.value)
+            self.core_connection.monitor_injection(enable, channel, TTLOverride.level.value)
             if enable:
                 self.core_connection.get_injection_status(channel, TTLOverride.en.value)
 
     def setup_dds_monitoring(self, enable, bus_channel, channel):
         if self.core_connection is not None:
-            self.core_connection.monitor(enable, bus_channel, channel)
+            self.core_connection.monitor_probe(enable, bus_channel, channel)
 
     def setup_dac_monitoring(self, enable, spi_channel, channel):
         if self.core_connection is not None:
-            self.core_connection.monitor(enable, spi_channel, channel)
+            self.core_connection.monitor_probe(enable, spi_channel, channel)
 
     def monitor_cb(self, channel, probe, value):
         if channel in self.ttl_widgets:
@@ -371,7 +373,12 @@ class _DeviceManager:
 
     def injection_status_cb(self, channel, override, value):
         if channel in self.ttl_widgets:
-            self.ttl_widgets[channel].cur_override = bool(value)
+            widget = self.ttl_widgets[channel]
+            if override == TTLOverride.en.value:
+                widget.cur_override = bool(value)
+            if override == TTLOverride.level.value:
+                widget.cur_level = bool(value)
+            widget.refresh_display()
 
     async def core_connector(self):
         while True:

--- a/artiq/firmware/libproto_artiq/moninj_proto.rs
+++ b/artiq/firmware/libproto_artiq/moninj_proto.rs
@@ -54,17 +54,17 @@ impl HostMessage {
                 channel: reader.read_u32()?,
                 probe: reader.read_u8()?
             },
-            1 => HostMessage::MonitorInjection {
-                enable: if reader.read_u8()? == 0 { false } else { true },
-                channel: reader.read_u32()?,
-                overrd: reader.read_u8()?
-            },
-            2 => HostMessage::Inject {
+            1 => HostMessage::Inject {
                 channel: reader.read_u32()?,
                 overrd: reader.read_u8()?,
                 value: reader.read_u8()?
             },
-            3 => HostMessage::GetInjectionStatus {
+            2 => HostMessage::GetInjectionStatus {
+                channel: reader.read_u32()?,
+                overrd: reader.read_u8()?
+            },
+            3 => HostMessage::MonitorInjection {
+                enable: if reader.read_u8()? == 0 { false } else { true },
                 channel: reader.read_u32()?,
                 overrd: reader.read_u8()?
             },

--- a/artiq/firmware/libproto_artiq/moninj_proto.rs
+++ b/artiq/firmware/libproto_artiq/moninj_proto.rs
@@ -32,7 +32,8 @@ pub fn read_magic<R>(reader: &mut R) -> Result<(), Error<R::ReadError>>
 
 #[derive(Debug)]
 pub enum HostMessage {
-    Monitor { enable: bool, channel: u32, probe: u8 },
+    MonitorProbe { enable: bool, channel: u32, probe: u8 },
+    MonitorInjection { enable: bool, channel: u32, overrd: u8 },
     Inject { channel: u32, overrd: u8, value: u8 },
     GetInjectionStatus { channel: u32, overrd: u8 }
 }
@@ -48,17 +49,22 @@ impl HostMessage {
         where R: Read + ?Sized
     {
         Ok(match reader.read_u8()? {
-            0 => HostMessage::Monitor {
+            0 => HostMessage::MonitorProbe {
                 enable: if reader.read_u8()? == 0 { false } else { true },
                 channel: reader.read_u32()?,
                 probe: reader.read_u8()?
             },
-            1 => HostMessage::Inject {
+            1 => HostMessage::MonitorInjection {
+                enable: if reader.read_u8()? == 0 { false } else { true },
+                channel: reader.read_u32()?,
+                overrd: reader.read_u8()?
+            },
+            2 => HostMessage::Inject {
                 channel: reader.read_u32()?,
                 overrd: reader.read_u8()?,
                 value: reader.read_u8()?
             },
-            2 => HostMessage::GetInjectionStatus {
+            3 => HostMessage::GetInjectionStatus {
                 channel: reader.read_u32()?,
                 overrd: reader.read_u8()?
             },

--- a/artiq/test/coredevice/test_moninj.py
+++ b/artiq/test/coredevice/test_moninj.py
@@ -25,7 +25,9 @@ class MonInjTest(ExperimentCase):
             loop.run_until_complete(moninj_comm.connect(core_host))
             try:
                 moninj_comm.get_injection_status(loop_out_channel, TTLOverride.en.value)
-                moninj_comm.monitor(True, loop_in_channel, TTLProbe.level.value)
+                moninj_comm.monitor_probe(True, loop_in_channel, TTLProbe.level.value)
+                moninj_comm.monitor_injection(True, loop_out_channel, TTLOverride.level.en.value)
+                loop.run_until_complete(asyncio.sleep(0.5))
                 moninj_comm.inject(loop_out_channel, TTLOverride.level.value, 0)
                 moninj_comm.inject(loop_out_channel, TTLOverride.level.en.value, 1)
                 loop.run_until_complete(asyncio.sleep(0.5))
@@ -50,5 +52,7 @@ class MonInjTest(ExperimentCase):
         ])
         self.assertEqual(injection_statuses, [
             (loop_out_channel, TTLOverride.en.value, 0),
+            (loop_out_channel, TTLOverride.en.value, 0),
+            (loop_out_channel, TTLOverride.en.value, 1),
             (loop_out_channel, TTLOverride.en.value, 1)
         ])


### PR DESCRIPTION
Previously if one dashboard overrode a channel this was not visible on any other dashboard - the channel appeared to operate under experiment control, and the actual output level was unrelated to the displayed output level.

This PR allows clients to be notified by the core device when the injection state is changed. With the current implementation the modifying client receives a notification of its change up to 200ms after the change, which means that the dashboard moninj panel cannot be used to generate events faster than 200ms.