### PR TITLE
worker_impy: ignore newline at start of experiment docstring

### DIFF
--- a/artiq/master/worker_impl.py
+++ b/artiq/master/worker_impl.py
@@ -170,7 +170,7 @@ def examine(device_mgr, dataset_mgr, file):
                 if exp_class.__doc__ is None:
                     name = class_name
                 else:
-                    name = exp_class.__doc__.splitlines()[0].strip()
+                    name = exp_class.__doc__.strip().splitlines()[0].strip()
                     if name[-1] == ".":
                         name = name[:-1]
                 argument_mgr = TraceArgumentManager()


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Accept experiment docstrings that start with a newline. 

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Description 

PEP 257 suggests valid multiline docstrings can start with a newline: support this syntax. 