### PR TITLE
dashboard: Sort TTL moninj channels by name

### DIFF
--- a/artiq/dashboard/moninj.py
+++ b/artiq/dashboard/moninj.py
@@ -20,6 +20,7 @@ class _TTLWidget(QtWidgets.QFrame):
         self.channel = channel
         self.set_mode = dm.ttl_set_mode
         self.force_out = force_out
+        self.title = title
 
         self.setFrameShape(QtWidgets.QFrame.Box)
         self.setFrameShadow(QtWidgets.QFrame.Raised)
@@ -131,7 +132,7 @@ class _TTLWidget(QtWidgets.QFrame):
             self.programmatic_change = False
 
     def sort_key(self):
-        return self.channel
+        return self.title
 
 
 class _SimpleDisplayWidget(QtWidgets.QFrame):


### PR DESCRIPTION
With growing system complexity, the moninj channel index is no longer a very intuitive ordering for typical end users.

@sbourdeauducq: Okay to merge? I could add a context menu option to switch between orders instead, but from our experience, there really isn't a use case for ordering by channel index.