### PR TITLE
kasli_generic(ARTIQ5): expose peripheral_processors

### DIFF
--- a/artiq/gateware/targets/kasli_generic.py
+++ b/artiq/gateware/targets/kasli_generic.py
@@ -95,16 +95,18 @@ def peripheral_grabber(module, peripheral):
     eem.Grabber.add_std(module, port, port_aux, port_aux2)
 
 
+peripheral_processors = {
+    "dio": peripheral_dio,
+    "urukul": peripheral_urukul,
+    "novogorny": peripheral_novogorny,
+    "sampler": peripheral_sampler,
+    "suservo": peripheral_suservo,
+    "zotino": peripheral_zotino,
+    "grabber": peripheral_grabber,
+}
+
+
 def add_peripherals(module, peripherals):
-    peripheral_processors = {
-        "dio": peripheral_dio,
-        "urukul": peripheral_urukul,
-        "novogorny": peripheral_novogorny,
-        "sampler": peripheral_sampler,
-        "suservo": peripheral_suservo,
-        "zotino": peripheral_zotino,
-        "grabber": peripheral_grabber,
-    }
     for peripheral in peripherals:
         peripheral_processors[peripheral["type"]](module, peripheral)
 


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

This PR cherry-picks the fix to #1403 into the release-5 branch