### PR TITLE
scheduler: Add shutdown test, minor refactors

### DIFF
--- a/artiq/master/scheduler.py
+++ b/artiq/master/scheduler.py
@@ -214,7 +214,7 @@ class PrepareStage(TaskObject):
                         if run.worker.closed.is_set():
                             break
                     if run.worker.closed.is_set():
-                            continue
+                        continue
                 run.status = RunStatus.preparing
                 try:
                     await run.build()


### PR DESCRIPTION
This is just to CI-test a few uncontroversial changes and get them out of the way before a larger imminent PR to extend the scheduler (support for idling experiments that yield to lower-priority runs).