### PR TITLE
Add issue & pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/1_Bug_Report.md
@@ -1,0 +1,48 @@
+---
+name: Bug report
+about: Report a bug in ARTIQ    
+
+---
+
+<!-- Above are non-Markdown tags for Github auto-prompting issue type. Template based on pylint: https://raw.githubusercontent.com/PyCQA/pylint/master/.github/ISSUE_TEMPLATE/ -->
+
+# Bug Report
+
+<!-- Thanks for reporting a bug report to ARTIQ! You can also discuss issues and ask questions on IRC (the [#m-labs channel on freenode](https://webchat.freenode.net/?channels=m-labs) or on the [ARTIQ mailing list](https://ssl.serverraum.org/lists/listinfo/artiq). Please check Github/those forums to avoid posting a repeat issue.  
+
+Context helps us fix issues faster, so please include the following: 
+-->
+
+## One-Line Summary
+
+Short summary.
+
+## Issue Details
+
+### Steps to Reproduce
+
+1. Step 1.
+2. Step 2.
+3. Step 3.
+
+### Expected Behavior
+
+Behavior
+
+### Actual (undesired) Behavior
+
+* Text description
+* Log message, tracebacks, screen shots where relevant
+
+### Your System
+
+* Operating System:
+* Conda version:
+* ARTIQ version: (package or git commit id, versions for bitstream, BIOS, runtime and host software). `conda list`
+* Hardware involved:
+
+<!--
+For in-depth information on bug reporting, see:
+
+http://www.chiark.greenend.org.uk/~sgtatham/bugs.html https://developer.mozilla.org/en-US/docs/Mozilla/QA/Bug_writing_guidelines
+-->

--- a/.github/ISSUE_TEMPLATE/1_Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/1_Bug_Report.md
@@ -38,7 +38,7 @@ Behavior
 
 * Operating System:
 * Conda version:
-* ARTIQ version: (package or git commit id, versions for bitstream, BIOS, runtime and host software). `conda list`
+* ARTIQ version: (package or git commit id, versions for bitstream, bootloader, runtime and host software). Run `conda list`
 * Hardware involved:
 
 <!--

--- a/.github/ISSUE_TEMPLATE/2_Feature_Request.md
+++ b/.github/ISSUE_TEMPLATE/2_Feature_Request.md
@@ -1,0 +1,28 @@
+---
+name: Feature request
+about: Suggest an idea for ARTIQ
+
+---
+
+<!--
+  Hi there! Thank you for wanting to make ARTIQ better.
+
+  Before you submit this, make sure that this feature wasn't
+  already requested or if it is not already implemented in the master branch.
+
+  Based on pylint: https://raw.githubusercontent.com/PyCQA/pylint/master/.github/ISSUE_TEMPLATE/2_Feature_request.md
+-->
+
+# ARTIQ Feature Request
+
+## Problem this request addresses
+
+A clear and concise description of what the problem is.
+
+## Describe the solution you'd like
+
+A clear and concise description of what you want to happen.
+
+## Additional context
+
+Add any other context about the feature request here.

--- a/.github/ISSUE_TEMPLATE/3_Question.md
+++ b/.github/ISSUE_TEMPLATE/3_Question.md
@@ -1,0 +1,21 @@
+---
+name: Support question
+about: Questions about ARTIQ that are not covered in the documentation (https://m-labs.hk/artiq/manual)
+
+---
+
+# Question
+
+<!-- 
+Make sure you check the ARTIQ documentation before posting a question. 
+Don't forget you can search it! 
+https://m-labs.hk/artiq/manual/
+-->
+
+## Category
+
+One-word category this question falls into: GUI, installation/setup, devices, development, documentation, etc.
+
+## Description
+
+Question text

--- a/.github/ISSUE_TEMPLATE/3_Question.md
+++ b/.github/ISSUE_TEMPLATE/3_Question.md
@@ -1,6 +1,6 @@
 ---
 name: Support question
-about: Questions about ARTIQ that are not covered in the documentation (https://m-labs.hk/artiq/manual)
+about: Questions about ARTIQ that are not covered in the documentation (https://m-labs.hk/artiq/manual-master/)
 
 ---
 
@@ -9,12 +9,15 @@ about: Questions about ARTIQ that are not covered in the documentation (https://
 <!-- 
 Make sure you check the ARTIQ documentation before posting a question. 
 Don't forget you can search it! 
-https://m-labs.hk/artiq/manual/
+https://m-labs.hk/artiq/manual-master/
+
+Can also ask on IRC: https://webchat.freenode.net/?channels=m-labs or 
+check mailing list archives: https://ssl.serverraum.org/lists-archive/artiq/ 
 -->
 
-## Category
+## Category: FILL_IN
 
-One-word category this question falls into: GUI, installation/setup, devices, development, documentation, etc.
+<!-- One-word category this question falls into: GUI, installation/setup, devices, development, documentation, etc. -->
 
 ## Description
 

--- a/.github/ISSUE_TEMPLATE/3_Question.md
+++ b/.github/ISSUE_TEMPLATE/3_Question.md
@@ -1,6 +1,6 @@
 ---
 name: Support question
-about: Questions about ARTIQ that are not covered in the documentation (https://m-labs.hk/artiq/manual-master/)
+about: Questions about ARTIQ that are not covered in the documentation (Latest: https://m-labs.hk/artiq/manual-master/ or Stable: https://m-labs.hk/artiq/manual/)
 
 ---
 
@@ -9,7 +9,8 @@ about: Questions about ARTIQ that are not covered in the documentation (https://
 <!-- 
 Make sure you check the ARTIQ documentation before posting a question. 
 Don't forget you can search it! 
-https://m-labs.hk/artiq/manual-master/
+Latest docs: https://m-labs.hk/artiq/manual-master/
+Stable branch docs: https://m-labs.hk/artiq/manual/
 
 Can also ask on IRC: https://webchat.freenode.net/?channels=m-labs or 
 check mailing list archives: https://ssl.serverraum.org/lists-archive/artiq/ 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,33 +12,45 @@ Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQU
 
 # ARTIQ Pull Request
 
-## Steps (Choose relevant, delete before submitting)
+## Steps (Choose relevant, delete irrelevant before submitting)
 
 ### All Pull Requests
 
-- [ ] Use correct spelling and grammar.
-- [ ] Update RELEASE_NOTES.md if there are noteworthy changes, especially if there are changes to existing APIs.
-- [ ] Close and/or update issues.
-- [ ] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off)).
+- [x] Use correct spelling and grammar.
+- [ ] Update [RELEASE_NOTES.md](../RELEASE_NOTES.md) if there are noteworthy changes, especially if there are changes to existing APIs.
+- [ ] Close/update issues.
+- [ ] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).
 
 ### Code Changes
 
-- [ ] Run `flake8` to check code style (follow PEP-8 style)
+- [ ] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
 - [ ] Test your changes or have someone test them. Mention what was tested and how.
 - [ ] Add and check docstrings and comments
 - [ ] Check, test, and update the conda recipes in [conda/](../doc/)
-- [ ] Check, test, and update the [unittests in /artiq/test/](../artiq/test/)
+- [ ] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)
 
 ### Documentation Changes
 
-- [ ] Check, test, and update the documentation in [doc/](../doc/). Build documentation (Linux only: `cd doc; make html`) to ensure no errors.
+- [ ] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc; make html`) to ensure no errors.
 
 ### Git Logistics
 
-- [ ] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes. Clean up your commits. See **TODO** for instructions.
-- [ ] Write short & meaningful commit messages with the changed topic & a concise description (50 characters or less) in the first line. Describe everything else in the long explanation. Review each of your commits for this. (`git show`)
+- [ ] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
+- [ ] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
+  ```
+  [topic]: description. < 50 characters total.
+  Longer description. < 70 characters per line
+  ```
+## Description of Changes
 
-## Description
+### Related Issue
+
+<!-- 
+If this PR fixes a particular issue, use the following to automatically close that issue
+once this PR gets merged:
+
+Closes #XXX 
+-->
 
 ## Type of Changes
 
@@ -50,16 +62,8 @@ Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQU
 | ✓  | :hammer: Refactoring  |
 | ✓  | :scroll: Docs |
 
-## Related Issue
-
-<!-- 
-If this PR fixes a particular issue, use the following to automatically close that issue
-once this PR gets merged:
-
-Closes #XXX 
--->
 
 ### Licensing
 
 See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
-ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under GNU GPL version 3.
+ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,65 @@
+<!--
+
+Thank you for submitting a PR to ARTIQ!
+
+To ease the process of reviewing your PR, do make sure to complete the following boxes.
+
+You can also read more about contributing to ARTIQ in this document:
+https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code
+
+Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
+-->
+
+# ARTIQ Pull Request
+
+## Steps (Choose relevant, delete before submitting)
+
+### All Pull Requests
+
+- [ ] Use correct spelling and grammar.
+- [ ] Update RELEASE_NOTES.md if there are noteworthy changes, especially if there are changes to existing APIs.
+- [ ] Close and/or update issues.
+- [ ] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off)).
+
+### Code Changes
+
+- [ ] Run `flake8` to check code style (follow PEP-8 style)
+- [ ] Test your changes or have someone test them. Mention what was tested and how.
+- [ ] Add and check docstrings and comments
+- [ ] Check, test, and update the conda recipes in [conda/](../doc/)
+- [ ] Check, test, and update the [unittests in /artiq/test/](../artiq/test/)
+
+### Documentation Changes
+
+- [ ] Check, test, and update the documentation in [doc/](../doc/). Build documentation (Linux only: `cd doc; make html`) to ensure no errors.
+
+### Git Logistics
+
+- [ ] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes. Clean up your commits. See **TODO** for instructions.
+- [ ] Write short & meaningful commit messages with the changed topic & a concise description (50 characters or less) in the first line. Describe everything else in the long explanation. Review each of your commits for this. (`git show`)
+
+## Description
+
+## Type of Changes
+
+<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
+|   | Type |
+| ------------- | ------------- |
+| ✓  | :bug: Bug fix  |
+| ✓  | :sparkles: New feature |
+| ✓  | :hammer: Refactoring  |
+| ✓  | :scroll: Docs |
+
+## Related Issue
+
+<!-- 
+If this PR fixes a particular issue, use the following to automatically close that issue
+once this PR gets merged:
+
+Closes #XXX 
+-->
+
+### Licensing
+
+See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
+ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under GNU GPL version 3.


### PR DESCRIPTION
Add issue & pull request templates to make pull requests/issues more uniform when adding to Github, and provide suggested information to include in pull requests/issues.

These will autopopulate on Github. Based on `pylint` templates.