### PR TITLE
Fix ad9910 ram mode asf scale error

### DIFF
--- a/artiq/coredevice/ad9910.py
+++ b/artiq/coredevice/ad9910.py
@@ -603,7 +603,7 @@ class AD9910:
         """
         for i in range(len(ram)):
             ram[i] = ((self.turns_to_pow(turns[i]) << 16) |
-                      self.amplitude_to_asf(amplitude[i]))
+                      self.amplitude_to_asf(amplitude[i]) << 2)
 
     @kernel
     def set_frequency(self, frequency):

--- a/artiq/coredevice/ad9910.py
+++ b/artiq/coredevice/ad9910.py
@@ -588,7 +588,7 @@ class AD9910:
             Suitable for :meth:`write_ram`.
         """
         for i in range(len(ram)):
-            ram[i] = self.amplitude_to_asf(amplitude[i]) << 16
+            ram[i] = self.amplitude_to_asf(amplitude[i]) << 18
 
     @portable(flags={"fast-math"})
     def turns_amplitude_to_ram(self, turns, amplitude, ram):


### PR DESCRIPTION

RAM mode amplitude to ASF conversion should be `<< 18` rather than `<< 16` when in `RAM_DEST_ASF` mode.

page 33
https://www.analog.com/media/en/technical-documentation/data-sheets/AD9910.pdf