### PR TITLE
examples: Fix DRTIO destination indices

### DIFF
--- a/artiq/examples/kasli_sawgmaster/repository/sines_2sayma.py
+++ b/artiq/examples/kasli_sawgmaster/repository/sines_2sayma.py
@@ -7,11 +7,17 @@ class Sines2Sayma(EnvExperiment):
         self.sawgs = [self.get_device("sawg"+str(i)) for i in range(16)]
 
     @kernel
+    def drtio_is_up(self):
+        for i in range(3):
+            if not self.core.get_rtio_destination_status(i):
+                return False
+        return True
+
+    @kernel
     def run(self):
         while True:
             print("waiting for DRTIO ready...")
-            while not (self.core.get_rtio_destination_status(0) and
-                       self.core.get_rtio_destination_status(1)):
+            while not self.drtio_is_up():
                 pass
             print("OK")
 
@@ -27,5 +33,5 @@ class Sines2Sayma(EnvExperiment):
                 # Do not use a sub-multiple of oscilloscope sample rates.
                 sawg.frequency0.set(9*MHz)
 
-            while self.core.get_rtio_destination_status(0) and self.core.get_rtio_destination_status(1):
+            while self.drtio_is_up():
                 pass

--- a/artiq/examples/kasli_sawgmaster/repository/sines_urukul_sayma.py
+++ b/artiq/examples/kasli_sawgmaster/repository/sines_urukul_sayma.py
@@ -9,6 +9,13 @@ class SinesUrukulSayma(EnvExperiment):
         self.sawgs = [self.get_device("sawg"+str(i)) for i in range(8)]
 
     @kernel
+    def drtio_is_up(self):
+        for i in range(2):
+            if not self.core.get_rtio_destination_status(i):
+                return False
+        return True
+
+    @kernel
     def run(self):
         # Note: when testing sync, do not reboot Urukul, as it is not
         # synchronized to the FPGA (yet).
@@ -23,7 +30,7 @@ class SinesUrukulSayma(EnvExperiment):
 
         while True:
             print("waiting for DRTIO ready...")
-            while not self.core.get_rtio_destination_status(0):
+            while not self.drtio_is_up():
                 pass
             print("OK")
 
@@ -38,5 +45,5 @@ class SinesUrukulSayma(EnvExperiment):
                 sawg.amplitude1.set(.4)
                 sawg.frequency0.set(9*MHz)
 
-            while self.core.get_rtio_destination_status(0):
+            while self.drtio_is_up():
                 pass

--- a/artiq/examples/sayma_masterdac/repository/sines_drtio.py
+++ b/artiq/examples/sayma_masterdac/repository/sines_drtio.py
@@ -10,8 +10,9 @@ class SAWGTestDRTIO(EnvExperiment):
     @kernel
     def run(self):
         core_log("waiting for DRTIO ready...")
-        while not self.core.get_rtio_destination_status(0):
-            pass
+        for i in range(3):
+            while not self.core.get_rtio_destination_status(i):
+                pass
         core_log("OK")
 
         self.core.reset()


### PR DESCRIPTION
Using the default routing table, links numbers and destinations are offset by 1, as destination 0 is local RTIO. Hence, code previously using `get_drtio_link_status` needs updating.

Not tested yet.

@sbourdeauducq: As discussed.