### PR TITLE
suservo: fix coefficient data writing

### DIFF
--- a/artiq/gateware/rtio/phy/servo.py
+++ b/artiq/gateware/rtio/phy/servo.py
@@ -81,8 +81,13 @@ class RTServoMem(Module):
                 1 +  # state_sel
                 1 +  # config_sel
                 len(m_state.adr))
+
         internal_address = Signal(internal_address_width)
-        self.comb += internal_address.eq(Cat(self.rtlink.o.address, self.rtlink.o.data[w.coeff:]))
+        self.comb += internal_address.eq(Cat(self.rtlink.o.address,
+                                             self.rtlink.o.data[w.coeff:]))
+
+        coeff_data = Signal(w.coeff)
+        self.comb += coeff_data.eq(self.rtlink.o.data[:w.coeff])
 
         we = internal_address[-1]
         state_sel = internal_address[-2]
@@ -91,7 +96,7 @@ class RTServoMem(Module):
         self.comb += [
                 self.rtlink.o.busy.eq(0),
                 m_coeff.adr.eq(internal_address[1:]),
-                m_coeff.dat_w.eq(Cat(self.rtlink.o.data, self.rtlink.o.data)),
+                m_coeff.dat_w.eq(Cat(coeff_data, coeff_data)),
                 m_coeff.we[0].eq(self.rtlink.o.stb & ~high_coeff &
                     we & ~state_sel),
                 m_coeff.we[1].eq(self.rtlink.o.stb & high_coeff &


### PR DESCRIPTION
Signed-off-by: Thomas Harty <thomas.harty@physics.ox.ac.uk>

<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Fix writing of SU-Servo coefficient data.

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

c.f. #1258

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Steps (Choose relevant, delete irrelevant before submitting)

The following test fails on Artiq 5 for a few reasons. This commit fixes one of the causes.

```python

import numpy.random as rand

from artiq.experiment import *
from artiq.coredevice.suservo import COEFF_WIDTH

class Startup(EnvExperiment):
    def build(self):
        self.setattr_device("core")
        self.setattr_device("aom_servo")
        self.setattr_device("aom_397_doppler")
        self.offset = -0.00817

    def run(self):

        coeff_max = 1 << COEFF_WIDTH - 1

        self.ftw = self.pow_ = self.offs = 0

        for i in range(1000):

            self.a1 = rand.randint(low=-coeff_max, high=coeff_max)
            self.b1 = rand.randint(low=-coeff_max, high=coeff_max)
            self.b0 = rand.randint(low=-coeff_max, high=coeff_max)
            self.adc = rand.randint(low=0, high=8)
            self.dly = rand.randint(low=0, high=256)
            self.profile = rand.randint(low=0, high=8)
            self.freq = rand.random() * 400*MHz
            self.phase = (rand.random() - 0.5) * 2
            self.offset = (rand.random() - 0.5) * 2

            self.krun()
        print("pased")

    @kernel
    def krun(self):
        dds = self.aom_servo.dds0
        self.ftw = dds.frequency_to_ftw(self.freq)
        self.pow_ = dds.turns_to_pow(self.phase)
        self.offs = int(round(self.offset*(1 << COEFF_WIDTH - 1)))

        self.core.break_realtime()

        self.aom_397_doppler.set_dds_mu(self.profile,
                                        self.ftw,
                                        self.offs,
                                        self.pow_)
        delay(10*us)
        self.aom_397_doppler.set_iir_mu(self.profile,
                                        self.adc,
                                        self.a1,
                                        self.b0,
                                        self.b1,
                                        self.dly)

        data = [0] * 8
        self.aom_397_doppler.get_profile_mu(self.profile, data)

        assert self.ftw >> 16 == data[0]
        assert self.b1 == data[1]
        assert self.pow_ == data[2]
        assert self.adc | (self.dly << 8) == data[3]
        assert self.offs == data[4]
        assert self.a1 == data[5]
        assert self.ftw & 0xffff == data[6]
        assert self.b0 == data[7]
```
### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Update [RELEASE_NOTES.md](../RELEASE_NOTES.md) if there are noteworthy changes, especially if there are changes to existing APIs.
- [ ] Close/update issues.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [ ] Add and check docstrings and comments
- [ ] Check, test, and update the conda recipes in [conda/](../doc/)
- [ ] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

- [ ] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
