### PR TITLE
compiler: Prettify repr for built-in types

### DIFF
--- a/artiq/compiler/builtins.py
+++ b/artiq/compiler/builtins.py
@@ -12,6 +12,9 @@ class TNone(types.TMono):
     def __init__(self):
         super().__init__("NoneType")
 
+    def __repr__(self):
+        return "TNone"
+
 class TBool(types.TMono):
     def __init__(self):
         super().__init__("bool")
@@ -23,6 +26,9 @@ class TBool(types.TMono):
     @staticmethod
     def one():
         return True
+
+    def __repr__(self):
+        return "TBool"
 
 class TInt(types.TMono):
     def __init__(self, width=None):
@@ -37,6 +43,17 @@ class TInt(types.TMono):
     @staticmethod
     def one():
         return 1
+
+    def __repr__(self):
+        try:
+            width = self.params["width"].value
+            if width == 32:
+                return "TInt32"
+            if width == 64:
+                return "TInt64"
+        except KeyError:
+            pass
+        return super().__repr__()
 
 def TInt32():
     return TInt(types.TValue(32))
@@ -63,23 +80,38 @@ class TFloat(types.TMono):
     def one():
         return 1.0
 
+    def __repr__(self):
+        return "TFloat"
+
 class TStr(types.TMono):
     def __init__(self):
         super().__init__("str")
+
+    def __repr__(self):
+        return "TStr"
 
 class TBytes(types.TMono):
     def __init__(self):
         super().__init__("bytes")
 
+    def __repr__(self):
+        return "TBytes"
+
 class TByteArray(types.TMono):
     def __init__(self):
         super().__init__("bytearray")
+
+    def __repr__(self):
+        return "TByteArray"
 
 class TList(types.TMono):
     def __init__(self, elt=None):
         if elt is None:
             elt = types.TVar()
         super().__init__("list", {"elt": elt})
+
+    def __repr__(self):
+        return "TList(" + repr(self.params["elt"]) + ")"
 
 class TArray(types.TMono):
     def __init__(self, elt=None):

--- a/artiq/compiler/types.py
+++ b/artiq/compiler/types.py
@@ -185,7 +185,7 @@ class TTuple(Type):
         return fn(accum, self)
 
     def __repr__(self):
-        return "artiq.compiler.types.TTuple(%s)" % repr(self.elts)
+        return "TTuple(%s)" % repr(self.elts)
 
     def __eq__(self, other):
         return isinstance(other, TTuple) and \


### PR DESCRIPTION
`__repr__()` shows up in the Sphinx-generated documentation for functions with type annotations. Previously, type signatures would often span several lines, as all types would be written out as `artiq.compiler.types.TMono(%s, %s)`, etc.

This change makes those signatures eminently more readable by rendering the types in the way they are usually used in the source code, that is, `TInt32`, `TFloat`, `TList(TInt64)`, etc.