### PR TITLE
pyon: encode subclasses of base types

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -25,7 +25,8 @@ ARTIQ-5
 * The controller manager now ignores device database entries without the
   ``"command"`` key set to facilitate sharing of devices between multiple
   masters.
-
+* PYON can now encode subclasses of basic types.
+  Examples include: namedtuples, lists (i.e. ``class specialized_list(list): pass``)
 
 ARTIQ-4
 -------

--- a/artiq/test/test_serialization.py
+++ b/artiq/test/test_serialization.py
@@ -1,11 +1,14 @@
 import unittest
 import json
 from fractions import Fraction
+from collections import namedtuple
 
 import numpy as np
 
 from artiq.protocols import pyon
 
+class special_list(list):
+    pass
 
 _pyon_test_object = {
     (1, 2): [(3, 4.2), (2, )],
@@ -17,6 +20,8 @@ _pyon_test_object = {
     "x": np.float16(9.0), "y": np.float32(9.0), "z": np.float64(9.0),
     1j: 1-9j,
     "q": np.complex128(1j),
+    "nt1": namedtuple("nt1", "test1 test2 test3")(np.float16(9.0), 5, "str"),
+    "l1": special_list([10, 100]),
 }
 
 


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Allow PYON to encode simple Python objects like NamedTuples and lists.
**Rationale**: have more readable and understandable data structures on client side for sending data to the target. For example, we are sending graph edges across PYON, encoded something like `start_position, destination_position, edge_type`. When these are all just numbers, it's a lot easier to understand them if we know the data structure like in a NamedTuple. A class would be ideal, but apparently too complex to be used by PYON.

### Related Issue

#1218 

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |


## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.md](../RELEASE_NOTES.md) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Close/update issues.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how. **Ran test_serialization.py, and added new tests.**
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

- [x] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
