### PR TITLE
tests: fix coredevice tests after implementing scheduler defaults

### DIFF
--- a/artiq/test/coredevice/test_portability.py
+++ b/artiq/test/coredevice/test_portability.py
@@ -10,7 +10,7 @@ def _run_on_host(k_class, *args, **kwargs):
     device_mgr = dict()
     device_mgr["core"] = sim_devices.Core(device_mgr)
 
-    k_inst = k_class((device_mgr, None, None),
+    k_inst = k_class((device_mgr, None, None, {}),
                      *args, **kwargs)
     k_inst.run()
     return k_inst

--- a/artiq/test/hardware_testbench.py
+++ b/artiq/test/hardware_testbench.py
@@ -111,7 +111,7 @@ class ExperimentCase(unittest.TestCase):
     def create(self, cls, *args, **kwargs):
         try:
             exp = cls(
-                (self.device_mgr, self.dataset_mgr, None),
+                (self.device_mgr, self.dataset_mgr, None, {}),
                 *args, **kwargs)
         except DeviceError as e:
             # skip if ddb does not match requirements


### PR DESCRIPTION
Hardware tests now pass, apart from a separate regression from the recent AD9910 driver work:
```
======================================================================
ERROR: test_sync_window (test_ad9910.AD9910Test)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/cjbe/artiq/artiq/test/coredevice/test_ad9910.py", line 342, in test_sync_window
    self.execute(AD9910Exp, "sync_window")
  File "/home/cjbe/artiq/artiq/test/hardware_testbench.py", line 137, in execute
    raise error from None
  File "/home/cjbe/artiq/artiq/test/hardware_testbench.py", line 132, in execute
    exp.run()
  File "/home/cjbe/artiq/artiq/test/coredevice/test_ad9910.py", line 17, in run
    getattr(self, self.runner)()
  File "/home/cjbe/artiq/artiq/language/core.py", line 54, in run_on_core
    return getattr(self, arg).run(run_on_core, ((self,) + k_args), k_kwargs)
  File "/home/cjbe/artiq/artiq/coredevice/core.py", line 123, in run
    self.compile(function, args, kwargs, set_result)
  File "/home/cjbe/artiq/artiq/coredevice/core.py", line 113, in compile
    raise CompileError(error.diagnostic) from error
artiq.coredevice.core.CompileError:
<artiq>/coredevice/ad9910.py:735:31-735:39: error: cannot unify numpy.int64 with numpy.int32: 64 is incompatible with 32
                self.set_sync(in_delay, window)
                              ^^^^^^^^
<artiq>/coredevice/ad9910.py:735:31-735:39: note: expression of type numpy.int64
                self.set_sync(in_delay, window)
                              ^^^^^^^^
```