### PR TITLE
dashboard: fix TTL moninj level display

### DIFF
--- a/artiq/dashboard/moninj.py
+++ b/artiq/dashboard/moninj.py
@@ -74,6 +74,7 @@ class _TTLWidget(QtWidgets.QFrame):
         self.cur_level = False
         self.cur_oe = False
         self.cur_override = False
+        self.cur_override_level = False
         self.refresh_display()
 
     def enterEvent(self, event):
@@ -106,7 +107,9 @@ class _TTLWidget(QtWidgets.QFrame):
                 self.set_mode(self.channel, "0")
 
     def refresh_display(self):
-        value_s = "1" if self.cur_level else "0"
+        level = self.cur_override_level if self.cur_override else self.cur_level
+        value_s = "1" if level else "0"
+
         if self.cur_override:
             value_s = "<b>" + value_s + "</b>"
             color = " color=\"red\""
@@ -377,7 +380,7 @@ class _DeviceManager:
             if override == TTLOverride.en.value:
                 widget.cur_override = bool(value)
             if override == TTLOverride.level.value:
-                widget.cur_level = bool(value)
+                widget.cur_override_level = bool(value)
             widget.refresh_display()
 
     async def core_connector(self):


### PR DESCRIPTION
Previously receiving an injection status callback for the TTL level set the displayed level, even if the channel was not overridden.