### PR TITLE
conda: Bump migen/misoc commits to fix Sayma build

### DIFF
--- a/conda/artiq-dev/meta.yaml
+++ b/conda/artiq-dev/meta.yaml
@@ -14,8 +14,8 @@ requirements:
   run:
     - python >=3.5.3,<3.6
     - setuptools 33.1.1
-    - migen 0.8 py35_0+git2d62c0c
-    - misoc 0.12 py35_0+git714ea689
+    - migen 0.8 py35_63+gitafe4405
+    - misoc 0.12 py35_11+git8e033c2c
     - jesd204b 0.10
     - microscope
     - binutils-or1k-linux >=2.27


### PR DESCRIPTION
Per @vmsch, the Sayma targets apparently don't build with the mi{gen, soc} versions pulled in by the `artiq-dev` conda metapackage. This updates the version references to the latest commits, fixing the build.