### PR TITLE
firmware: Use larger ARP cache

### DIFF
--- a/artiq/firmware/runtime/main.rs
+++ b/artiq/firmware/runtime/main.rs
@@ -270,9 +270,8 @@ fn startup_ethernet() {
         smoltcp::phy::EthernetTracer::new(net_device, net_trace_fn)
     };
 
-    let mut neighbor_map = [None; 8];
     let neighbor_cache =
-        smoltcp::iface::NeighborCache::new(&mut neighbor_map[..]);
+        smoltcp::iface::NeighborCache::new(alloc::btree_map::BTreeMap::new());
     let mut interface  =
         smoltcp::iface::EthernetInterfaceBuilder::new(net_device)
                        .neighbor_cache(neighbor_cache)


### PR DESCRIPTION
This works around a problematic interaction between ARP cache
expiry in smoltcp (with its 3 seconds timeout before a discovery
request is sent) and our TCP keepalive settings, where the timeout
is reached before the keepalive had a chance to be sent.

GitHub: Closes #1150.