### PR TITLE
test_pc_rpc: fix equality bug (#1188)

### DIFF
--- a/artiq/test/test_pc_rpc.py
+++ b/artiq/test/test_pc_rpc.py
@@ -100,7 +100,7 @@ class RPCCase(unittest.TestCase):
         """
 
         def _annotated_function(
-            arg1: str, arg2: np.ndarray = np.array([1, 2])
+            arg1: str, arg2: np.ndarray = np.array([1,])
         ) -> np.ndarray:
             """Sample docstring."""
             return arg1


### PR DESCRIPTION

Fixes bug from 5108ed8. Truth value of multi-element numpy array is
not defined. Completes #1186 and fixes/amends #1188.

Signed-off-by: Drew Risinger <drewrisinger@users.noreply.github.com>