### PR TITLE
pc_rpc.Server: Handle generic exceptions without crashing

### DIFF
--- a/artiq/protocols/asyncio_server.py
+++ b/artiq/protocols/asyncio_server.py
@@ -44,6 +44,8 @@ class AsyncioServer:
 
     def _client_done(self, task):
         self._client_tasks.remove(task)
+        if task.exception() and task.exception() != asyncio.CancelledError:
+            raise task.exception()
 
     def _handle_connection(self, reader, writer):
         task = asyncio.ensure_future(self._handle_connection_cr(reader, writer))

--- a/artiq/protocols/pc_rpc.py
+++ b/artiq/protocols/pc_rpc.py
@@ -150,6 +150,9 @@ class Client:
             if not more:
                 break
             buf += more.decode()
+        if not buf:
+            self.__socket.close()
+            raise ConnectionError('The RPC server closed the connection')
         return pyon.decode(buf)
 
     def __do_action(self, action):


### PR DESCRIPTION

# ARTIQ Pull Request

## Description of Changes

Add a generic Exception handler to Server to prevent it from crashing unexpectedly during requests. Report these exceptions to the `logger` and also to the requesting Client. 

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

