### PR TITLE
Docs: fix build warnings

### DIFF
--- a/artiq/coredevice/ad9910.py
+++ b/artiq/coredevice/ad9910.py
@@ -16,7 +16,7 @@ __all__ = [
     "PHASE_MODE_CONTINUOUS", "PHASE_MODE_ABSOLUTE", "PHASE_MODE_TRACKING",
     "RAM_DEST_FTW", "RAM_DEST_POW", "RAM_DEST_ASF", "RAM_DEST_POWASF",
     "RAM_MODE_DIRECTSWITCH", "RAM_MODE_RAMPUP", "RAM_MODE_BIDIR_RAMP",
-    "RAM_MODE_CONT_BIDIR_RAMP", "RAM_MODE_CONT_RECIRCULATE",
+    "RAM_MODE_CONT_BIDIR_RAMP", "RAM_MODE_CONT_RAMPUP",
 ]
 
 
@@ -440,7 +440,7 @@ class AD9910:
         :param mode: Profile RAM mode (:const:`RAM_MODE_DIRECTSWITCH`,
             :const:`RAM_MODE_RAMPUP`, :const:`RAM_MODE_BIDIR_RAMP`,
             :const:`RAM_MODE_CONT_BIDIR_RAMP`, or
-            :const:`RAM_MODE_CONT_RECIRCULATE`, default:
+            :const:`RAM_MODE_CONT_RAMPUP`, default:
             :const:`RAM_MODE_RAMPUP`)
         """
         hi = (step << 8) | (end >> 2)

--- a/artiq/coredevice/spi2.py
+++ b/artiq/coredevice/spi2.py
@@ -187,10 +187,10 @@ class SPIMaster:
         :meth:`__init__`.
 
         .. warning:: If this method is called while recording a DMA
-        sequence, the playback of the sequence will not update the
-        driver state.
-        When required, update the driver state manually (by calling
-        this method) after playing back a DMA sequence.
+           sequence, the playback of the sequence will not update the
+           driver state.
+           When required, update the driver state manually (by calling
+           this method) after playing back a DMA sequence.
 
         :param div: SPI clock divider (see: :meth:`set_config_mu`)
         :param length: SPI transfer length (see: :meth:`set_config_mu`)


### PR DESCRIPTION
Warnings thrown while building docs. Forgot to rename some attributes, and a bad indent in spi2 docstring.

Signed-off-by: Drew Risinger <drewrisinger@users.noreply.github.com>