### PR TITLE
ctlmgr: ignore controllers without a "command" field

### DIFF
--- a/artiq/devices/ctlmgr.py
+++ b/artiq/devices/ctlmgr.py
@@ -180,11 +180,9 @@ class Controllers:
     def __setitem__(self, k, v):
         try:
             if (isinstance(v, dict) and v["type"] == "controller" and
-                    self.host_filter in get_ip_addresses(v["host"])):
-                command = v.get("command", None)
-                if command is None:
-                    return
-                v["command"] = command.format(name=k,
+                    self.host_filter in get_ip_addresses(v["host"]) and
+                    "command" in v):
+                v["command"] = v["command"].format(name=k,
                                                    bind=self.host_filter,
                                                    port=v["port"])
                 self.queue.put_nowait(("set", (k, v)))

--- a/artiq/devices/ctlmgr.py
+++ b/artiq/devices/ctlmgr.py
@@ -181,7 +181,10 @@ class Controllers:
         try:
             if (isinstance(v, dict) and v["type"] == "controller" and
                     self.host_filter in get_ip_addresses(v["host"])):
-                v["command"] = v["command"].format(name=k,
+                command = v.get("command", None)
+                if command is None:
+                    return
+                v["command"] = command.format(name=k,
                                                    bind=self.host_filter,
                                                    port=v["port"])
                 self.queue.put_nowait(("set", (k, v)))


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
Allow controllers to be specified without a "command" field. The user takes responsibility for ensuring the controller is running: the controller manager does not attempt to ping the controller.

This is useful when one has a common controller shared between several masters.


## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

