### PR TITLE
sync_struct: catch ConnectionErrors in _receive_cr

### DIFF
--- a/artiq/protocols/sync_struct.py
+++ b/artiq/protocols/sync_struct.py
@@ -155,6 +155,8 @@ class Subscriber:
 
                 for notify_cb in self.notify_cbs:
                     notify_cb(mod)
+        except ConnectionError:
+            pass
         finally:
             if self.disconnect_cb is not None:
                 self.disconnect_cb()


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

sync_struct: catch connection errors raised in _receive_cr
