### PR TITLE
Added clear command to artiq_flash to erase flash memory

### DIFF
--- a/artiq/frontend/artiq_flash.py
+++ b/artiq/frontend/artiq_flash.py
@@ -28,7 +28,7 @@ Valid actions:
     * storage: write storage image to flash
     * firmware: write firmware to flash
     * load: load gateware bitstream into device (volatile but fast)
-    * clear: clear flash memory
+    * erase: erase flash memory
     * start: trigger the target to (re)load its gateware bitstream from flash
 
 Prerequisites:
@@ -133,7 +133,7 @@ class Programmer:
             "flash bank {name} jtagspi 0 0 0 0 {tap}.{name}.proxy {ir:#x}",
             tap=tap, name=name, ir=0x02 + index)
 
-    def clear_flash(self, bankname):
+    def erase_flash(self, bankname):
         self.load_proxy()
         add_commands(self._script,
                      "flash probe {bankname}",
@@ -370,12 +370,12 @@ def main():
                 programmer.load(gateware_bit, 0)
         elif action == "start":
             programmer.start()
-        elif action == "clear":
+        elif action == "erase":
             if args.target == "sayma":
-                programmer.clear_flash("spi0")
-                programmer.clear_flash("spi1")
+                programmer.erase_flash("spi0")
+                programmer.erase_flash("spi1")
             else:
-                programmer.clear_flash("spi0")
+                programmer.erase_flash("spi0")
         else:
             raise ValueError("invalid action", action)
 

--- a/artiq/frontend/artiq_flash.py
+++ b/artiq/frontend/artiq_flash.py
@@ -28,6 +28,7 @@ Valid actions:
     * storage: write storage image to flash
     * firmware: write firmware to flash
     * load: load gateware bitstream into device (volatile but fast)
+    * clear: clear flash memory
     * start: trigger the target to (re)load its gateware bitstream from flash
 
 Prerequisites:
@@ -131,6 +132,13 @@ class Programmer:
             "target create {tap}.{name}.proxy testee -chain-position {tap}.tap",
             "flash bank {name} jtagspi 0 0 0 0 {tap}.{name}.proxy {ir:#x}",
             tap=tap, name=name, ir=0x02 + index)
+
+    def clear_flash(self, bankname):
+        self.load_proxy()
+        add_commands(self._script,
+                     "flash probe {bankname}",
+                     "flash erase_sector {bankname} 0 last",
+                     bankname=bankname)
 
     def load(self, bitfile, pld):
         os.stat(bitfile) # check for existence
@@ -362,6 +370,12 @@ def main():
                 programmer.load(gateware_bit, 0)
         elif action == "start":
             programmer.start()
+        elif action == "clear":
+            if args.target == "sayma":
+                programmer.clear_flash("spi0")
+                programmer.clear_flash("spi1")
+            else:
+                programmer.clear_flash("spi0")
         else:
             raise ValueError("invalid action", action)
 


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Added `clear` command to `artiq_flash` to erase flash memory

### Related Issue

Sometimes after flashing kasli or sayma for the n-th time ARTIQ won't boot. Usually clearing flash memory helps with this problem, so I added an option to do this from `artiq_flash`. Tested on Kasli v1.1.

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |
| ✓  | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Update [RELEASE_NOTES.md](../RELEASE_NOTES.md) if there are noteworthy changes, especially if there are changes to existing APIs.
- [ ] Close/update issues.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [ ] Check, test, and update the conda recipes in [conda/](../doc/)
- [ ] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

- [x] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
