### PR TITLE
compiler: Allow `None` in type hints

### DIFF
--- a/artiq/compiler/embedding.py
+++ b/artiq/compiler/embedding.py
@@ -950,6 +950,9 @@ class Stitcher:
         return function_node
 
     def _extract_annot(self, function, annot, kind, call_loc, fn_kind):
+        if annot is None:
+            annot = builtins.TNone()
+
         if not isinstance(annot, types.Type):
             diag = diagnostic.Diagnostic("error",
                 "type annotation for {kind}, '{annot}', is not an ARTIQ type",

--- a/artiq/test/lit/embedding/annotation.py
+++ b/artiq/test/lit/embedding/annotation.py
@@ -12,6 +12,11 @@ def foo(x: TInt64, y: TInt64 = 1) -> TInt64:
     return x+y
 
 @kernel
+def bar(x: TInt64) -> None:
+    print(x)
+
+@kernel
 def entrypoint():
     print(foo(0, 2))
     print(foo(1, 3))
+    bar(3)

--- a/artiq/test/lit/embedding/error_specialized_annot.py
+++ b/artiq/test/lit/embedding/error_specialized_annot.py
@@ -4,9 +4,9 @@
 from artiq.experiment import *
 
 class c():
-# CHECK-L: ${LINE:+2}: error: type annotation for argument 'x', 'None', is not an ARTIQ type
+# CHECK-L: ${LINE:+2}: error: type annotation for argument 'x', '<class 'float'>', is not an ARTIQ type
     @kernel
-    def hello(self, x: None):
+    def hello(self, x: float):
         pass
 
     @kernel


### PR DESCRIPTION
Similar to how Python itself interprets `None` as `type(None)`,
make it translate to `TNone` in ARTIQ compiler type hints.

We have somewhat unintentionally been running with this change
locally for a long time, and (certainly without me realising) ended up
with `None` being used all over our code base – it seems like this
syntax comes naturally to users without much thought.

(Passes artiq-fast build tests, this time.)