### PR TITLE
Kasli DRTIO master: do not init rtio core until serdes PLL has locked.

### DIFF
--- a/artiq/firmware/runtime/rtio_mgt.rs
+++ b/artiq/firmware/runtime/rtio_mgt.rs
@@ -1,3 +1,4 @@
+use clock;
 use board_misoc::csr;
 #[cfg(has_rtio_clock_switch)]
 use board_misoc::config;
@@ -45,6 +46,13 @@ pub mod drtio {
     pub fn startup(io: &Io) {
         unsafe {
             csr::drtio_transceiver::stable_clkin_write(1);
+
+            let t = clock::get_ms();
+            while csr::rtio_clkmul::pll_locked_read() == 0 {
+                if clock::get_ms() > t + 100 {
+                    error!("rtio clock multiplier PLL lock timeout");
+                }
+            }
         }
         io.spawn(4096, link_thread);
     }

--- a/artiq/gateware/targets/kasli.py
+++ b/artiq/gateware/targets/kasli.py
@@ -604,28 +604,33 @@ class Tester(_StandaloneBase):
             self.rtio_crg.cd_rtio.clk, self.grabber0.deserializer.cd_cl.clk)
 
 
-class _RTIOClockMultiplier(Module):
+class _RTIOClockMultiplier(Module, AutoCSR):
     def __init__(self, rtio_clk_freq):
+        self._pll_locked = CSRStatus()
         self.clock_domains.cd_rtiox4 = ClockDomain(reset_less=True)
 
         # See "Global Clock Network Deskew Using Two BUFGs" in ug472.
         clkfbout = Signal()
         clkfbin = Signal()
         rtiox4_clk = Signal()
+        pll_locked = Signal()
+
         self.specials += [
             Instance("MMCME2_BASE",
-                p_CLKIN1_PERIOD=1e9/rtio_clk_freq,
-                i_CLKIN1=ClockSignal("rtio"),
-                i_RST=ResetSignal("rtio"),
+                     o_LOCKED=pll_locked,
+                     p_CLKIN1_PERIOD=1e9/rtio_clk_freq,
+                     i_CLKIN1=ClockSignal("rtio"),
+                     i_RST=ResetSignal("rtio"),
 
-                p_CLKFBOUT_MULT_F=8.0, p_DIVCLK_DIVIDE=1,
+                     p_CLKFBOUT_MULT_F=8.0, p_DIVCLK_DIVIDE=1,
 
-                o_CLKFBOUT=clkfbout, i_CLKFBIN=clkfbin,
+                     o_CLKFBOUT=clkfbout, i_CLKFBIN=clkfbin,
 
-                p_CLKOUT0_DIVIDE_F=2.0, o_CLKOUT0=rtiox4_clk,
+                     p_CLKOUT0_DIVIDE_F=2.0, o_CLKOUT0=rtiox4_clk,
             ),
             Instance("BUFG", i_I=clkfbout, o_O=clkfbin),
-            Instance("BUFG", i_I=rtiox4_clk, o_O=self.cd_rtiox4.clk)
+            Instance("BUFG", i_I=rtiox4_clk, o_O=self.cd_rtiox4.clk),
+            MultiReg(pll_locked, self._pll_locked.status)
         ]
 
 
@@ -710,6 +715,8 @@ class _MasterBase(MiniSoC, AMPSoC):
                 self.crg.cd_sys.clk, gtp.rxoutclk)
 
         self.submodules.rtio_clkmul = _RTIOClockMultiplier(rtio_clk_freq)
+        self.csr_devices.append("rtio_clkmul")
+
         fix_serdes_timing_path(platform)
 
     def add_rtio(self, rtio_channels):


### PR DESCRIPTION
fixes 1155

@jordens if you still have your test setup intact, please could you test this on your setup?

@sbourdeauducq do we need to apply similar fixes anywhere else?