### PR TITLE
compiler: Quote tuples as TTuple values

### DIFF
--- a/artiq/compiler/embedding.py
+++ b/artiq/compiler/embedding.py
@@ -221,6 +221,17 @@ class ASTSynthesizer:
             return asttyped.ListT(elts=elts, ctx=None, type=builtins.TList(),
                                   begin_loc=begin_loc, end_loc=end_loc,
                                   loc=begin_loc.join(end_loc))
+        elif isinstance(value, tuple):
+            begin_loc = self._add("(")
+            elts = []
+            for index, elt in enumerate(value):
+                elts.append(self.quote(elt))
+                self._add(", ")
+            end_loc   = self._add(")")
+            return asttyped.TupleT(elts=elts, ctx=None,
+                                   type=types.TTuple([e.type for e in elts]),
+                                   begin_loc=begin_loc, end_loc=end_loc,
+                                   loc=begin_loc.join(end_loc))
         elif isinstance(value, numpy.ndarray):
             begin_loc = self._add("numpy.array([")
             elts = []

--- a/artiq/compiler/transforms/llvm_ir_generator.py
+++ b/artiq/compiler/transforms/llvm_ir_generator.py
@@ -1566,6 +1566,11 @@ class LLVMIRGenerator:
             lleltsptr = llglobal.bitcast(lleltsary.type.element.as_pointer())
             llconst   = ll.Constant(llty, [lleltsptr, ll.Constant(lli32, len(llelts))])
             return llconst
+        elif types.is_tuple(typ):
+            assert isinstance(value, tuple), fail_msg
+            llelts = [self._quote(v, t, lambda: path() + [str(i)])
+                for i, (v, t) in enumerate(zip(value, typ.elts))]
+            return ll.Constant(llty, llelts)
         elif types.is_rpc(typ) or types.is_c_function(typ) or types.is_builtin_function(typ):
             # RPC, C and builtin functions have no runtime representation.
             return ll.Constant(llty, ll.Undefined)

--- a/artiq/test/lit/embedding/tuple.py
+++ b/artiq/test/lit/embedding/tuple.py
@@ -1,0 +1,9 @@
+# RUN: %python -m artiq.compiler.testbench.embedding %s
+
+from artiq.language.core import *
+
+values = (1, 2)
+
+@kernel
+def entrypoint():
+    assert values == (1, 2)


### PR DESCRIPTION
Previously, they would end up being TInstances, rendering them rather useless.

@whitequark: Am I missing something here that would make this undesirable in the general case, or was this just an oversight?

If we were worried about codegen for tuples with a lot of elements, we could emit a reference to a global constant instead.