### PR TITLE
Sync struct exc

### DIFF
--- a/artiq/protocols/sync_struct.py
+++ b/artiq/protocols/sync_struct.py
@@ -154,6 +154,8 @@ class Subscriber:
 
                 for notify_cb in self.notify_cbs:
                     notify_cb(mod)
+        except (ConnectionError, asyncio.CancelledError):
+            pass
         finally:
             if self.disconnect_cb is not None:
                 self.disconnect_cb()

--- a/artiq/protocols/sync_struct.py
+++ b/artiq/protocols/sync_struct.py
@@ -120,7 +120,7 @@ class Subscriber:
             self.writer.write(_protocol_banner)
             self.writer.write((self.notifier_name + "\n").encode())
             self.receive_task = asyncio.ensure_future(self._receive_cr())
-        except Exception:
+        except:
             self.writer.close()
             del self.reader
             del self.writer

--- a/artiq/protocols/sync_struct.py
+++ b/artiq/protocols/sync_struct.py
@@ -33,8 +33,8 @@ class ModAction(Enum):
     required.
 
     The path (member field) the change applies to is given in
-    ``m["path"]`` as a list; elements give successive levels of indexing. (There
-    is no ``path`` on initial initialization.)
+    ``m["path"]`` as a list; elements give successive levels of indexing.
+    (There is no ``path`` on initial initialization.)
 
     Details on the modification are stored in additional data fields specific
     to each type.
@@ -97,10 +97,11 @@ class Subscriber:
         from the publisher. The mod is passed as parameter. The function is
         called after the mod has been processed.
         A list of functions may also be used, and they will be called in turn.
-    :param disconnect_cb: An optional function called when disconnection happens
-        from external causes (i.e. not when ``close`` is called).
+    :param disconnect_cb: An optional function called when disconnection
+    happens from external causes (i.e. not when ``close`` is called).
     """
-    def __init__(self, notifier_name, target_builder, notify_cb=None, disconnect_cb=None):
+    def __init__(self, notifier_name, target_builder, notify_cb=None,
+                 disconnect_cb=None):
         self.notifier_name = notifier_name
         self.target_builder = target_builder
         if notify_cb is None:
@@ -164,12 +165,12 @@ class Subscriber:
 class Notifier:
     """Encapsulates a structure whose changes need to be published.
 
-    All mutations to the structure must be made through the :class:`.Notifier`. The
-    original structure must only be accessed for reads.
+    All mutations to the structure must be made through the :class:`.Notifier`.
+    The original structure must only be accessed for reads.
 
-    In addition to the list methods below, the :class:`.Notifier` supports the index
-    syntax for modification and deletion of elements. Modification of nested
-    structures can be also done using the index syntax, for example:
+    In addition to the list methods below, the :class:`.Notifier` supports the
+    index syntax for modification and deletion of elements. Modification of
+    nested structures can be also done using the index syntax, for example:
 
     >>> n = Notifier([])
     >>> n.append([])
@@ -178,8 +179,8 @@ class Notifier:
     [[42]]
 
     This class does not perform any network I/O and is meant to be used with
-    e.g. the :class:`.Publisher` for this purpose. Only one publisher at most can be
-    associated with a :class:`.Notifier`.
+    e.g. the :class:`.Publisher` for this purpose. Only one publisher at most
+    can be associated with a :class:`.Notifier`.
 
     :param backing_struct: Structure to encapsulate.
     """
@@ -271,8 +272,8 @@ class Publisher(AsyncioServer):
     a :class:`.Notifier`.
 
     :param notifiers: A dictionary containing the notifiers to associate with
-        the :class:`.Publisher`. The keys of the dictionary are the names of the
-        notifiers to be used with :class:`.Subscriber`.
+        the :class:`.Publisher`. The keys of the dictionary are the names of
+        the notifiers to be used with :class:`.Subscriber`.
     """
     def __init__(self, notifiers):
         AsyncioServer.__init__(self)
@@ -313,7 +314,8 @@ class Publisher(AsyncioServer):
                     await writer.drain()
             finally:
                 self._recipients[notifier_name].remove(queue)
-        except (ConnectionResetError, ConnectionAbortedError, BrokenPipeError, TimeoutError):
+        except (ConnectionResetError, ConnectionAbortedError, BrokenPipeError,
+                TimeoutError):
             # subscribers disconnecting are a normal occurrence
             pass
         finally:

--- a/artiq/protocols/sync_struct.py
+++ b/artiq/protocols/sync_struct.py
@@ -120,7 +120,7 @@ class Subscriber:
             self.writer.write(_protocol_banner)
             self.writer.write((self.notifier_name + "\n").encode())
             self.receive_task = asyncio.ensure_future(self._receive_cr())
-        except:
+        except Exception:
             self.writer.close()
             del self.reader
             del self.writer
@@ -314,8 +314,7 @@ class Publisher(AsyncioServer):
                     await writer.drain()
             finally:
                 self._recipients[notifier_name].remove(queue)
-        except (ConnectionResetError, ConnectionAbortedError, BrokenPipeError,
-                TimeoutError):
+        except (ConnectionError, TimeoutError, asyncio.CancelledError):
             # subscribers disconnecting are a normal occurrence
             pass
         finally:


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Tweak exception handling in `sync_struct`

1. Catch `ConnectionErrors` in `Subscriber._receiver_cr`. Logic for this change is that disconnects from the server are handled by `disconnect_cb` rather than trying to catch exceptions from `_receiver_cr`. Unhanded exceptions in the receiver lead to `Future/Task exception was never retrieved` messages.
2. Flake8 whitespace fixes
3. Catch `ConnectionError` rather than its subclasses. also catch `CancelledError` in a couple of places
4. `except Exception:` rather than bare `except:` to make flake8 happy

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->


### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
