### PR TITLE
Update for AD9910 ram mode

### DIFF
--- a/artiq/coredevice/ad9910.py
+++ b/artiq/coredevice/ad9910.py
@@ -360,6 +360,9 @@ class AD9910:
             (:const:`RAM_DEST_FTW`, :const:`RAM_DEST_POW`,
             :const:`RAM_DEST_ASF`, :const:`RAM_DEST_POWASF`).
         :param ram_enable: RAM mode enable.
+        :param manual_osk_external: Enable OSK pin control in manual OSK mode.
+        :param osk_enable: Enable OSK mode.
+        :param select_auto_osk: Select manual or automatic OSK mode
         """
         self.write32(_AD9910_REG_CFR1,
                      (ram_enable << 31) |
@@ -630,6 +633,10 @@ class AD9910:
 
     @kernel
     def set_frequency(self, frequency):
+        """Set the value stored to the AD9910's FTW register
+
+        :param frequency: frequency to be stored, in Hz
+        """
         return self.set_ftw(self.frequency_to_ftw(frequency))
 
     @kernel

--- a/artiq/coredevice/ad9910.py
+++ b/artiq/coredevice/ad9910.py
@@ -345,8 +345,7 @@ class AD9910:
     @kernel
     def set_cfr1(self, power_down=0b0000, phase_autoclear=0,
                  drg_load_lrr=0, drg_autoclear=0,
-                 internal_profile=0, ram_destination=0, ram_enable=0,
-                 manual_osk_external=0, osk_enable=0, select_auto_osk=0):
+                 internal_profile=0, ram_destination=0, ram_enable=0):
         """Set CFR1. See the AD9910 datasheet for parameter meanings.
 
         This method does not pulse IO_UPDATE.
@@ -360,20 +359,14 @@ class AD9910:
             (:const:`RAM_DEST_FTW`, :const:`RAM_DEST_POW`,
             :const:`RAM_DEST_ASF`, :const:`RAM_DEST_POWASF`).
         :param ram_enable: RAM mode enable.
-        :param manual_osk_external: Enable OSK pin control in manual OSK mode.
-        :param osk_enable: Enable OSK mode.
-        :param select_auto_osk: Select manual or automatic OSK mode.
         """
         self.write32(_AD9910_REG_CFR1,
                      (ram_enable << 31) |
                      (ram_destination << 29) |
-                     (manual_osk_external << 23) |
                      (internal_profile << 17) |
                      (drg_load_lrr << 15) |
                      (drg_autoclear << 14) |
                      (phase_autoclear << 13) |
-                     (osk_enable << 9) |
-                     (select_auto_osk << 8) |
                      (power_down << 4) |
                      2)  # SDIO input only, MSB first
 

--- a/artiq/coredevice/ad9910.py
+++ b/artiq/coredevice/ad9910.py
@@ -362,7 +362,7 @@ class AD9910:
         :param ram_enable: RAM mode enable.
         :param manual_osk_external: Enable OSK pin control in manual OSK mode.
         :param osk_enable: Enable OSK mode.
-        :param select_auto_osk: Select manual or automatic OSK mode
+        :param select_auto_osk: Select manual or automatic OSK mode.
         """
         self.write32(_AD9910_REG_CFR1,
                      (ram_enable << 31) |

--- a/artiq/coredevice/ad9910.py
+++ b/artiq/coredevice/ad9910.py
@@ -345,7 +345,8 @@ class AD9910:
     @kernel
     def set_cfr1(self, power_down=0b0000, phase_autoclear=0,
                  drg_load_lrr=0, drg_autoclear=0,
-                 internal_profile=0, ram_destination=0, ram_enable=0):
+                 internal_profile=0, ram_destination=0, ram_enable=0,
+                 manual_osk_external=0, osk_enable=0, select_auto_osk=0):
         """Set CFR1. See the AD9910 datasheet for parameter meanings.
 
         This method does not pulse IO_UPDATE.
@@ -363,10 +364,13 @@ class AD9910:
         self.write32(_AD9910_REG_CFR1,
                      (ram_enable << 31) |
                      (ram_destination << 29) |
+                     (manual_osk_external << 23) |
                      (internal_profile << 17) |
                      (drg_load_lrr << 15) |
                      (drg_autoclear << 14) |
                      (phase_autoclear << 13) |
+                     (osk_enable << 9) |
+                     (select_auto_osk << 8) |
                      (power_down << 4) |
                      2)  # SDIO input only, MSB first
 
@@ -526,7 +530,7 @@ class AD9910:
 
     @kernel
     def set_asf(self, asf):
-        self.write32(_AD9910_REG_ASF, asf)
+        self.write32(_AD9910_REG_ASF, asf<<2)
 
     @kernel
     def set_pow(self, pow_):

--- a/artiq/coredevice/ad9910.py
+++ b/artiq/coredevice/ad9910.py
@@ -529,14 +529,26 @@ class AD9910:
 
     @kernel
     def set_ftw(self, ftw):
+        """Set the value stored to the AD9910's frequency tuning word (FTW) register.
+
+        :param ftw: Frequency tuning word to be stored, range: 0 to 0xffffffff.
+        """
         self.write32(_AD9910_REG_FTW, ftw)
 
     @kernel
     def set_asf(self, asf):
+        """Set the value stored to the AD9910's amplitude scale factor (ASF) register.
+
+        :param asf: Amplitude scale factor to be stored, range: 0 to 0x3ffe.
+        """
         self.write32(_AD9910_REG_ASF, asf<<2)
 
     @kernel
     def set_pow(self, pow_):
+        """Set the value stored to the AD9910's phase offset word (POW) register.
+
+        :param pow_: Phase offset word to be stored, range: 0 to 0xffff.
+        """
         self.write32(_AD9910_REG_POW, pow_)
 
     @portable(flags={"fast-math"})
@@ -633,18 +645,26 @@ class AD9910:
 
     @kernel
     def set_frequency(self, frequency):
-        """Set the value stored to the AD9910's FTW register
+        """Set the value stored to the AD9910's frequency tuning word (FTW) register.
 
-        :param frequency: frequency to be stored, in Hz
+        :param frequency: frequency to be stored, in Hz.
         """
         return self.set_ftw(self.frequency_to_ftw(frequency))
 
     @kernel
     def set_amplitude(self, amplitude):
+        """Set the value stored to the AD9910's amplitude scale factor (ASF) register.
+
+        :param amplitude: amplitude to be stored, in units of full scale.
+        """
         return self.set_asf(self.amplitude_to_asf(amplitude))
 
     @kernel
     def set_phase(self, turns):
+        """Set the value stored to the AD9910's phase offset word (POW) register.
+
+        :param turns: phase offset to be stored, in turns.
+        """
         return self.set_pow(self.turns_to_pow(turns))
 
     @kernel


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Function set_asf() in class AD9910 should contain <<2, as per ASF register documentation on p. 58 of https://www.analog.com/media/en/technical-documentation/data-sheets/AD9910.pdf.

Updated docstrings for several functions in class AD9910.

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
