### PR TITLE
Kasli: allow modifying/adding generic peripherals

### DIFF
--- a/artiq/gateware/targets/kasli_generic.py
+++ b/artiq/gateware/targets/kasli_generic.py
@@ -99,18 +99,19 @@ def peripheral_grabber(module, peripheral):
     eem.Grabber.add_std(module, port, port_aux, port_aux2)
 
 
-def add_peripherals(module, peripherals):
-    peripheral_processors = {
-        "dio": peripheral_dio,
-        "urukul": peripheral_urukul,
-        "novogorny": peripheral_novogorny,
-        "sampler": peripheral_sampler,
-        "suservo": peripheral_suservo,
-        "zotino": peripheral_zotino,
-        "grabber": peripheral_grabber,
-    }
+_peripheral_processors = {
+    "dio": peripheral_dio,
+    "urukul": peripheral_urukul,
+    "novogorny": peripheral_novogorny,
+    "sampler": peripheral_sampler,
+    "suservo": peripheral_suservo,
+    "zotino": peripheral_zotino,
+    "grabber": peripheral_grabber,
+}
+def add_peripherals(module: "MiniSoC", peripherals: dict):
+    """Add dictionary-specified peripherals to a Kasli SoC build`."""
     for peripheral in peripherals:
-        peripheral_processors[peripheral["type"]](module, peripheral)
+        _peripheral_processors[peripheral["type"]](module, peripheral)
 
 
 class GenericStandalone(StandaloneBase):


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Makes the peripheral processor dictionary accessible to outside modules
for potential modifications. Allows people writing their own peripherals
to still integrate with the kasli_generic process without having to
extensively patch the whole kasli_generic module.

Also add a few docstrings/type hints.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] _I don't think this is required, but it is useful to know for outside groups._ Update [RELEASE_NOTES.md](../RELEASE_NOTES.md) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [ ] _Not tested b/c very simple refactor:_ Test your changes or have someone test them. Mention what was tested and how. 
- [x] Add and check docstrings and comments
- [x] _NA:_ Check test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
