### PR TITLE
ad53xx improvements

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -60,6 +60,7 @@ Highlights:
 * Python 3.7 compatibility (Nix and source builds only, no Conda).
 * Various other bugs from 4.0 fixed.
 * Preliminary Sayma v2 and Metlino hardware support.
+* Zotino now exposes `voltage_to_mu()`
 
 Breaking changes:
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -11,6 +11,7 @@ Highlights:
 * Performance improvements:
   - #1432: SERDES TTL inputs can now detect edges on pulses that are shorter
     than the RTIO period
+* Zotino now exposes `voltage_to_mu()`
 
 Breaking changes:
 
@@ -60,7 +61,6 @@ Highlights:
 * Python 3.7 compatibility (Nix and source builds only, no Conda).
 * Various other bugs from 4.0 fixed.
 * Preliminary Sayma v2 and Metlino hardware support.
-* Zotino now exposes `voltage_to_mu()`
 
 Breaking changes:
 

--- a/artiq/coredevice/ad53xx.py
+++ b/artiq/coredevice/ad53xx.py
@@ -97,11 +97,10 @@ def voltage_to_mu(voltage, offset_dacs=0x2000, vref=5.):
       (default: 0x2000)
     :param vref: DAC reference voltage (default: 5.)
     """
-    volt_lims = [-16 * vref * offset_dacs / (1 << 16),
-                 4 * vref * ((1 << 16) - 1 - 4 * offset_dacs) / (1 << 16)]
-    if voltage < volt_lims[0] or voltage > volt_lims[1]:
+    code = int(round((1 << 16) * (voltage / (4. * vref)) + offset_dacs * 0x4))
+    if code < 0x0 or code > 0xffff:
         raise ValueError("Invalid DAC voltage!")
-    return int(round((1 << 16) * (voltage / (4. * vref)) + offset_dacs * 0x4))
+    return code
 
 
 class _DummyTTL:

--- a/artiq/coredevice/ad53xx.py
+++ b/artiq/coredevice/ad53xx.py
@@ -89,12 +89,18 @@ def voltage_to_mu(voltage, offset_dacs=0x2000, vref=5.):
     voltage when the DAC register is set to mid-scale.
     An offset of V can be used to trim out a DAC offset error of -V.
 
+    Valid voltages are: [-2*vref, + 2*vref - 1 LSB] + voltage offset
+
     :param voltage: Voltage
     :param offset_dacs: Register value for the two offset DACs
       (default: 0x2000)
     :param vref: DAC reference voltage (default: 5.)
     """
-    return int(round(0x10000*(voltage/(4.*vref)) + offset_dacs*0x4))
+    volt_lims = [-16 * vref * offset_dacs / (1 << 16),
+                 4 * vref * ((1 << 16) - 1 - 4 * offset_dacs) / (1 << 16)]
+    if voltage < volt_lims[0] or voltage > volt_lims[1]:
+        raise ValueError("Invalid DAC voltage!")
+    return int(round((1 << 16) * (voltage / (4. * vref)) + offset_dacs * 0x4))
 
 
 class _DummyTTL:

--- a/artiq/coredevice/ad53xx.py
+++ b/artiq/coredevice/ad53xx.py
@@ -157,9 +157,6 @@ class AD53xx:
         self.offset_dacs = offset_dacs
         self.core = dmgr.get(core)
 
-    # make driver accessible (see #1341)
-    voltage_to_mu = staticmethod(voltage_to_mu)
-
     @kernel
     def init(self, blind=False):
         """Configures the SPI bus, drives LDAC and CLR high, programmes
@@ -375,3 +372,14 @@ class AD53xx:
         self.core.break_realtime()
         self.write_offset_mu(channel, 0x8000-offset_err)
         self.write_gain_mu(channel, 0xffff-gain_err)
+
+    @portable
+    def voltage_to_mu(self, voltage):
+        """Returns the 16-bit DAC register value required to produce a given
+        output voltage, assuming offset and gain errors have been trimmed out.
+
+        Valid voltages are: [-2*vref, + 2*vref - 1 LSB] + voltage offset
+
+        :param voltage: Voltage
+        """
+        return voltage_to_mu(voltage, self.offset_dacs, self.vref)

--- a/artiq/coredevice/ad53xx.py
+++ b/artiq/coredevice/ad53xx.py
@@ -80,6 +80,7 @@ def ad53xx_cmd_read_ch(channel, op):
     return AD53XX_CMD_SPECIAL | AD53XX_SPECIAL_READ | (op + (channel << 7))
 
 
+# maintain function definition for backward compatibility
 @portable
 def voltage_to_mu(voltage, offset_dacs=0x2000, vref=5.):
     """Returns the 16-bit DAC register value required to produce a given output
@@ -156,6 +157,9 @@ class AD53xx:
         self.vref = vref
         self.offset_dacs = offset_dacs
         self.core = dmgr.get(core)
+
+    # make driver accessible (see #1341)
+    voltage_to_mu = staticmethod(voltage_to_mu)
 
     @kernel
     def init(self, blind=False):

--- a/artiq/coredevice/ad53xx.py
+++ b/artiq/coredevice/ad53xx.py
@@ -86,16 +86,19 @@ def voltage_to_mu(voltage, offset_dacs=0x2000, vref=5.):
     """Returns the 16-bit DAC register value required to produce a given output
     voltage, assuming offset and gain errors have been trimmed out.
 
+    The 16-bit register value may also be used with 14-bit DACs. The additional
+    bits are disregarded by 14-bit DACs.
+
     Also used to return offset register value required to produce a given
     voltage when the DAC register is set to mid-scale.
     An offset of V can be used to trim out a DAC offset error of -V.
 
-    Valid voltages are: [-2*vref, + 2*vref - 1 LSB] + voltage offset
-
-    :param voltage: Voltage
+    :param voltage: Voltage in SI units.
+        Valid voltages are: [-2*vref, + 2*vref - 1 LSB] + voltage offset.
     :param offset_dacs: Register value for the two offset DACs
       (default: 0x2000)
     :param vref: DAC reference voltage (default: 5.)
+    :return: The 16-bit DAC register value
     """
     code = int(round((1 << 16) * (voltage / (4. * vref)) + offset_dacs * 0x4))
     if code < 0x0 or code > 0xffff:
@@ -114,8 +117,8 @@ class _DummyTTL:
 
 
 class AD53xx:
-    """Analog devices AD53[67][0123] family of 16-bit multi-channel Digital to
-    Analog Converters.
+    """Analog devices AD53[67][0123] family of multi-channel Digital to Analog
+    Converters.
 
     :param spi_device: SPI bus device name
     :param ldac_device: LDAC RTIO TTLOut channel name (optional)
@@ -378,8 +381,11 @@ class AD53xx:
         """Returns the 16-bit DAC register value required to produce a given
         output voltage, assuming offset and gain errors have been trimmed out.
 
-        Valid voltages are: [-2*vref, + 2*vref - 1 LSB] + voltage offset
+        The 16-bit register value may also be used with 14-bit DACs. The
+        additional bits are disregarded by 14-bit DACs.
 
-        :param voltage: Voltage
+        :param voltage: Voltage in SI units.
+            Valid voltages are: [-2*vref, + 2*vref - 1 LSB] + voltage offset.
+        :return: The 16-bit DAC register value
         """
         return voltage_to_mu(voltage, self.offset_dacs, self.vref)

--- a/artiq/coredevice/ad53xx.py
+++ b/artiq/coredevice/ad53xx.py
@@ -82,7 +82,7 @@ def ad53xx_cmd_read_ch(channel, op):
 
 @portable
 def voltage_to_mu(voltage, offset_dacs=0x2000, vref=5.):
-    """Returns the DAC register value required to produce a given output
+    """Returns the 16-bit DAC register value required to produce a given output
     voltage, assuming offset and gain errors have been trimmed out.
 
     Also used to return offset register value required to produce a given
@@ -114,8 +114,8 @@ class _DummyTTL:
 
 
 class AD53xx:
-    """Analog devices AD53[67][0123] family of multi-channel Digital to Analog
-    Converters.
+    """Analog devices AD53[67][0123] family of 16-bit multi-channel Digital to
+    Analog Converters.
 
     :param spi_device: SPI bus device name
     :param ldac_device: LDAC RTIO TTLOut channel name (optional)


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
*  Input validation has been added to voltage_to_mu(). (closes #1444)
*  Documentation improvements
    * State valid voltage range (closes #1443)
    * Conversion is only valid for 16-bit members of the family
*  Make `voltage_to_mu()` availible as a `statimethod`. The exising function is maintained for backwads compatibility, but is also exposed as a `staticmethod` of `AD53xx`. (closes #1341)


## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
|  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
|   | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.md](../RELEASE_NOTES.md) for new Zotino method
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes
    *  Called voltage_to_mu via zotino and imports (both in and outside kernel)
    *  Verified that exception is rasied on over/underflow
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/). 
 There seem to be no Zotino tests.

### Documentation Changes

- [x] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.


### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
