### PR TITLE
language: Support appending to datasets

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -20,6 +20,8 @@ ARTIQ-5
   edge timestamps are not required. See :mod:`artiq.coredevice.edge_counter` for
   the core device driver and :mod:`artiq.gateware.rtio.phy.edge_counter`/
   :meth:`artiq.gateware.eem.DIO.add_std` for the gateware components.
+* List datasets can now be efficiently appended to from experiments using
+  :meth:`artiq.language.environment.HasEnvironment.append_to_dataset`.
 * The controller manager now ignores device database entries without the
   ``"command"`` key set to facilitate sharing of devices between multiple
   masters.

--- a/artiq/frontend/artiq_influxdb.py
+++ b/artiq/frontend/artiq_influxdb.py
@@ -131,6 +131,9 @@ class _Mock:
     def __delitem__(self, k):
         pass
 
+    def append(self, v):
+        pass
+
 
 class Datasets:
     def __init__(self, filter_function, writer, init):

--- a/artiq/language/environment.py
+++ b/artiq/language/environment.py
@@ -321,6 +321,18 @@ class HasEnvironment:
         as ``slice(*sub_tuple)`` (multi-dimensional slicing)."""
         self.__dataset_mgr.mutate(key, index, value)
 
+    @rpc(flags={"async"})
+    def append_to_dataset(self, key, value):
+        """Append a value to a dataset.
+
+        The target dataset must be a list (i.e. support ``append()``), and must
+        have previously been set from this experiment.
+
+        The broadcast/persist/archive mode of the given key remains unchanged
+        from when the dataset was last set. Appended values are transmitted
+        efficiently as incremental modifications in broadcast mode."""
+        self.__dataset_mgr.append_to(key, value)
+
     def get_dataset(self, key, default=NoDefault, archive=True):
         """Returns the contents of a dataset.
 

--- a/artiq/master/worker_db.py
+++ b/artiq/master/worker_db.py
@@ -136,23 +136,27 @@ class DatasetManager:
         elif key in self.local:
             del self.local[key]
 
-    def mutate(self, key, index, value):
-        target = None
-        if key in self.local:
-            target = self.local[key]
+    def _get_mutation_target(self, key):
+        target = self.local.get(key, None)
         if key in self._broadcaster.raw_view:
             if target is not None:
                 assert target is self._broadcaster.raw_view[key][1]
-            target = self._broadcaster[key][1]
+            return self._broadcaster[key][1]
         if target is None:
-            raise KeyError("Cannot mutate non-existing dataset")
+            raise KeyError("Cannot mutate nonexistent dataset '{}'".format(key))
+        return target
 
+    def mutate(self, key, index, value):
+        target = self._get_mutation_target(key)
         if isinstance(index, tuple):
             if isinstance(index[0], tuple):
                 index = tuple(slice(*e) for e in index)
             else:
                 index = slice(*index)
         setitem(target, index, value)
+
+    def append_to(self, key, value):
+        self._get_mutation_target(key).append(value)
 
     def get(self, key, archive=False):
         if key in self.local:

--- a/artiq/master/worker_db.py
+++ b/artiq/master/worker_db.py
@@ -173,8 +173,18 @@ class DatasetManager:
     def write_hdf5(self, f):
         datasets_group = f.create_group("datasets")
         for k, v in self.local.items():
-            datasets_group[k] = v
+            _write(datasets_group, k, v)
 
         archive_group = f.create_group("archive")
         for k, v in self.archive.items():
-            archive_group[k] = v
+            _write(archive_group, k, v)
+
+
+def _write(group, k, v):
+    # Add context to exception message when the user writes a dataset that is
+    # not representable in HDF5.
+    try:
+        group[k] = v
+    except TypeError as e:
+        raise TypeError("Error writing dataset '{}' of type '{}': {}".format(
+            k, type(v), e))

--- a/artiq/test/test_datasets.py
+++ b/artiq/test/test_datasets.py
@@ -1,0 +1,69 @@
+"""Tests for the (Env)Experiment-facing dataset interface."""
+
+import copy
+import unittest
+
+from artiq.experiment import EnvExperiment
+from artiq.master.worker_db import DatasetManager
+from artiq.protocols.sync_struct import process_mod
+
+
+class MockDatasetDB:
+    def __init__(self):
+        self.data = dict()
+
+    def get(self, key):
+        return self.data[key][1]
+
+    def update(self, mod):
+        # Copy mod before applying to avoid sharing references to objects
+        # between this and the DatasetManager, which would lead to mods being
+        # applied twice.
+        process_mod(self.data, copy.deepcopy(mod))
+
+    def delete(self, key):
+        del self.data[key]
+
+
+class TestExperiment(EnvExperiment):
+    def get(self, key):
+        return self.get_dataset(key)
+
+    def set(self, key, value, **kwargs):
+        self.set_dataset(key, value, **kwargs)
+
+
+KEY = "foo"
+
+
+class ExperimentDatasetCase(unittest.TestCase):
+    def setUp(self):
+        # Create an instance of TestExperiment locally in this process and a
+        # mock dataset db to back it. When used from the master, the worker IPC
+        # connection would marshal updates between dataset_mgr and dataset_db.
+        self.dataset_db = MockDatasetDB()
+        self.dataset_mgr = DatasetManager(self.dataset_db)
+        self.exp = TestExperiment((None, self.dataset_mgr, None))
+
+    def test_set_local(self):
+        with self.assertRaises(KeyError):
+            self.exp.get(KEY)
+
+        for i in range(2):    
+            self.exp.set(KEY, i)
+            self.assertEqual(self.exp.get(KEY), i)
+            with self.assertRaises(KeyError):
+                self.dataset_db.get(KEY)
+
+    def test_set_broadcast(self):
+        with self.assertRaises(KeyError):
+            self.exp.get(KEY)
+
+        self.exp.set(KEY, 0, broadcast=True)
+        self.assertEqual(self.exp.get(KEY), 0)
+        self.assertEqual(self.dataset_db.get(KEY), 0)
+
+        self.exp.set(KEY, 1, broadcast=False)
+        self.assertEqual(self.exp.get(KEY), 1)
+        with self.assertRaises(KeyError):
+            self.dataset_db.get(KEY)


### PR DESCRIPTION
This adds `HasEnvironment.append_to_dataset()` for (efficiently) appending to datasets from experiment code.

All the required `sync_struct` machinery is already in place; appending just wasn't exposed previously.

Also adds some unit tests; the dataset API was largely untested before.