### PR TITLE
Added option of specifying another username when connecting through SSH.

### DIFF
--- a/artiq/remoting.py
+++ b/artiq/remoting.py
@@ -59,7 +59,7 @@ class LocalClient(Client):
 
 class SSHClient(Client):
     def __init__(self, host, jump_host=None):
-        if host.find("@") >= 0:
+        if "@" in host:
             self.username, self.host = host.split("@")
         else:
             self.host = host

--- a/artiq/remoting.py
+++ b/artiq/remoting.py
@@ -59,7 +59,11 @@ class LocalClient(Client):
 
 class SSHClient(Client):
     def __init__(self, host, jump_host=None):
-        self.host = host
+        if host.find("@") >= 0:
+            self.username, self.host = host.split("@")
+        else:
+            self.host = host
+            self.username = None
         self.jump_host = jump_host
         self.ssh = None
         self.sftp = None
@@ -83,7 +87,7 @@ class SSHClient(Client):
             self.ssh = paramiko.SSHClient()
             self.ssh.load_system_host_keys()
             self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-            self.ssh.connect(self.host, sock=proxy)
+            self.ssh.connect(self.host, username=self.username, sock=proxy)
 
             logger.debug("Connecting to {}".format(self.host))
         return self.ssh


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
Added option of specifying another username when connecting through SSH (using `username@server`)
### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Update [RELEASE_NOTES.md](../RELEASE_NOTES.md) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [ ] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
Tested if I can connect both with and without specifying username.
- [ ] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

- [ ] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
