### PR TITLE
Suservo

### DIFF
--- a/artiq/coredevice/suservo.py
+++ b/artiq/coredevice/suservo.py
@@ -441,7 +441,7 @@ class Channel:
         base = (self.servo_channel << 8) | (profile << 3)
         for i in range(len(data)):
             data[i] = self.servo.read(base + i)
-            delay(4*us)
+            delay(6*us)
 
     @kernel
     def get_y_mu(self, profile):

--- a/artiq/coredevice/suservo.py
+++ b/artiq/coredevice/suservo.py
@@ -259,10 +259,10 @@ class Channel:
         This method does not advance the timeline. Output RF switch setting
         takes effect immediately and is independent of any other activity
         (profile settings, other channels). The RF switch behaves like
-        :class:`artiq.coredevice.ttl.TTLOut`. RTIO event replacement is supported. IIR updates take place
-        once the RF switch has been enabled for the configured delay and the
-        profile setting has been stable. Profile changes take between one and
-        two servo cycles to reach the DDS.
+        :class:`artiq.coredevice.ttl.TTLOut`. RTIO event replacement is
+        supported. IIR updates take place once the RF switch has been enabled
+        for the configured delay and the profile setting has been stable.
+        Profile changes take between one and two servo cycles to reach the DDS.
 
         :param en_out: RF switch enable
         :param en_iir: IIR updates enable

--- a/artiq/coredevice/suservo.py
+++ b/artiq/coredevice/suservo.py
@@ -129,6 +129,7 @@ class SUServo:
         :param addr: Memory location address.
         :param value: Data to be written.
         """
+        value &= (1 << COEFF_WIDTH) - 1
         addr |= WE
         value |= (addr >> 8) << COEFF_WIDTH
         addr = addr & 0xff
@@ -283,7 +284,7 @@ class Channel:
         """
         base = (self.servo_channel << 8) | (profile << 3)
         self.servo.write(base + 0, ftw >> 16)
-        self.servo.write(base + 6, ftw)
+        self.servo.write(base + 6, ftw & 0xffff)
         self.servo.write(base + 4, offs)
         self.servo.write(base + 2, pow_)
 

--- a/artiq/coredevice/suservo.py
+++ b/artiq/coredevice/suservo.py
@@ -320,7 +320,7 @@ class Channel:
         The recurrence relation is (all data signed and MSB aligned):
 
         .. math::
-            a_0 y_n = a_1 y_{n - 1} + b_0 (x_n + o)/2 + b_1 (x_{n - 1} + o)/2
+            y_n = a_1 y_{n - 1} + b_0 (x_n + o)/2 + b_1 (x_{n - 1} + o)/2
 
         Where:
 
@@ -329,7 +329,6 @@ class Channel:
             * :math:`x_n` and :math:`x_{n-1}` are the current and previous
               filter inputs in :math:`[-1, 1[`.
             * :math:`o` is the offset
-            * :math:`a_0` is the normalization factor :math:`2^{11}`
             * :math:`a_1` is the feedback gain
             * :math:`b_0` and :math:`b_1` are the feedforward gains for the two
               delays

--- a/artiq/gateware/rtio/phy/servo.py
+++ b/artiq/gateware/rtio/phy/servo.py
@@ -81,8 +81,13 @@ class RTServoMem(Module):
                 1 +  # state_sel
                 1 +  # config_sel
                 len(m_state.adr))
+
         internal_address = Signal(internal_address_width)
-        self.comb += internal_address.eq(Cat(self.rtlink.o.address, self.rtlink.o.data[w.coeff:]))
+        self.comb += internal_address.eq(Cat(self.rtlink.o.address,
+                                             self.rtlink.o.data[w.coeff:]))
+
+        coeff_data = Signal(w.coeff)
+        self.comb += coeff_data.eq(self.rtlink.o.data[:w.coeff])
 
         we = internal_address[-1]
         state_sel = internal_address[-2]
@@ -91,7 +96,7 @@ class RTServoMem(Module):
         self.comb += [
                 self.rtlink.o.busy.eq(0),
                 m_coeff.adr.eq(internal_address[1:]),
-                m_coeff.dat_w.eq(Cat(self.rtlink.o.data, self.rtlink.o.data)),
+                m_coeff.dat_w.eq(Cat(coeff_data, coeff_data)),
                 m_coeff.we[0].eq(self.rtlink.o.stb & ~high_coeff &
                     we & ~state_sel),
                 m_coeff.we[1].eq(self.rtlink.o.stb & high_coeff &


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Fix assorted SUServo issues:
1. Sign extend coefficients we read back (they are stored in the LSB of int32s)
2. Fix writing of coefficients to servo memory
3. flake8 and doc fixes
4. increase delay in profile register read back to avoid underflows
5. apply bit masks to avoid corrupting servo memory

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

Closes #1258, #1256

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Update [RELEASE_NOTES.md](../RELEASE_NOTES.md) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Close/update issues.
- [ ] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments

Tested using the following script under artiq5.0.dev:
```python
import numpy.random as rand

from artiq.experiment import *
from artiq.coredevice.suservo import COEFF_WIDTH

class Startup(EnvExperiment):
    def build(self):
        self.setattr_device("core")
        self.setattr_device("aom_servo")
        self.setattr_device("aom_397_doppler")
        self.offset = -0.00817

    def run(self):

        coeff_max = 1 << COEFF_WIDTH - 1

        self.ftw = self.pow_ = self.offs = 0

        for i in range(1000):

            self.a1 = rand.randint(low=-coeff_max, high=coeff_max)
            self.b1 = rand.randint(low=-coeff_max, high=coeff_max)
            self.b0 = rand.randint(low=-coeff_max, high=coeff_max)
            self.adc = rand.randint(low=0, high=8)
            self.dly = rand.randint(low=0, high=256)
            self.profile = rand.randint(low=0, high=8)
            self.freq = rand.random() * 400*MHz
            self.phase = (rand.random() - 0.5) * 2
            self.offset = (rand.random() - 0.5) * 2

            self.krun()
        print("pased")

    @kernel
    def krun(self):
        dds = self.aom_servo.dds0
        self.ftw = dds.frequency_to_ftw(self.freq)
        self.pow_ = dds.turns_to_pow(self.phase)
        self.offs = int(round(self.offset*(1 << COEFF_WIDTH - 1)))

        self.core.break_realtime()

        self.aom_397_doppler.set_dds_mu(self.profile,
                                        self.ftw,
                                        self.offs,
                                        self.pow_)
        delay(10*us)
        self.aom_397_doppler.set_iir_mu(self.profile,
                                        self.adc,
                                        self.a1,
                                        self.b0,
                                        self.b1,
                                        self.dly)

        data = [0] * 8
        self.aom_397_doppler.get_profile_mu(self.profile, data)

        assert self.ftw >> 16 == data[0]
        assert self.b1 == data[1]
        assert self.pow_ == data[2]
        assert self.adc | (self.dly << 8) == data[3]
        assert self.offs == data[4]
        assert self.a1 == data[5]
        assert self.ftw & 0xffff == data[6]
        assert self.b0 == data[7]
```