### PR TITLE
kasli: add support for windows platform.

### DIFF
--- a/artiq/examples/kasli_basic/repository/kasli_tester.py
+++ b/artiq/examples/kasli_basic/repository/kasli_tester.py
@@ -4,6 +4,9 @@ import select
 
 from artiq.experiment import *
 
+if os.name == "nt":
+    import msvcrt
+
 
 def chunker(seq, size):
     res = []
@@ -16,18 +19,18 @@ def chunker(seq, size):
         yield res
 
 
-if os.name == "nt":
-   import msvcrt
-   is_key_pressed = msvcrt.kbhit
-else:
-   is_key_pressed = lambda: select.select([sys.stdin,], [], [], 0.0)[0]
-        
-def is_enter_pressed() -> TBool: 
-	if is_key_pressed:
-		sys.stdin.read(1)
-		return True
-	else:
-		return False
+def is_enter_pressed() -> TBool:
+    if os.name == "nt":
+        if msvcrt.kbhit() and msvcrt.getch() == b"\r":
+            return True
+        else:
+            return False
+    else:
+        if select.select([sys.stdin, ], [], [], 0.0)[0]:
+            sys.stdin.read(1)
+            return True
+        else:
+            return False
 
 
 class KasliTester(EnvExperiment):

--- a/artiq/examples/kasli_basic/repository/kasli_tester.py
+++ b/artiq/examples/kasli_basic/repository/kasli_tester.py
@@ -1,4 +1,5 @@
 import sys
+import os
 import select
 
 from artiq.experiment import *
@@ -15,12 +16,18 @@ def chunker(seq, size):
         yield res
 
 
-def is_enter_pressed() -> TBool:
-    if select.select([sys.stdin,], [], [], 0.0)[0]:
-        sys.stdin.read(1)
-        return True
-    else:
-        return False
+if os.name == "nt":
+   import msvcrt
+   is_key_pressed = msvcrt.kbhit
+else:
+   is_key_pressed = lambda: select.select([sys.stdin,], [], [], 0.0)[0]
+        
+def is_enter_pressed() -> TBool: 
+	if is_key_pressed:
+		sys.stdin.read(1)
+		return True
+	else:
+		return False
 
 
 class KasliTester(EnvExperiment):


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Add Windows platform support to kasli_tester.py

### Related Issue

None

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.

### Documentation Changes

None

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
