### PR TITLE
coredevice/suservo: Fix {get,set}_y_mu() scaling

### DIFF
--- a/artiq/coredevice/suservo.py
+++ b/artiq/coredevice/suservo.py
@@ -450,12 +450,12 @@ class Channel:
         """Get a profile's IIR state (filter output, Y0) in machine units.
 
         The IIR state is also know as the "integrator", or the DDS amplitude
-        scale factor. It is 18 bits wide and unsigned.
+        scale factor. It is 17 bits wide and unsigned.
 
         This method does not advance the timeline but consumes all slack.
 
         :param profile: Profile number (0-31)
-        :return: 18 bit unsigned Y0
+        :return: 17 bit unsigned Y0
         """
         return self.servo.read(STATE_SEL | (self.servo_channel << 5) | profile)
 
@@ -464,7 +464,7 @@ class Channel:
         """Get a profile's IIR state (filter output, Y0).
 
         The IIR state is also know as the "integrator", or the DDS amplitude
-        scale factor. It is 18 bits wide and unsigned.
+        scale factor. It is 17 bits wide and unsigned.
 
         This method does not advance the timeline but consumes all slack.
 
@@ -478,7 +478,7 @@ class Channel:
         """Set a profile's IIR state (filter output, Y0) in machine units.
 
         The IIR state is also know as the "integrator", or the DDS amplitude
-        scale factor. It is 18 bits wide and unsigned.
+        scale factor. It is 17 bits wide and unsigned.
 
         This method must not be used when the servo could be writing to the
         same location. Either deactivate the profile, or deactivate IIR
@@ -498,7 +498,7 @@ class Channel:
         """Set a profile's IIR state (filter output, Y0).
 
         The IIR state is also know as the "integrator", or the DDS amplitude
-        scale factor. It is 18 bits wide and unsigned.
+        scale factor. It is 17 bits wide and unsigned.
 
         This method must not be used when the servo could be writing to the
         same location. Either deactivate the profile, or deactivate IIR

--- a/artiq/coredevice/suservo.py
+++ b/artiq/coredevice/suservo.py
@@ -6,6 +6,7 @@ from artiq.coredevice import urukul, sampler
 
 
 COEFF_WIDTH = 18
+Y_FULL_SCALE_MU = (1 << (COEFF_WIDTH - 1)) - 1
 COEFF_DEPTH = 10 + 1
 WE = 1 << COEFF_DEPTH + 1
 STATE_SEL = 1 << COEFF_DEPTH
@@ -18,7 +19,7 @@ COEFF_SHIFT = 11
 @portable
 def y_mu_to_full_scale(y):
     """Convert servo Y data from machine units to units of full scale."""
-    return y*(1./(1 << COEFF_WIDTH - 1))
+    return y / Y_FULL_SCALE_MU
 
 
 @portable
@@ -508,4 +509,6 @@ class Channel:
         :param profile: Profile number (0-31)
         :param y: IIR state in units of full scale
         """
-        self.set_y_mu(profile, int(round((1 << COEFF_WIDTH - 1)*y)))
+        y_mu = int(round(y * Y_FULL_SCALE_MU))
+        self.set_y_mu(profile, y_mu)
+        return y_mu


### PR DESCRIPTION
Y0 is 18 bit signed, so the code (correctly) used 2^17 for the scale factor. The maximum representable number is 2^17 - 1, though, so `Channel.set_y(1.0)` would overflow to negative full scale instead. 