### PR TITLE
Add methods to set experiment pipeline/priority/flush defaults

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -27,6 +27,7 @@ ARTIQ-5
   masters.
 * The meaning of the ``-d/--dir`` and ``--srcbuild`` options of ``artiq_flash``
   has changed.
+* Experiments can now programatically set their default pipeline, priority, and flush flag.
 
 
 ARTIQ-4

--- a/artiq/dashboard/experiments.py
+++ b/artiq/dashboard/experiments.py
@@ -162,14 +162,14 @@ class _ArgumentEditor(QtWidgets.QTreeWidget):
 
     async def _recompute_argument(self, name):
         try:
-            arginfo = await self.manager.compute_arginfo(self.expurl)
+            expdesc = await self.manager.compute_expdesc(self.expurl)
         except:
             logger.error("Could not recompute argument '%s' of '%s'",
                          name, self.expurl, exc_info=True)
             return
         argument = self.manager.get_submission_arguments(self.expurl)[name]
 
-        procdesc = arginfo[name][0]
+        procdesc = expdesc["arginfo"][name][0]
         state = procdesc_to_entry(procdesc).default_state(procdesc)
         argument["desc"] = procdesc
         argument["state"] = state
@@ -272,7 +272,8 @@ class _ExperimentDock(QtWidgets.QMdiSubWindow):
             scheduling["due_date"] = due_date
         datetime_en.stateChanged.connect(update_datetime_en)
 
-        pipeline_name = QtWidgets.QLineEdit()
+        self.pipeline_name = QtWidgets.QLineEdit()
+        pipeline_name = self.pipeline_name
         self.layout.addWidget(QtWidgets.QLabel("Pipeline:"), 1, 2)
         self.layout.addWidget(pipeline_name, 1, 3)
 
@@ -280,9 +281,10 @@ class _ExperimentDock(QtWidgets.QMdiSubWindow):
 
         def update_pipeline_name(text):
             scheduling["pipeline_name"] = text
-        pipeline_name.textEdited.connect(update_pipeline_name)
+        pipeline_name.textChanged.connect(update_pipeline_name)
 
-        priority = QtWidgets.QSpinBox()
+        self.priority = QtWidgets.QSpinBox()
+        priority = self.priority
         priority.setRange(-99, 99)
         self.layout.addWidget(QtWidgets.QLabel("Priority:"), 2, 0)
         self.layout.addWidget(priority, 2, 1)
@@ -293,7 +295,8 @@ class _ExperimentDock(QtWidgets.QMdiSubWindow):
             scheduling["priority"] = value
         priority.valueChanged.connect(update_priority)
 
-        flush = QtWidgets.QCheckBox("Flush")
+        self.flush = QtWidgets.QCheckBox("Flush")
+        flush = self.flush
         flush.setToolTip("Flush the pipeline (of current- and higher-priority "
                          "experiments) before starting the experiment")
         self.layout.addWidget(flush, 2, 2, 1, 2)
@@ -386,11 +389,12 @@ class _ExperimentDock(QtWidgets.QMdiSubWindow):
 
     async def _recompute_arguments_task(self, overrides=dict()):
         try:
-            arginfo = await self.manager.compute_arginfo(self.expurl)
+            expdesc = await self.manager.compute_expdesc(self.expurl)
         except:
-            logger.error("Could not recompute arguments of '%s'",
+            logger.error("Could not recompute experiment description of '%s'",
                          self.expurl, exc_info=True)
             return
+        arginfo = expdesc["arginfo"]
         for k, v in overrides.items():
             # Some values (e.g. scans) may have multiple defaults in a list
             if ("default" in arginfo[k][0]
@@ -406,6 +410,28 @@ class _ExperimentDock(QtWidgets.QMdiSubWindow):
         self.argeditor = _ArgumentEditor(self.manager, self, self.expurl)
         self.argeditor.restore_state(argeditor_state)
         self.layout.addWidget(self.argeditor, 0, 0, 1, 5)
+
+    def contextMenuEvent(self, event):
+        menu = QtWidgets.QMenu(self)
+        reset_sched = menu.addAction("Reset scheduler settings")
+        action = menu.exec_(self.mapToGlobal(event.pos()))
+        if action == reset_sched:
+            asyncio.ensure_future(self._recompute_sched_options_task())
+
+    async def _recompute_sched_options_task(self):
+        try:
+            expdesc = await self.manager.compute_expdesc(self.expurl)
+        except:
+            logger.error("Could not recompute experiment description of '%s'",
+                         self.expurl, exc_info=True)
+            return
+        sched_defaults = expdesc["scheduler_defaults"]
+
+        scheduling = self.manager.get_submission_scheduling(self.expurl)
+        scheduling.update(sched_defaults)
+        self.priority.setValue(scheduling["priority"])
+        self.pipeline_name.setText(scheduling["pipeline_name"])
+        self.flush.setChecked(scheduling["flush"])
 
     def _load_hdf5_clicked(self):
         asyncio.ensure_future(self._load_hdf5_task())
@@ -508,6 +534,8 @@ class ExperimentManager:
                 "due_date": None,
                 "flush": False
             }
+            if expurl[:5] == "repo:":
+                scheduling.update(self.explist[expurl[5:]]["scheduler_defaults"])
             self.submission_scheduling[expurl] = scheduling
             return scheduling
 
@@ -640,7 +668,7 @@ class ExperimentManager:
                 rids.append(rid)
         asyncio.ensure_future(self._request_term_multiple(rids))
 
-    async def compute_arginfo(self, expurl):
+    async def compute_expdesc(self, expurl):
         file, class_name, use_repository = self.resolve_expurl(expurl)
         if use_repository:
             revision = self.get_submission_options(expurl)["repo_rev"]
@@ -648,7 +676,7 @@ class ExperimentManager:
             revision = None
         description = await self.experiment_db_ctl.examine(
             file, use_repository, revision)
-        return description[class_name]["arginfo"]
+        return description[class_name]
 
     async def open_file(self, file):
         description = await self.experiment_db_ctl.examine(file, False)

--- a/artiq/language/environment.py
+++ b/artiq/language/environment.py
@@ -207,10 +207,12 @@ class HasEnvironment:
             self.__device_mgr = managers_or_parent[0]
             self.__dataset_mgr = managers_or_parent[1]
             self.__argument_mgr = managers_or_parent[2]
+            self.__scheduler_defaults = managers_or_parent[3]
         else:
             self.__device_mgr = managers_or_parent.__device_mgr
             self.__dataset_mgr = managers_or_parent.__dataset_mgr
             self.__argument_mgr = managers_or_parent.__argument_mgr
+            self.__scheduler_defaults = {}
             managers_or_parent.register_child(self)
 
         self.__in_build = True
@@ -363,6 +365,21 @@ class HasEnvironment:
         """Sets the contents of a dataset as attribute. The names of the
         dataset and of the attribute are the same."""
         setattr(self, key, self.get_dataset(key, default, archive))
+
+    def set_default_scheduling(self, priority=None, pipeline_name=None, flush=None):
+        """Sets the default scheduling options.
+
+        This function should only be called from ``build``."""
+        if not self.__in_build:
+            raise TypeError("set_default_scheduling() should only "
+                            "be called from build()")
+
+        if priority is not None:
+            self.__scheduler_defaults["priority"] = int(priority)
+        if pipeline_name is not None:
+            self.__scheduler_defaults["pipeline_name"] = pipeline_name
+        if flush is not None:
+            self.__scheduler_defaults["flush"] = flush
 
 
 class Experiment:

--- a/artiq/master/experiments.py
+++ b/artiq/master/experiments.py
@@ -46,7 +46,8 @@ class _RepoScanner:
             entry = {
                 "file": filename,
                 "class_name": class_name,
-                "arginfo": arginfo
+                "arginfo": arginfo,
+                "scheduler_defaults": class_desc["scheduler_defaults"]
             }
             entry_dict[name] = entry
 
@@ -115,7 +116,6 @@ class ExperimentDB:
             t1 = time.monotonic()
             new_explist = await _RepoScanner(self.worker_handlers).scan(wd)
             logger.info("repository scan took %d seconds", time.monotonic()-t1)
-
             update_from_dict(self.explist, new_explist)
         finally:
             self._scanning = False

--- a/artiq/master/worker.py
+++ b/artiq/master/worker.py
@@ -303,8 +303,8 @@ class Worker:
         await self._create_process(logging.WARNING)
         r = dict()
 
-        def register(class_name, name, arginfo):
-            r[class_name] = {"name": name, "arginfo": arginfo}
+        def register(class_name, name, arginfo, scheduler_defaults):
+            r[class_name] = {"name": name, "arginfo": arginfo, "scheduler_defaults": scheduler_defaults}
         self.register_experiment = register
         await self._worker_action({"action": "examine", "file": file},
                                   timeout)

--- a/artiq/master/worker_impl.py
+++ b/artiq/master/worker_impl.py
@@ -174,11 +174,12 @@ def examine(device_mgr, dataset_mgr, file):
                     if name[-1] == ".":
                         name = name[:-1]
                 argument_mgr = TraceArgumentManager()
-                exp_class((device_mgr, dataset_mgr, argument_mgr))
+                scheduler_defaults = {}
+                cls = exp_class((device_mgr, dataset_mgr, argument_mgr, scheduler_defaults))
                 arginfo = OrderedDict(
                     (k, (proc.describe(), group, tooltip))
                     for k, (proc, group, tooltip) in argument_mgr.requested_args.items())
-                register_experiment(class_name, name, arginfo)
+                register_experiment(class_name, name, arginfo, scheduler_defaults)
     finally:
         new_keys = set(sys.modules.keys())
         for key in new_keys - previous_keys:
@@ -277,7 +278,7 @@ def main():
                 os.makedirs(dirname, exist_ok=True)
                 os.chdir(dirname)
                 argument_mgr = ProcessArgumentManager(expid["arguments"])
-                exp_inst = exp((device_mgr, dataset_mgr, argument_mgr))
+                exp_inst = exp((device_mgr, dataset_mgr, argument_mgr, {}))
                 put_object({"action": "completed"})
             elif action == "prepare":
                 exp_inst.prepare()


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
Add methods callable from experiment build() to set pipeline/priority/flush defaults.
Suggestions on a cleaner way of indicating the functionality of the "recompute scheduler options" button without bloating the GUI appreciated.
Closes #692

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.md](../RELEASE_NOTES.md) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Close/update issues.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments