### PR TITLE
Enabled internal pullup for CML SYSREF outputs, otherwise there is no signal on them.

### DIFF
--- a/artiq/firmware/libboard_artiq/hmc830_7043.rs
+++ b/artiq/firmware/libboard_artiq/hmc830_7043.rs
@@ -150,9 +150,9 @@ pub mod hmc7043 {
     // enabled, divider, output config, is sysref
     const OUTPUT_CONFIG: [(bool, u16, u8, bool); 14] = [
         (true,  DAC_CLK_DIV,  0x08, false),  //  0: DAC1_CLK
-        (true,  SYSREF_DIV,   0x00, true),   //  1: DAC1_SYSREF
+        (true,  SYSREF_DIV,   0x01, true),   //  1: DAC1_SYSREF
         (true,  DAC_CLK_DIV,  0x08, false),  //  2: DAC0_CLK
-        (true,  SYSREF_DIV,   0x00, true),   //  3: DAC0_SYSREF
+        (true,  SYSREF_DIV,   0x01, true),   //  3: DAC0_SYSREF
         (true,  SYSREF_DIV,   0x10, true),   //  4: AMC_FPGA_SYSREF0
         (true,  FPGA_CLK_DIV, 0x10, true),   //  5: AMC_FPGA_SYSREF1
         (false, 0,            0x10, false),  //  6: unused


### PR DESCRIPTION
Signed-off-by: Paweł Kulik <pawel.kulik@creotech.pl>

<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Without setting driver impedance there is no signal on SYSREF outputs. [Figure 20.](https://datasheet.octopart.com/HMC7043LP7FETR-Analog-Devices-datasheet-62096689.pdf#%5B%7B%22num%22%3A33%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C54%2C714%2Cnull%5D) suggests that we should enable internal 100 Ohms when using DC coupling and no external pullups (altough it's not clear to me what they had in mind in this documentation). I checked that ARTIQ now progresses past "DAC sync failed: no sync lock" + that there is a clean clock on SYSREF intputs with 1Vpp swing. Before that change there was no signal and 0V at sysref signals.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Close/update issues.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes
- [x] Test your changes or have someone test them. Mention what was tested and how.


### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
