### PR TITLE
firmware: fix conditional compilation of pca9548

### DIFF
--- a/artiq/firmware/libboard_artiq/lib.rs
+++ b/artiq/firmware/libboard_artiq/lib.rs
@@ -25,10 +25,7 @@ pub mod mailbox;
 #[cfg(has_kernel_cpu)]
 pub mod rpc_queue;
 
-#[cfg(any(soc_platform = "kasli",
-          soc_platform = "sayma_amc",
-          soc_platform = "sayma_rtm",
-          soc_platform = "kc705"))]
+#[cfg(any(soc_platform = "kasli", has_si5324))]
 mod pca9548;
 #[cfg(has_si5324)]
 pub mod si5324;


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Fixes conditional compilation of the pca9548 module.

### Related Issue

Fix for [build failure of artiq-board-metlino-master](https://nixbld.m-labs.hk/build/11703/nixlog/1).

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
