### PR TITLE
Added option of flashing only RTM gateware.

### DIFF
--- a/artiq/frontend/artiq_flash.py
+++ b/artiq/frontend/artiq_flash.py
@@ -26,6 +26,7 @@ def get_argparser():
 Valid actions:
 
     * gateware: write gateware bitstream to flash
+    * rtm_gateware: write RTM board gateware bitstream to flash
     * bootloader: write bootloader to flash
     * storage: write storage image to flash
     * firmware: write firmware to flash
@@ -340,7 +341,7 @@ def main():
         bin_dir = os.path.join(artiq_dir, "board-support")
 
     needs_artifacts = any(action in args.action
-                          for action in ["gateware", "bootloader", "firmware", "load"])
+                          for action in ["gateware", "bootloader", "firmware", "load", "rtm_gateware"])
     variant = args.variant
     if needs_artifacts and variant is None:
         variants = []
@@ -419,6 +420,14 @@ def main():
                     artifact_path(rtm_variant_dir, "gateware", "top.bit"), header=True)
                 programmer.write_binary(*config["rtm_gateware"],
                                         rtm_gateware_bin)
+        elif action == "rtm_gateware":
+            if args.target == "sayma" and variant != "simplesatellite" and variant != "master":
+                rtm_gateware_bin = convert_gateware(
+                    artifact_path(rtm_variant_dir, "gateware", "top.bit"), header=True)
+                programmer.write_binary(*config["rtm_gateware"],
+                                        rtm_gateware_bin)
+            else:
+                raise ValueError("No RTM board for this board and variant.")
         elif action == "bootloader":
             bootloader_bin = artifact_path(variant_dir, "software", "bootloader", "bootloader.bin")
             programmer.write_binary(*config["bootloader"], bootloader_bin)


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Added `rtm_gateware` option to `artiq_flash`, which flashes only RTM gateware on Sayma AMC variants with RTM. It makes debugging RTM faster.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |
| ✓  | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Update [RELEASE_NOTES.md](../RELEASE_NOTES.md) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [ ] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [ ] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

- [ ] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
