### PR TITLE
influx_schedule: log repo_rev along with other info

### DIFF
--- a/artiq/frontend/artiq_influxdb_schedule.py
+++ b/artiq/frontend/artiq_influxdb_schedule.py
@@ -148,6 +148,7 @@ class Log(dict):
                         "priority": v["priority"],
                         "due_date": v["due_date"] or -1.,
                         "arguments": v["expid"].get("arguments", {}),
+                        "repo_rev": v["expid"]["repo_rev"],
                         "flush": v["flush"],
                     },
                     tags={


### PR DESCRIPTION
# Log repo_rev to influxDB

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Summary

Very simple tweak to log `repo_rev` to InfluxDB as a tag, via `artiq_influx_schedule`. 