### PR TITLE
ad9910: fix asf range

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -13,6 +13,8 @@ Highlights:
     than the RTIO period
 * Coredevice SI to mu conversions now always return valid codes, or raise a `ValueError`.
 * Zotino now exposes `voltage_to_mu()`
+* `ad9910`: The maximum amplitude scale factor is now `0x3fff` (was `0x3ffe`
+  before).
 
 Breaking changes:
 

--- a/artiq/coredevice/ad9910.py
+++ b/artiq/coredevice/ad9910.py
@@ -539,9 +539,9 @@ class AD9910:
     def set_asf(self, asf):
         """Set the value stored to the AD9910's amplitude scale factor (ASF) register.
 
-        :param asf: Amplitude scale factor to be stored, range: 0 to 0x3ffe.
+        :param asf: Amplitude scale factor to be stored, range: 0 to 0x3fff.
         """
-        self.write32(_AD9910_REG_ASF, asf<<2)
+        self.write32(_AD9910_REG_ASF, asf << 2)
 
     @kernel
     def set_pow(self, pow_):
@@ -581,8 +581,8 @@ class AD9910:
     def amplitude_to_asf(self, amplitude):
         """Return 14-bit amplitude scale factor corresponding to given
         fractional amplitude."""
-        code = int32(round(amplitude * 0x3ffe))
-        if code < 0 or code > (1 << 14) - 1:
+        code = int32(round(amplitude * 0x3fff))
+        if code < 0 or code > 0x3fff:
             raise ValueError("Invalid AD9910 fractional amplitude!")
         return code
 
@@ -590,7 +590,7 @@ class AD9910:
     def asf_to_amplitude(self, asf):
         """Return amplitude as a fraction of full scale corresponding to given
         amplitude scale factor."""
-        return asf / float(0x3ffe)
+        return asf / float(0x3fff)
 
     @portable(flags={"fast-math"})
     def frequency_to_ram(self, frequency, ram):


### PR DESCRIPTION
The ASF is a 14-bit word. The highest possible value is 0x3fff, not
0x3ffe. `int(round(1.0 * 0x3fff)) == 0x3fff`.

I don't remember and understand why this was 0x3ffe since the beginning.
0x3fff was already used as a default in `set_mu()`

Signed-off-by: Robert Jördens <rj@quartiq.de>

<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.md](../RELEASE_NOTES.md) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Close/update issues.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [ ] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [ ] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [ ] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

- [x] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
