### PR TITLE
[WIP] mirny: add

### DIFF
--- a/artiq/coredevice/adf5355.py
+++ b/artiq/coredevice/adf5355.py
@@ -9,12 +9,9 @@ on Mirny-style prefixed SPI buses.
 # https://www.analog.com/media/en/technical-documentation/user-guides/EV-ADF5356SD1Z-UG-1087.pdf
 
 
-from numpy import int32
-
-from artiq.language.core import (kernel, portable, delay_mu, delay, now_mu,
-                                 at_mu)
-from artiq.language.units import ns, us
-from artiq.coredevice import spi2 as spi, mirny
+from artiq.language.core import kernel, delay
+from artiq.language.units import us
+from artiq.coredevice import spi2 as spi
 
 SPI_CONFIG = (0*spi.SPI_OFFLINE | 0*spi.SPI_END |
               0*spi.SPI_INPUT | 1*spi.SPI_CS_POLARITY |

--- a/artiq/coredevice/adf5355.py
+++ b/artiq/coredevice/adf5355.py
@@ -1,5 +1,5 @@
-""""RTIO driver for the Analog Devices ADF[45]35[56] family of GHz PLLs
-on Mirny-style prefixed SPI buses
+"""RTIO driver for the Analog Devices ADF[45]35[56] family of GHz PLLs
+on Mirny-style prefixed SPI buses.
 """
 
 # https://github.com/analogdevicesinc/linux/blob/master/Documentation/devicetree/bindings/iio/frequency/adf5355.txt

--- a/artiq/coredevice/adf5355.py
+++ b/artiq/coredevice/adf5355.py
@@ -1,0 +1,68 @@
+""""RTIO driver for the Analog Devices ADF[45]35[56] family of GHz PLLs
+on Mirny-style prefixed SPI buses
+"""
+
+# https://github.com/analogdevicesinc/linux/blob/master/Documentation/devicetree/bindings/iio/frequency/adf5355.txt
+# https://github.com/analogdevicesinc/linux/blob/master/drivers/iio/frequency/adf5355.c
+# https://www.analog.com/media/en/technical-documentation/data-sheets/ADF5356.pdf
+# https://www.analog.com/media/en/technical-documentation/data-sheets/ADF5355.pdf
+# https://www.analog.com/media/en/technical-documentation/user-guides/EV-ADF5356SD1Z-UG-1087.pdf
+
+
+from numpy import int32
+
+from artiq.language.core import (kernel, portable, delay_mu, delay, now_mu,
+                                 at_mu)
+from artiq.language.units import ns, us
+from artiq.coredevice import spi2 as spi, mirny
+
+SPI_CONFIG = (0*spi.SPI_OFFLINE | 0*spi.SPI_END |
+              0*spi.SPI_INPUT | 1*spi.SPI_CS_POLARITY |
+              0*spi.SPI_CLK_POLARITY | 0*spi.SPI_CLK_PHASE |
+              0*spi.SPI_LSB_FIRST | 0*spi.SPI_HALF_DUPLEX)
+
+
+class ADF5355:
+    """Analog Devices AD[45]35[56] family of GHz PLLs.
+
+    :param cpld_device: Mirny CPLD device name
+    :param sw_device: Mirny RF switch device name
+    :param channel: Mirny RF channel index
+    :param core_device: Core device name (default: "core")
+    """
+    kernel_invariants = {"cpld", "sw", "channel", "core"}
+
+    def __init__(self, dmgr, cpld_device, sw_device, channel,
+                 core="core"):
+        self.cpld = dmgr.get(cpld_device)
+        self.sw = dmgr.get(sw_device)
+        self.channel = channel
+        self.core = dmgr.get(core)
+
+    @kernel
+    def set_att_mu(self, att):
+        """Set digital step attenuator in machine units.
+
+        :param att: Attenuation setting, 8 bit digital.
+        """
+        self.cpld.set_att_mu(self.channel, att)
+
+    @kernel
+    def write(self, data):
+        self.cpld.write_ext(self.channel | 4, 32, data)
+
+    @kernel
+    def read_muxout(self):
+        return bool(self.cpld.read_reg(0) & (1 << (self.channel + 8)))
+
+    @kernel
+    def init(self):
+        self.write((1 << 27) | 4)
+        if not self.read_muxout():
+            raise ValueError("MUXOUT not high")
+        delay(100*us)
+        self.write((2 << 27) | 4)
+        if self.read_muxout():
+            raise ValueError("MUXOUT not low")
+        delay(100*us)
+        self.write((6 << 27) | 4)

--- a/artiq/coredevice/mirny.py
+++ b/artiq/coredevice/mirny.py
@@ -1,0 +1,66 @@
+from artiq.language.core import kernel, delay
+from artiq.language.units import us
+
+from numpy import int32
+
+from artiq.coredevice import spi2 as spi
+
+
+SPI_CONFIG = (0*spi.SPI_OFFLINE | 0*spi.SPI_END |
+              0*spi.SPI_INPUT | 1*spi.SPI_CS_POLARITY |
+              0*spi.SPI_CLK_POLARITY | 0*spi.SPI_CLK_PHASE |
+              0*spi.SPI_LSB_FIRST | 0*spi.SPI_HALF_DUPLEX)
+
+# SPI clock write and read dividers
+SPIT_WR = 4
+SPIT_RD = 16
+
+SPI_CS = 1
+
+class Mirny:
+    WE = 1 << 24
+    kernel_invariants = {"bus", "core", "WE"}
+
+    def __init__(self, dmgr, spi_device, core_device="core"):
+        self.core = dmgr.get(core_device)
+        self.bus = dmgr.get(spi_device)
+
+    @kernel
+    def read_reg(self, addr):
+        self.bus.set_config_mu(SPI_CONFIG | spi.SPI_INPUT | spi.SPI_END, 24,
+                               SPIT_RD, SPI_CS)
+        self.bus.write((addr << 25))
+        return self.bus.read() & int32(0xffff)
+
+    @kernel
+    def write_reg(self, addr, data):
+        self.bus.set_config_mu(SPI_CONFIG | spi.SPI_END, 24, SPIT_WR, SPI_CS)
+        self.bus.write((addr << 25) | self.WE | ((data & 0xffff) << 8))
+
+    @kernel
+    def init(self):
+        reg0 = self.read_reg(0)
+        if reg0 & 0b11 != 0b11:
+            raise ValueError("Mirny HW_REV mismatch")
+        if (reg0 >> 2) & 0b11 != 0b00:
+            raise ValueError("Mirny PROTO_REV mismatch")
+        delay(100*us)  # slack
+
+    @kernel
+    def set_att_mu(self, channel, att):
+        """Set digital step attenuator in machine units.
+
+        :param att: Attenuation setting, 8 bit digital.
+        """
+        self.bus.set_config_mu(SPI_CONFIG | spi.SPI_END, 16, SPIT_WR, SPI_CS)
+        self.bus.write(((channel | 8) << 25) | (att << 16))
+
+    @kernel
+    def write_ext(self, addr, length, data):
+        self.bus.set_config_mu(SPI_CONFIG, 8, SPIT_WR, SPI_CS)
+        self.bus.write(addr << 25)
+        self.bus.set_config_mu(SPI_CONFIG | spi.SPI_END, length,
+                               SPIT_WR, SPI_CS)
+        if length < 32:
+            data <<= 32 - length
+        self.bus.write(data)

--- a/artiq/gateware/targets/kasli_generic.py
+++ b/artiq/gateware/targets/kasli_generic.py
@@ -99,6 +99,13 @@ def peripheral_grabber(module, peripheral):
     eem.Grabber.add_std(module, port, port_aux, port_aux2)
 
 
+def peripheral_mirny(module, peripheral):
+    if len(peripheral["ports"]) != 1:
+        raise ValueError("wrong number of ports")
+    eem.Mirny.add_std(module, peripheral["ports"][0],
+        ttl_serdes_7series.Output_8X)
+
+
 peripheral_processors = {
     "dio": peripheral_dio,
     "urukul": peripheral_urukul,
@@ -107,6 +114,7 @@ peripheral_processors = {
     "suservo": peripheral_suservo,
     "zotino": peripheral_zotino,
     "grabber": peripheral_grabber,
+    "mirny": peripheral_mirny,
 }
 
 

--- a/doc/manual/core_drivers_reference.rst
+++ b/doc/manual/core_drivers_reference.rst
@@ -99,6 +99,18 @@ RF generation drivers
 .. automodule:: artiq.coredevice.ad9914
     :members:
 
+:mod:`artiq.coredevice.mirny` module
++++++++++++++++++++++++++++++++++++++
+
+.. automodule:: artiq.coredevice.mirny
+    :members:
+
+:mod:`artiq.coredevice.adf5355` module
++++++++++++++++++++++++++++++++++++++++
+
+.. automodule:: artiq.coredevice.adf5355
+    :members:
+
 :mod:`artiq.coredevice.spline` module
 +++++++++++++++++++++++++++++++++++++
 


### PR DESCRIPTION
* This targets the CPLD gateware at https://github.com/quartiq/mirny
* includes initial coredevice driver, eem shims, and kasli_generic tooling
* addresses the ARTIQ side of #1130
* Register abstraction to be written

Test report from @airwoodix:

  - on a fresh power-up, it needs two tries to lock (artiq_run twice);
  - the MUXOUT=DVDD check in ADF5355.init fails randomly when
    manipulating reg1. It might be a delay thing, haven't investigated
    systematically yet;
  - the clk_sel documentation in the gateware code seems wrong to
    me. The schematics has in_sel0 and in_sel1 exchanged. The easiest
    might be to exchange the pins in the platform description.

# ARTIQ Pull Request

## Description of Changes

### Related Issue

Closes #1130

## Type of Changes

|   | Type |
| ------------- | ------------- |
|   | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
|   | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.md](../RELEASE_NOTES.md) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Close/update issues.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

- [x] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
