### PR TITLE
gateware/eem: Force IOB=TRUE on Urukul SYNC output

### DIFF
--- a/artiq/gateware/eem.py
+++ b/artiq/gateware/eem.py
@@ -87,7 +87,7 @@ class Urukul(_EEM):
             ),
         ]
         ttls = [(6, eem, "io_update"),
-                (7, eem, "dds_reset_sync_in")]
+                (7, eem, "dds_reset_sync_in", Misc("IOB=TRUE"))]
         if eem_aux is not None:
             ttls += [(0, eem_aux, "sync_clk"),
                      (1, eem_aux, "sync_in"),
@@ -97,12 +97,12 @@ class Urukul(_EEM):
                      (5, eem_aux, "sw1"),
                      (6, eem_aux, "sw2"),
                      (7, eem_aux, "sw3")]
-        for i, j, sig in ttls:
+        for i, j, sig, *extra_args in ttls:
             ios.append(
                 ("urukul{}_{}".format(eem, sig), 0,
                     Subsignal("p", Pins(_eem_pin(j, i, "p"))),
                     Subsignal("n", Pins(_eem_pin(j, i, "n"))),
-                    IOStandard(iostandard)
+                    IOStandard(iostandard), *extra_args
                 ))
         return ios
 


### PR DESCRIPTION
Without this, the final register in the SYNC signal TTLClockGen
isn't (always) placed in the I/O tile, leading to more jitter
than necessary, and causing "double window" artefacts. See
sinara-hw/Urukul#16 for more details.

(Patch based on work by Weida Zhang, testing by various members
of the community in Oxford and elsewhere.)

---

@jordens: Over on the Urukul issue, you mentioned:

> We generally expect the toolchain to pack these registers. I'd be surprised if it didn't here. If it didn't we should find out and check all similar cases (e.g. TTL I/O or SPI clocks) where we assume packing.

Given that this definitely changes behaviour on the Urukul SYNC clock, are there any other signals we should pin like this right away?