### PR TITLE
SUServo: remove references to non-existent a0 parameter

### DIFF
--- a/artiq/coredevice/suservo.py
+++ b/artiq/coredevice/suservo.py
@@ -319,7 +319,7 @@ class Channel:
         The recurrence relation is (all data signed and MSB aligned):
 
         .. math::
-            a_0 y_n = a_1 y_{n - 1} + b_0 (x_n + o)/2 + b_1 (x_{n - 1} + o)/2
+            y_n = a_1 y_{n - 1} + b_0 (x_n + o)/2 + b_1 (x_{n - 1} + o)/2
 
         Where:
 
@@ -328,7 +328,6 @@ class Channel:
             * :math:`x_n` and :math:`x_{n-1}` are the current and previous
               filter inputs in :math:`[-1, 1[`.
             * :math:`o` is the offset
-            * :math:`a_0` is the normalization factor :math:`2^{11}`
             * :math:`a_1` is the feedback gain
             * :math:`b_0` and :math:`b_1` are the feedforward gains for the two
               delays


### PR DESCRIPTION
I believe this parameter was used in a previous version of the servo, but has since been removed.