### PR TITLE
compiler, language: Implement @kernel_from_string

### DIFF
--- a/artiq/test/lit/embedding/eval.py
+++ b/artiq/test/lit/embedding/eval.py
@@ -1,0 +1,18 @@
+# RUN: %python -m artiq.compiler.testbench.embedding %s
+
+from artiq.language.core import *
+
+
+def make_incrementer(increment):
+    return kernel_from_string(["a"], "return a + {}".format(increment),
+                              portable)
+
+
+foo = make_incrementer(1)
+bar = make_incrementer(2)
+
+
+@kernel
+def entrypoint():
+    assert foo(4) == 5
+    assert bar(4) == 6


### PR DESCRIPTION
With support for polymorphism (or type erasure on pointers to
member functions) being absent in the ARTIQ compiler, code
generation is vital to be able to implement abstractions that
work with user-provided lists/trees of objects with uniform
interfaces (e.g. a common base class, or duck typing), but
different concrete types.

`@kernel_from_string` has been in production use for exactly
this use case in Oxford for the better part of a year now
(various places in ndscan).

I do realize that part of the current use case might be
obsoleted by future extensions to ARTIQ Python (see discussion
in #1089), but generating source code will likely always have a
small place to fill in some gaps between the richness of Python
and the restrictions of kernel code. The (intentionally) restrictive
interface will hopefully make sure its role does in fact remain
small.

(This PR extracts the related diff between our local tree and
current upstream master into one commit; apologies for any
accidental omissions.)