### PR TITLE
Suservo extension: arbitrary number of channels and coherent phase tracking mode

### DIFF
--- a/artiq/coredevice/suservo.py
+++ b/artiq/coredevice/suservo.py
@@ -12,6 +12,7 @@ Y_FULL_SCALE_MU = (1 << (COEFF_WIDTH - 1)) - 1
 T_CYCLE = (2*(8 + 64) + 2)*8*ns  # Must match gateware Servo.t_cycle.
 COEFF_SHIFT = 11 # Must match gateware IIRWidths.shift
 PROFILE_WIDTH = 5 # Must match gateware IIRWidths.profile
+FINE_TS_WIDTH = 3 # Must match bitlength of SERDES multiplication factor
 
 @portable
 def y_mu_to_full_scale(y):
@@ -121,8 +122,19 @@ class SUServo:
             prev_cpld_cfg = cpld.cfg_reg
             cpld.cfg_write(prev_cpld_cfg | (0xf << urukul.CFG_MASK_NU))
             dds.init(blind=True)
+
+            if dds.sync_data.sync_delay_seed != -1:
+                for channel_idx in range(4):
+                    mask_nu_this = 1 << (urukul.CFG_MASK_NU + channel_idx)
+                    cpld.cfg_write(prev_cpld_cfg | mask_nu_this)
+                    delay(8 * us)
+                    dds.tune_sync_delay(dds.sync_data.sync_delay_seed,
+                                        cpld_channel_idx=channel_idx)
+                    delay(50 * us)
             cpld.cfg_write(prev_cpld_cfg)
 
+        self.set_io_update_delays(
+            [dds.sync_data.io_update_delay for dds in self.ddses])
 
     @kernel
     def write(self, addr, value):
@@ -247,6 +259,18 @@ class SUServo:
         val = self.get_adc_mu(channel)
         gain = (self.gains >> (channel*2)) & 0b11
         return adc_mu_to_volts(val, gain)
+
+    @kernel
+    def set_io_update_delays(self, dlys):
+        """Set IO_UPDATE pulse alignment delays.
+
+        :param dlys: List of delays for each Urukul
+        """
+        bits = 0
+        mask_fine_ts = (1 << FINE_TS_WIDTH) - 1
+        for i in range(len(dlys)):
+            bits |= (dlys[i] & mask_fine_ts) << (FINE_TS_WIDTH * i)
+        self.write(self.io_dly_addr, bits)
 
 
 class Channel:
@@ -580,11 +604,21 @@ class CPLD(urukul.CPLD):
     """
     rb_len = 8
 
+    def __init__(self, dmgr, spi_device, io_update_device=None,
+                 **kwargs):
+        # Separate IO_UPDATE TTL output device used by SUServo core,
+        # if active, else by artiq.coredevice.suservo.AD9910
+        # :meth:`measure_io_update_alignment`.
+        # The urukul.CPLD driver utilises the CPLD CFG register
+        # option instead for pulsing IO_UPDATE of masked DDSs.
+        self.io_update_ttl = dmgr.get(io_update_device)
+        urukul.CPLD.__init__(self, dmgr, spi_device, **kwargs)
+
     @kernel
     def enable_readback(self):
         """
         This method sets the RB_EN flag in the Urukul CPLD configuration
-        register. Once set, the CPLD expects an alternating sequence of 
+        register. Once set, the CPLD expects an alternating sequence of
         two SPI transactions:
 
             * 1: Any transaction. If returning data, the rb_len LSBs
@@ -610,9 +644,9 @@ class CPLD(urukul.CPLD):
     def sta_read(self, full=False):
         """
         Read rb_len LSBs from status register
-        
+
         :param full: retrieve status register by concatenating data from
-            several readback transactions. If rb_len < 8, the (8 - rb_len) 
+            several readback transactions. If rb_len < 8, the (8 - rb_len)
             MSBs will be missing from each subtransaction. Also, ifc_mode
             cannot be read.
         """
@@ -691,7 +725,7 @@ class CPLD(urukul.CPLD):
         :param cs: Select data to be returned from the readback register.
              - urukul.CS_RB_LSBS does not modify the readback register upon readback
              - urukul.CS_RB_PROTO_REV loads the (rb_len - 1) LSBs of proto_rev
-             - urukul.CS_PLL_LOCK loads the min(rb_len - 1, 4) PLL lock status bits  
+             - urukul.CS_PLL_LOCK loads the min(rb_len - 1, 4) PLL lock status bits
         :return: CPLD readback register.
         """
         self.bus.set_config_mu(
@@ -736,3 +770,50 @@ class AD9910(ad9910.AD9910):
     def read_ram(self, data):
         # 3-wire SPI transactions consisting of multiple transfers are not supported.
         raise NotImplementedError
+
+    @kernel
+    def measure_io_update_alignment(self, delay_start, delay_stop):
+        """Refer to artiq.coredevice.ad9910 :meth:`measure_io_update_alignment`.
+        In order that this method can operate the io_update_ttl also used by the SUServo
+        core, deactivate the servo before (see :meth:`set_config`).
+        """
+        # set up DRG
+        self.set_cfr1(drg_load_lrr=1, drg_autoclear=1)
+        # DRG -> FTW, DRG enable
+        self.write32(ad9910._AD9910_REG_CFR2, 0x01090000)
+        # no limits
+        self.write64(ad9910._AD9910_REG_RAMP_LIMIT, -1, 0)
+        # DRCTL=0, dt=1 t_SYNC_CLK
+        self.write32(ad9910._AD9910_REG_RAMP_RATE, 0x00010000)
+        # dFTW = 1, (work around negative slope)
+        self.write64(ad9910._AD9910_REG_RAMP_STEP, -1, 0)
+        # un-mask DDS
+        cfg_masked = self.cpld.cfg_reg
+        self.cpld.cfg_write(cfg_masked & ~(0xf << urukul.CFG_MASK_NU))
+        delay(70 * us)  # slack
+        # delay io_update after RTIO edge
+        t = now_mu() + 8 & ~7
+        at_mu(t + delay_start)
+        # assumes a maximum t_SYNC_CLK period
+        self.cpld.io_update_ttl.pulse(self.core.mu_to_seconds(16 - delay_start))  # realign
+        # re-mask DDS
+        self.cpld.cfg_write(cfg_masked)
+        delay(10 * us)  # slack
+        # disable DRG autoclear and LRR on io_update
+        self.set_cfr1()
+        delay(10 * us)  # slack
+        # stop DRG
+        self.write64(ad9910._AD9910_REG_RAMP_STEP, 0, 0)
+        delay(10 * us)  # slack
+        # un-mask DDS
+        self.cpld.cfg_write(cfg_masked & ~(0xf << urukul.CFG_MASK_NU))
+        at_mu(t + 0x20000 + delay_stop)
+        self.cpld.io_update_ttl.pulse(self.core.mu_to_seconds(16 - delay_stop))  # realign
+        # re-mask DDS
+        self.cpld.cfg_write(cfg_masked)
+        ftw = self.read32(ad9910._AD9910_REG_FTW)  # read out effective FTW
+        delay(100*us)  # slack
+        # disable DRG
+        self.write32(ad9910._AD9910_REG_CFR2, 0x01010000)
+        self.cpld.io_update.pulse(16 * ns)
+        return ftw & 1

--- a/artiq/coredevice/suservo.py
+++ b/artiq/coredevice/suservo.py
@@ -571,3 +571,168 @@ class Channel:
             raise ValueError("Invalid SUServo y-value!")
         self.set_y_mu(profile, y_mu)
         return y_mu
+
+
+class CPLD(urukul.CPLD):
+    """
+    This module contains a subclass of the Urukul driver class in artiq.coredevice
+    adapted to use CPLD read-back via half-duplex SPI.
+    """
+    rb_len = 8
+
+    @kernel
+    def enable_readback(self):
+        """
+        This method sets the RB_EN flag in the Urukul CPLD configuration
+        register. Once set, the CPLD expects an alternating sequence of 
+        two SPI transactions:
+
+            * 1: Any transaction. If returning data, the rb_len LSBs
+                of that will be stored in the CPLD.
+
+            * 2: One read transaction in half-duplex SPI mode shifting
+                out data from the CPLD over MOSI (use :meth:`readback`).
+
+        To end this protocol, call :meth:`disable_readback` during step 1.
+        """
+        self.cfg_write(self.cfg_reg | (1 << urukul.CFG_RB_EN))
+
+    @kernel
+    def disable_readback(self):
+        """
+        This method clears the RB_EN flag in the Urukul CPLD configuration
+        register. This marks the end of the readback protocol (see
+        :meth:`enable_readback`).
+        """
+        self.cfg_write(self.cfg_reg & ~(1 << urukul.CFG_RB_EN))
+
+    @kernel
+    def sta_read(self, full=False):
+        """
+        Read rb_len LSBs from status register
+        
+        :param full: retrieve status register by concatenating data from
+            several readback transactions. If rb_len < 8, the (8 - rb_len) 
+            MSBs will be missing from each subtransaction. Also, ifc_mode
+            cannot be read.
+        """
+        self.enable_readback()
+        self.sta_read_impl()
+        delay(16 * us)  # slack
+        r = self.readback() << urukul.STA_RF_SW
+        delay(16 * us)  # slack
+        if full:
+            self.enable_readback()  # dummy write
+            r |= self.readback(urukul.CS_RB_PLL_LOCK) << urukul.STA_PLL_LOCK
+            delay(16 * us)  # slack
+            self.enable_readback()  # dummy write
+            r |= self.readback(urukul.CS_RB_PROTO_REV) << urukul.STA_PROTO_REV
+            delay(16 * us)  # slack
+        self.disable_readback()
+        return r
+
+    @kernel
+    def proto_rev_read(self):
+        """Read rb_len LSBs of proto_rev"""
+        self.enable_readback()
+        self.enable_readback()  # dummy write
+        r = self.readback(urukul.CS_RB_PROTO_REV)
+        self.disable_readback()
+        return r
+
+    @kernel
+    def pll_lock_read(self):
+        """Read min(rb_len - 1, 4) LSBs of pll_lock status"""
+        self.enable_readback()
+        self.enable_readback()  # dummy write
+        r = self.readback(urukul.CS_RB_PLL_LOCK)
+        self.disable_readback()
+        return r & 0xf
+
+    @kernel
+    def get_att_mu(self):
+        # Different behaviour to urukul.CPLD.get_att_mu: Here, the
+        # latch enable of the attenuators activates 31.5dB
+        # attenuation during the transactions.
+        lengths = [self.rb_len] * (32 // self.rb_len + 1)
+        lengths[-1] = 32 % self.rb_len
+        shifts = [0] * len(lengths)
+        for i in range(len(lengths)):
+            cumsum = 0
+            for j in range(i + 1):
+                cumsum += lengths[j]
+            shifts[i] = 32 - cumsum
+
+        att_reg = int32(0)
+        self.enable_readback()
+        for i in range(len(lengths)):
+            num_bits = lengths[i]
+            if num_bits > 0:
+                self.core.break_realtime()
+                self.bus.set_config_mu(urukul.SPI_CONFIG | spi.SPI_END, num_bits,
+                                       urukul.SPIT_ATT_RD, urukul.CS_ATT)
+                self.bus.write(0)  # shift in zeros, shift out num_bits bits
+                r = self.readback() & ((1 << num_bits) - 1)
+                att_reg |= r << shifts[i]
+
+        delay(16 * us)  # slack
+        self.disable_readback()
+
+        self.att_reg = int32(att_reg)
+        delay(8 * us)  # slack
+        self.set_all_att_mu(self.att_reg)  # shift and latch current value again
+        return self.att_reg
+
+    @kernel
+    def readback(self, cs=urukul.CS_RB_LSBS):
+        """Read from the readback register in half-duplex SPI mode
+        See :meth:`enable_readback` for usage instructions.
+
+        :param cs: Select data to be returned from the readback register.
+             - urukul.CS_RB_LSBS does not modify the readback register upon readback
+             - urukul.CS_RB_PROTO_REV loads the (rb_len - 1) LSBs of proto_rev
+             - urukul.CS_PLL_LOCK loads the min(rb_len - 1, 4) PLL lock status bits  
+        :return: CPLD readback register.
+        """
+        self.bus.set_config_mu(
+            urukul.SPI_CONFIG | spi.SPI_END | spi.SPI_INPUT | spi.SPI_HALF_DUPLEX,
+            self.rb_len, urukul.SPIT_CFG_RD, cs)
+        self.bus.write(0)
+        return int32(self.bus.read())
+
+
+class AD9910(ad9910.AD9910):
+    """
+    This module contains a subclass of the AD9910 driver class in artiq.coredevice
+    using CPLD read-back via half-duplex SPI.
+    """
+
+    # Re-declare set of kernel invariants to avoid warning about non-existent
+    # `sw` attribute, as the AD9910 (instance) constructor writes to the
+    # class attributes.
+    kernel_invariants = {
+        "chip_select", "cpld", "core", "bus", "ftw_per_hz", "sysclk_per_mu"
+    }
+
+    @kernel
+    def read32(self, addr):
+        """
+        ! This method returns only the .suservo.CPLD.rb_len least significant bits !
+        """
+        self.cpld.enable_readback()
+        self.read32_impl(addr)
+        delay(12 * us)  # slack
+        r = self.cpld.readback()
+        delay(12 * us)  # slack
+        self.cpld.disable_readback()
+        return r
+
+    @kernel
+    def read64(self, addr):
+        # 3-wire SPI transactions consisting of multiple transfers are not supported.
+        raise NotImplementedError
+
+    @kernel
+    def read_ram(self, data):
+        # 3-wire SPI transactions consisting of multiple transfers are not supported.
+        raise NotImplementedError

--- a/artiq/examples/kasli_suservo/device_db.py
+++ b/artiq/examples/kasli_suservo/device_db.py
@@ -135,53 +135,66 @@ device_db = {
         "arguments": {"channel": 15},
     },
 
+    "ttl_urukul0_io_update": {
+        "type": "local",
+        "module": "artiq.coredevice.ttl",
+        "class": "TTLOut",
+        "arguments": {"channel": 16}
+    },
+    "ttl_urukul1_io_update": {
+        "type": "local",
+        "module": "artiq.coredevice.ttl",
+        "class": "TTLOut",
+        "arguments": {"channel": 17}
+    },
+
     "suservo0_ch0": {
-        "type": "local",
-        "module": "artiq.coredevice.suservo",
-        "class": "Channel",
-        "arguments": {"channel": 16, "servo_device": "suservo0"}
-    },
-    "suservo0_ch1": {
-        "type": "local",
-        "module": "artiq.coredevice.suservo",
-        "class": "Channel",
-        "arguments": {"channel": 17, "servo_device": "suservo0"}
-    },
-    "suservo0_ch2": {
         "type": "local",
         "module": "artiq.coredevice.suservo",
         "class": "Channel",
         "arguments": {"channel": 18, "servo_device": "suservo0"}
     },
-    "suservo0_ch3": {
+    "suservo0_ch1": {
         "type": "local",
         "module": "artiq.coredevice.suservo",
         "class": "Channel",
         "arguments": {"channel": 19, "servo_device": "suservo0"}
     },
-    "suservo0_ch4": {
+    "suservo0_ch2": {
         "type": "local",
         "module": "artiq.coredevice.suservo",
         "class": "Channel",
         "arguments": {"channel": 20, "servo_device": "suservo0"}
     },
-    "suservo0_ch5": {
+    "suservo0_ch3": {
         "type": "local",
         "module": "artiq.coredevice.suservo",
         "class": "Channel",
         "arguments": {"channel": 21, "servo_device": "suservo0"}
     },
-    "suservo0_ch6": {
+    "suservo0_ch4": {
         "type": "local",
         "module": "artiq.coredevice.suservo",
         "class": "Channel",
         "arguments": {"channel": 22, "servo_device": "suservo0"}
     },
-    "suservo0_ch7": {
+    "suservo0_ch5": {
         "type": "local",
         "module": "artiq.coredevice.suservo",
         "class": "Channel",
         "arguments": {"channel": 23, "servo_device": "suservo0"}
+    },
+    "suservo0_ch6": {
+        "type": "local",
+        "module": "artiq.coredevice.suservo",
+        "class": "Channel",
+        "arguments": {"channel": 24, "servo_device": "suservo0"}
+    },
+    "suservo0_ch7": {
+        "type": "local",
+        "module": "artiq.coredevice.suservo",
+        "class": "Channel",
+        "arguments": {"channel": 25, "servo_device": "suservo0"}
     },
 
     "suservo0": {
@@ -189,12 +202,10 @@ device_db = {
         "module": "artiq.coredevice.suservo",
         "class": "SUServo",
         "arguments": {
-            "channel": 24,
+            "channel": 26,
             "pgia_device": "spi_sampler0_pgia",
-            "cpld0_device": "urukul0_cpld",
-            "cpld1_device": "urukul1_cpld",
-            "dds0_device": "urukul0_dds",
-            "dds1_device": "urukul1_dds"
+            "cpld_devices": ["urukul0_cpld", "urukul1_cpld"],
+            "dds_devices": ["urukul0_dds", "urukul1_dds"],
         }
     },
 
@@ -202,33 +213,37 @@ device_db = {
         "type": "local",
         "module": "artiq.coredevice.spi2",
         "class": "SPIMaster",
-        "arguments": {"channel": 25}
+        "arguments": {"channel": 27}
     },
 
     "spi_urukul0": {
         "type": "local",
         "module": "artiq.coredevice.spi2",
         "class": "SPIMaster",
-        "arguments": {"channel": 26}
+        "arguments": {"channel": 28}
     },
     "urukul0_cpld": {
         "type": "local",
-        "module": "artiq.coredevice.urukul",
+        "module": "artiq.coredevice.suservo",
         "class": "CPLD",
         "arguments": {
             "spi_device": "spi_urukul0",
+            "io_update_device": "ttl_urukul0_io_update",
+            "sync_device": "clkgen_dds_sync_in",
             "refclk": 100e6,
             "clk_sel": 0
         }
     },
     "urukul0_dds": {
         "type": "local",
-        "module": "artiq.coredevice.ad9910",
+        "module": "artiq.coredevice.suservo",
         "class": "AD9910",
         "arguments": {
             "pll_n": 40,
             "chip_select": 3,
             "cpld_device": "urukul0_cpld",
+            "io_update_delay": 0,
+            "sync_delay_seed": -1,
         }
     },
 
@@ -236,26 +251,40 @@ device_db = {
         "type": "local",
         "module": "artiq.coredevice.spi2",
         "class": "SPIMaster",
-        "arguments": {"channel": 27}
+        "arguments": {"channel": 29}
     },
     "urukul1_cpld": {
         "type": "local",
-        "module": "artiq.coredevice.urukul",
+        "module": "artiq.coredevice.suservo",
         "class": "CPLD",
         "arguments": {
             "spi_device": "spi_urukul1",
+            "io_update_device": "ttl_urukul1_io_update",
+            "sync_device": "clkgen_dds_sync_in",
             "refclk": 100e6,
             "clk_sel": 0
         }
     },
     "urukul1_dds": {
         "type": "local",
-        "module": "artiq.coredevice.ad9910",
+        "module": "artiq.coredevice.suservo",
         "class": "AD9910",
         "arguments": {
             "pll_n": 40,
             "chip_select": 3,
             "cpld_device": "urukul1_cpld",
+            "io_update_delay": 0,
+            "sync_delay_seed": -1,
+        }
+    },
+
+    "clkgen_dds_sync_in": {
+        "type": "local",
+        "module": "artiq.coredevice.ttl",
+        "class": "TTLClockGen",
+        "arguments": {
+            "channel": 30,
+            "acc_width": 4
         }
     },
 

--- a/artiq/examples/kasli_suservo/repository/suservo.py
+++ b/artiq/examples/kasli_suservo/repository/suservo.py
@@ -6,8 +6,7 @@ class SUServo(EnvExperiment):
         self.setattr_device("core")
         self.setattr_device("led0")
         self.setattr_device("suservo0")
-        for i in range(8):
-            self.setattr_device("suservo0_ch{}".format(i))
+        self.setattr_device("suservo0_ch0")
 
     def run(self):
         self.init()
@@ -63,8 +62,8 @@ class SUServo(EnvExperiment):
             offset=-.5,  # 5 V with above PGIA settings
             frequency=71*MHz,
             phase=0.)
-        # enable RF, IIR updates and profile 0
-        self.suservo0_ch0.set(en_out=1, en_iir=1, profile=0)
+        # enable RF, IIR updates, phase tracking and profile 0
+        self.suservo0_ch0.set(en_out=1, en_iir=1, en_pt=1, profile=0)
         # enable global servo iterations
         self.suservo0.set_config(enable=1)
 

--- a/artiq/gateware/eem.py
+++ b/artiq/gateware/eem.py
@@ -188,6 +188,7 @@ class Urukul(_EEM):
                 target.submodules += phy
                 target.rtio_channels.append(rtio.Channel.from_phy(phy))
 
+
 class Sampler(_EEM):
     @staticmethod
     def io(eem, eem_aux, iostandard="LVDS_25"):
@@ -470,11 +471,10 @@ class Grabber(_EEM):
 class SUServo(_EEM):
     @staticmethod
     def io(*eems, iostandard="LVDS_25"):
-        assert len(eems) in (4, 6)
-        io = (Sampler.io(*eems[0:2], iostandard=iostandard)
-                + Urukul.io_qspi(*eems[2:4], iostandard=iostandard))
-        if len(eems) == 6:  # two Urukuls
-            io += Urukul.io_qspi(*eems[4:6], iostandard=iostandard)
+        assert len(eems) >= 4 and len(eems) % 2 == 0
+        io = Sampler.io(*eems[0:2], iostandard=iostandard)
+        for i in range(len(eems)//2-1):
+            io += Urukul.io_qspi(*eems[(2*i+2):(2*i+4)], iostandard = iostandard)
         return io
 
     @classmethod
@@ -513,10 +513,9 @@ class SUServo(_EEM):
                                 # difference (4 cycles measured)
                                 t_conv=57 - 4, t_rtt=t_rtt + 4)
         iir_p = servo.IIRWidths(state=25, coeff=18, adc=16, asf=14, word=16,
-                                accu=48, shift=shift, channel=3,
-                                profile=profile, dly=8)
+                                accu=48, shift=shift, profile=profile, dly=8)
         dds_p = servo.DDSParams(width=8 + 32 + 16 + 16,
-                                channels=adc_p.channels, clk=clk)
+                                channels=4*len(eem_urukul), clk=clk)
         su = servo.Servo(sampler_pads, urukul_pads, adc_p, iir_p, dds_p)
         su = ClockDomainsRenamer("rio_phy")(su)
         # explicitly name the servo submodule to enable the migen namer to derive
@@ -537,15 +536,10 @@ class SUServo(_EEM):
         target.submodules += phy
         target.rtio_channels.append(rtio.Channel.from_phy(phy, ififo_depth=4))
 
-        for i in range(2):
-            if len(eem_urukul) > i:
-                spi_p, spi_n = (
-                    target.platform.request("{}_spi_p".format(eem_urukul[i])),
-                    target.platform.request("{}_spi_n".format(eem_urukul[i])))
-            else:  # create a dummy bus
-                spi_p = Record([("clk", 1), ("cs_n", 1)])  # mosi, cs_n
-                spi_n = None
-
+        for eem_urukuli in eem_urukul:
+            spi_p, spi_n = (
+                target.platform.request("{}_spi_p".format(eem_urukuli)),
+                target.platform.request("{}_spi_n".format(eem_urukuli)))
             phy = spi2.SPIMaster(spi_p, spi_n)
             target.submodules += phy
             target.rtio_channels.append(rtio.Channel.from_phy(phy, ififo_depth=4))

--- a/artiq/gateware/rtio/phy/servo.py
+++ b/artiq/gateware/rtio/phy/servo.py
@@ -5,21 +5,29 @@ from artiq.gateware.rtio import rtlink
 
 class RTServoCtrl(Module):
     """Per channel RTIO control interface"""
-    def __init__(self, ctrl):
+    def __init__(self, ctrl, ctrl_reftime):
         self.rtlink = rtlink.Interface(
-            rtlink.OInterface(len(ctrl.profile) + 2))
+            rtlink.OInterface(
+                data_width=max(len(ctrl.profile) + 3,
+                               len(ctrl_reftime.sysclks_fine)),
+                address_width=1)
+            )
 
         # # #
 
+        sel_ref = self.rtlink.o.address[0]
         self.comb += [
-                ctrl.stb.eq(self.rtlink.o.stb),
-                self.rtlink.o.busy.eq(0)
+                ctrl.stb.eq(self.rtlink.o.stb & ~sel_ref),
+                self.rtlink.o.busy.eq(0),
+                ctrl_reftime.stb.eq(self.rtlink.o.stb & sel_ref),
         ]
+        ctrl_cases = {
+            0: Cat(ctrl.en_out, ctrl.en_iir, ctrl.en_pt, ctrl.profile).eq(
+                            self.rtlink.o.data),
+            1: ctrl_reftime.sysclks_fine.eq(self.rtlink.o.data),
+        }
         self.sync.rio_phy += [
-                If(self.rtlink.o.stb,
-                    Cat(ctrl.en_out, ctrl.en_iir, ctrl.profile).eq(
-                            self.rtlink.o.data)
-                )
+                If(self.rtlink.o.stb, Case(self.rtlink.o.address, ctrl_cases))
         ]
 
 

--- a/artiq/gateware/rtio/phy/servo.py
+++ b/artiq/gateware/rtio/phy/servo.py
@@ -38,24 +38,25 @@ class RTServoMem(Module):
     typically longer than the 8-bit RIO address space. We pack the overflow
     onto the RTIO data word after the data.
 
-    Servo address space (from LSB):
-      - IIR coefficient/state memory address, (w.profile + w.channel + 2) bits.
-        If the state memory is selected, the lower bits are used directly as
-        the memory address. If the coefficient memory is selected, the LSB
-        (high_coeff) selects between the upper and lower halves of the memory
-        location, which is two coefficients wide, with the remaining bits used
-        as the memory address.
-      - config_sel (1 bit)
-      - state_sel (1 bit)
+    Servo address space (from MSB):
       - we (1 bit)
+      - sel_coeff (1 bit)
+        If selected, the coefficient memory location is
+            addressed by all the lower bits excluding the LSB (high_coeff).
+          - high_coeff (1 bit) selects between the upper and lower halves of that
+            memory location.
+        Else (if ~sel_coeff), the following bits are:
+          - sel (2 bits) selects between the following memory locations:
 
-     destination    | config_sel | state_sel
-    ----------------|------------|----------
-     IIR coeff mem  |    0       |   0
-     IIR coeff mem  |    1       |   0
-     IIR state mem  |    0       |   1
-     config (write) |    1       |   1
-     status (read)  |    1       |   1
+                 destination    |  sel  |  sel_coeff   |
+                ----------------|-------|--------------|
+                 IIR coeff mem  |   -   |       1      |
+                 Reserved       |   1   |       0      |
+                 IIR state mem  |   2   |       0      |
+                 config (write) |   3   |       0      |
+                 status (read)  |   3   |       0      |
+
+          - IIR state memory address
 
     Values returned to the user on the Python side of the RTIO interface are
     32 bit, so we sign-extend all values from w.coeff to that width. This works
@@ -71,6 +72,8 @@ class RTServoMem(Module):
                 # mode=READ_FIRST,
                 clock_domain="rio")
         self.specials += m_state, m_coeff
+        # width of channel address
+        w_channel = ceil(log2(len(servo.iir.dds)))
 
         # just expose the w.coeff (18) MSBs of state
         assert w.state >= w.coeff
@@ -83,7 +86,7 @@ class RTServoMem(Module):
         assert 8 + w.dly < w.coeff
 
         # coeff, profile, channel, 2 mems, rw
-        internal_address_width = 3 + w.profile + w.channel + 1 + 1
+        internal_address_width = 3 + w.profile + w_channel + 1 + 1
         rtlink_address_width = min(8, internal_address_width)
         overflow_address_width = internal_address_width - rtlink_address_width
         self.rtlink = rtlink.Interface(
@@ -109,15 +112,19 @@ class RTServoMem(Module):
 
         assert len(self.rtlink.o.address) + len(self.rtlink.o.data) - w.coeff == (
                 1 +  # we
-                1 +  # state_sel
+                1 +  # sel_coeff
                 1 +  # high_coeff
                 len(m_coeff.adr))
         # ensure that we can fit config/status into the state address space
         assert len(self.rtlink.o.address) + len(self.rtlink.o.data) - w.coeff >= (
                 1 +  # we
-                1 +  # state_sel
-                1 +  # config_sel
+                1 +  # sel_coeff
+                2 +  # sel
                 len(m_state.adr))
+        # ensure that IIR state mem addresses are at least 2 bits less wide than
+        # IIR coeff mem addresses to ensure we can fit SEL after the state mem
+        # address and before the SEL_COEFF bit.
+        assert w.profile + w_channel >= 4
 
         internal_address = Signal(internal_address_width)
         self.comb += internal_address.eq(Cat(self.rtlink.o.address,
@@ -127,52 +134,51 @@ class RTServoMem(Module):
         self.comb += coeff_data.eq(self.rtlink.o.data[:w.coeff])
 
         we = internal_address[-1]
-        state_sel = internal_address[-2]
-        config_sel = internal_address[-3]
+        sel_coeff = internal_address[-2]
+        sel1 = internal_address[-3]
+        sel0 = internal_address[-4]
         high_coeff = internal_address[0]
+        sel = Signal(2)
         self.comb += [
                 self.rtlink.o.busy.eq(0),
+                sel.eq(Mux(sel_coeff, 0, Cat(sel0, sel1))),
                 m_coeff.adr.eq(internal_address[1:]),
                 m_coeff.dat_w.eq(Cat(coeff_data, coeff_data)),
-                m_coeff.we[0].eq(self.rtlink.o.stb & ~high_coeff &
-                    we & ~state_sel),
-                m_coeff.we[1].eq(self.rtlink.o.stb & high_coeff &
-                    we & ~state_sel),
+                m_coeff.we[0].eq(self.rtlink.o.stb & ~high_coeff & we & sel_coeff),
+                m_coeff.we[1].eq(self.rtlink.o.stb & high_coeff & we & sel_coeff),
                 m_state.adr.eq(internal_address),
                 m_state.dat_w[w.state - w.coeff:].eq(self.rtlink.o.data),
-                m_state.we.eq(self.rtlink.o.stb & we & state_sel & ~config_sel),
+                m_state.we.eq(self.rtlink.o.stb & we & (sel == 2)),
         ]
+
         read = Signal()
-        read_state = Signal()
         read_high = Signal()
-        read_config = Signal()
+        read_sel = Signal(2)
         self.sync.rio += [
                 If(read,
                     read.eq(0)
                 ),
                 If(self.rtlink.o.stb,
                     read.eq(~we),
-                    read_state.eq(state_sel),
+                    read_sel.eq(sel),
                     read_high.eq(high_coeff),
-                    read_config.eq(config_sel),
                 )
         ]
         self.sync.rio_phy += [
-                If(self.rtlink.o.stb & we & state_sel & config_sel,
+                If(self.rtlink.o.stb & we & (sel == 3),
                     config.eq(self.rtlink.o.data)
                 ),
-                If(read & read_config & read_state,
+                If(read & (read_sel == 3),
                     [_.clip.eq(0) for _ in servo.iir.ctrl]
                 )
         ]
+        read_acts = { # read return value by destination
+            0: _eq_sign_extend(self.rtlink.i.data,
+                Mux(read_high, m_coeff.dat_r[w.coeff:], m_coeff.dat_r[:w.coeff])),
+            2: _eq_sign_extend(self.rtlink.i.data, m_state.dat_r[w.state - w.coeff:]),
+            3: _eq_sign_extend(self.rtlink.i.data, status)
+        }
         self.comb += [
                 self.rtlink.i.stb.eq(read),
-                _eq_sign_extend(self.rtlink.i.data,
-                    Mux(read_state,
-                        Mux(read_config,
-                            status,
-                            m_state.dat_r[w.state - w.coeff:]),
-                        Mux(read_high,
-                            m_coeff.dat_r[w.coeff:],
-                            m_coeff.dat_r[:w.coeff])))
+                Case(read_sel, read_acts)
         ]

--- a/artiq/gateware/suservo/__init__.py
+++ b/artiq/gateware/suservo/__init__.py
@@ -1,0 +1,10 @@
+"""Gateware implementation of the Sampler-Urukul (AD9910) DDS amplitude servo.
+
+General conventions:
+
+ - ``t_...`` signals and constants refer to time spans measured in the gateware
+   module's default clock (typically a 125 MHz RTIO clock).
+ - ``start`` signals cause modules to proceed with the next servo iteration iff
+   they are currently idle (i.e. their value is irrelevant while the module is
+   busy, so they are not necessarily one-clock-period strobes).
+"""

--- a/artiq/gateware/suservo/dds_ser.py
+++ b/artiq/gateware/suservo/dds_ser.py
@@ -1,14 +1,15 @@
 import logging
+from collections import namedtuple
 
 from migen import *
 
 from . import spi
 
-
 logger = logging.getLogger(__name__)
 
-
-DDSParams = spi.SPIParams
+DDSParams = namedtuple("DDSParams", spi.SPIParams._fields + (
+    "sysclk_per_clk",  # DDS_CLK per FPGA system clock
+))
 
 
 class DDS(spi.SPISimple):

--- a/artiq/gateware/suservo/iir.py
+++ b/artiq/gateware/suservo/iir.py
@@ -1,8 +1,6 @@
 from collections import namedtuple
 import logging
-
 from migen import *
-
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +16,6 @@ IIRWidths = namedtuple("IIRWidths", [
     "word",     # "word" size to break up DDS profile data (16)
     "asf",      # unsigned amplitude scale factor for DDS (14)
     "shift",    # fixed point scaling coefficient for a1, b0, b1 (log2!) (11)
-    "channel",  # channels (log2!) (3)
     "profile",  # profiles per channel (log2!) (5)
     "dly",      # the activation delay
 ])
@@ -31,6 +28,11 @@ def signed(v, w):
     if v & (1 << w - 1):
         v -= 1 << w
     return v
+
+def bitlen(x):
+    """Returns the minimum bit-length of an integer ``x``"""
+    from math import ceil, log2
+    return ceil(log2(x))
 
 
 class DSP(Module):
@@ -101,14 +103,14 @@ class IIR(Module):
     This module implements a multi-channel IIR (infinite impulse response)
     filter processor optimized for synthesis on FPGAs.
 
-    The module is parametrized by passing a ``IIRWidths()`` object which
-    will be abbreviated W here.
+    The module is parametrized by passing a ``IIRWidths()`` object, and
+    two more objects which will be abbreviated W, W_O and W_I here.
 
-    It reads 1 << W.channels input channels (typically from an ADC)
+    It reads W_I.channels input channels (typically from an ADC)
     and on each iteration processes the data using a first-order IIR filter.
     At the end of the cycle each the output of the filter together with
     additional data (typically frequency tunning word and phase offset word
-    for a DDS) are presented at the 1 << W.channels outputs of the module.
+    for a DDS) are presented at the W_O.channels outputs of the module.
 
     Profile memory
     ==============
@@ -147,10 +149,10 @@ class IIR(Module):
     -------------
 
     The state memory holds all Y1 values (IIR processor outputs) for all
-    profiles of all channels in the lower half (1 << W.profile + W.channel
-    addresses) and the pairs of old and new ADC input values X1, and X0,
-    in the upper half (1 << W.channel addresses). Each memory location is
-    W.state bits wide.
+    profiles of all channels in the lower half (1 << W.profile)*W_O.channels
+    addresses, and the pairs of old and new ADC input values X1, and X0,
+    in the upper half (W_I.channels addresses).
+    Each memory location is W.state bits wide.
 
     Real-time control
     =================
@@ -164,10 +166,10 @@ class IIR(Module):
     Delayed IIR processing
     ======================
 
-    The IIR filter iterations on a given channel are only performed all of the
-    following are true:
+    The IIR filter iterations on a given channel are only performed if all of
+    the following are true:
 
-        * PROFILE, EN_IIR, EN_OUT have not been updated in the within the
+        * PROFILE, EN_IIR, EN_OUT have not been updated within the
           last DLY cycles
         * EN_IIR is asserted
         * EN_OUT is asserted
@@ -178,9 +180,8 @@ class IIR(Module):
     Typical design at the DSP level. This does not include the description of
     the pipelining or the overall latency involved.
 
-    IIRWidths(state=25, coeff=18, adc=16,
-        asf=14, word=16, accu=48, shift=11,
-        channel=3, profile=5, dly=8)
+    IIRWidths(state=25, coeff=18, adc=16, asf=14,
+        word=16, accu=48, shift=11, profile=5, dly=8)
 
     X0 = ADC * 2^(25 - 1 - 16)
     X1 = X0 delayed by one cycle
@@ -215,40 +216,39 @@ class IIR(Module):
     --/--: signal with a given bit width always includes a sign bit
     -->--: flow is to the right and down unless otherwise indicated
     """
-    def __init__(self, w):
-        self.widths = w
-        for i, j in enumerate(w):
-            assert j > 0, (i, j, w)
+    def __init__(self, w, w_i, w_o):
+        for v in (w, w_i, w_o):
+            for i, j in enumerate(v):
+                assert j > 0, (i, j, v)
         assert w.word <= w.coeff  # same memory
         assert w.state + w.coeff + 3 <= w.accu
 
-        # m_coeff of active profiles should only be accessed during
+        # m_coeff of active profiles should only be accessed externally during
         # ~processing
         self.specials.m_coeff = Memory(
                 width=2*w.coeff,  # Cat(pow/ftw/offset, cfg/a/b)
-                depth=4 << w.profile + w.channel)
-        # m_state[x] should only be read during ~(shifting |
-        # loading)
-        # m_state[y] of active profiles should only be read during
+                depth=(4 << w.profile)*w_o.channels)
+        # m_state[x] should only be read externally during ~(shifting | loading)
+        # m_state[y] of active profiles should only be read externally during
         # ~processing
         self.specials.m_state = Memory(
                 width=w.state,  # y1,x0,x1
-                depth=(1 << w.profile + w.channel) + (2 << w.channel))
+                depth=(1 << w.profile)*w_o.channels + 2*w_i.channels)
         # ctrl should only be updated synchronously
         self.ctrl = [Record([
-            ("profile", w.profile),
-            ("en_out", 1),
-            ("en_iir", 1),
-            ("clip", 1),
-            ("stb", 1)])
-            for i in range(1 << w.channel)]
+                ("profile", w.profile),
+                ("en_out", 1),
+                ("en_iir", 1),
+                ("clip", 1),
+                ("stb", 1)])
+                for i in range(w_o.channels)]
         # only update during ~loading
         self.adc = [Signal((w.adc, True), reset_less=True)
-                for i in range(1 << w.channel)]
+                for i in range(w_i.channels)]
         # Cat(ftw0, ftw1, pow, asf)
-        # only read during ~processing
+        # only read externally during ~processing
         self.dds = [Signal(4*w.word, reset_less=True)
-                for i in range(1 << w.channel)]
+                for i in range(w_o.channels)]
         # perform one IIR iteration, start with loading,
         # then processing, then shifting, end with done
         self.start = Signal()
@@ -270,100 +270,116 @@ class IIR(Module):
         en_iirs = Array([ch.en_iir for ch in self.ctrl])
         clips = Array([ch.clip for ch in self.ctrl])
 
-        # state counter
-        state = Signal(w.channel + 2)
-        # pipeline group activity flags (SR)
-        stage = Signal(3)
+        # Main state machine sequencing the steps of each servo iteration. The
+        # module IDLEs until self.start is asserted, and then runs through LOAD,
+        # PROCESS and SHIFT in order (see description of corresponding flags
+        # above). The steps share the same memory ports, and are executed
+        # strictly sequentially.
+        #
+        # LOAD/SHIFT just read/write one address per cycle; the duration needed
+        # to iterate over all channels is determined by counting cycles.
+        #
+        # The PROCESSing step is split across a three-stage pipeline, where each
+        # stage has up to four clock cycles latency. We feed the first stage
+        # using the (MSBs of) t_current_step, and, after all channels have been
+        # covered, proceed once the pipeline has completely drained.
         self.submodules.fsm = fsm = FSM("IDLE")
-        state_clr = Signal()
-        stage_en = Signal()
+        t_current_step = Signal(max=max(4 * (w_o.channels + 2), 2 * w_i.channels))
+        t_current_step_clr = Signal()
+
+        # pipeline group activity flags (SR)
+        #  0: load from memory
+        #  1: compute
+        #  2: write to output registers (DDS profiles, clip flags)
+        stages_active = Signal(3)
         fsm.act("IDLE",
                 self.done.eq(1),
-                state_clr.eq(1),
+                t_current_step_clr.eq(1),
                 If(self.start,
                     NextState("LOAD")
                 )
         )
         fsm.act("LOAD",
                 self.loading.eq(1),
-                If(state == (1 << w.channel) - 1,
-                    state_clr.eq(1),
-                    stage_en.eq(1),
+                If(t_current_step == w_i.channels - 1,
+                    t_current_step_clr.eq(1),
+                    NextValue(stages_active[0], 1),
                     NextState("PROCESS")
                 )
         )
         fsm.act("PROCESS",
                 self.processing.eq(1),
                 # this is technically wasting three cycles
-                # (one for setting stage, and phase=2,3 with stage[2])
-                If(stage == 0,
-                    state_clr.eq(1),
-                    NextState("SHIFT")
+                # (one for setting stages_active, and phase=2,3 with stages_active[2])
+                If(stages_active == 0,
+                    t_current_step_clr.eq(1),
+                    NextState("SHIFT"),
                 )
         )
         fsm.act("SHIFT",
                 self.shifting.eq(1),
-                If(state == (2 << w.channel) - 1,
+                If(t_current_step == 2 * w_i.channels - 1,
                     NextState("IDLE")
                 )
         )
 
         self.sync += [
-                state.eq(state + 1),
-                If(state_clr,
-                    state.eq(0),
-                ),
-                If(stage_en,
-                    stage[0].eq(1)
+                If(t_current_step_clr,
+                    t_current_step.eq(0)
+                ).Else(
+                    t_current_step.eq(t_current_step + 1)
                 )
         ]
 
-        # pipeline group channel pointer
+        # global pipeline phase (lower two bits of t_current_step)
+        pipeline_phase = Signal(2, reset_less=True)
+        # pipeline group channel pointer (SR)
         # for each pipeline stage, this is the channel currently being
         # processed
-        channel = [Signal(w.channel, reset_less=True) for i in range(3)]
+        channel = [Signal(max=w_o.channels, reset_less=True) for i in range(3)]
+        self.comb += Cat(pipeline_phase, channel[0]).eq(t_current_step)
+        self.sync += [
+            If(pipeline_phase == 3,
+                Cat(channel[1:]).eq(Cat(channel[:-1])),
+                stages_active[1:].eq(stages_active[:-1]),
+                If(channel[0] == w_o.channels - 1,
+                    stages_active[0].eq(0)
+                )
+            )
+        ]
+
         # pipeline group profile pointer (SR)
         # for each pipeline stage, this is the profile currently being
         # processed
         profile = [Signal(w.profile, reset_less=True) for i in range(2)]
-        # pipeline phase (lower two bits of state)
-        phase = Signal(2, reset_less=True)
-
-        self.comb += Cat(phase, channel[0]).eq(state)
         self.sync += [
-                Case(phase, {
-                    0: [
-                        profile[0].eq(profiles[channel[0]]),
-                        profile[1].eq(profile[0])
-                    ],
-                    3: [
-                        Cat(channel[1:]).eq(Cat(channel[:-1])),
-                        stage[1:].eq(stage[:-1]),
-                        If(channel[0] == (1 << w.channel) - 1,
-                            stage[0].eq(0)
-                        )
-                    ]
-                })
+            If(pipeline_phase == 0,
+                profile[0].eq(profiles[channel[0]]),
+                profile[1].eq(profile[0]),
+            )
         ]
 
         m_coeff = self.m_coeff.get_port()
         m_state = self.m_state.get_port(write_capable=True)  # mode=READ_FIRST
         self.specials += m_state, m_coeff
 
+        #
+        # Hook up main IIR filter.
+        #
+
         dsp = DSP(w)
         self.submodules += dsp
 
         offset_clr = Signal()
-
         self.comb += [
-                m_coeff.adr.eq(Cat(phase, profile[0],
-                    Mux(phase==0, channel[1], channel[0]))),
+                m_coeff.adr.eq(Cat(pipeline_phase, profile[0],
+                    Mux(pipeline_phase == 0, channel[1], channel[0]))),
                 dsp.offset[-w.coeff - 1:].eq(Mux(offset_clr, 0,
                     Cat(m_coeff.dat_r[:w.coeff], m_coeff.dat_r[w.coeff - 1])
                 )),
                 dsp.coeff.eq(m_coeff.dat_r[w.coeff:]),
                 dsp.state.eq(m_state.dat_r),
-                Case(phase, {
+                Case(pipeline_phase, {
                     0: dsp.accu_clr.eq(1),
                     2: [
                         offset_clr.eq(1),
@@ -373,15 +389,20 @@ class IIR(Module):
                 })
         ]
 
+
+        #
+        # Arbitrate state memory access between steps.
+        #
+
         # selected adc and profile delay (combinatorial from dat_r)
         # both share the same coeff word (sel in the lower 8 bits)
-        sel_profile = Signal(w.channel)
+        sel_profile = Signal(max=w_i.channels)
         dly_profile = Signal(w.dly)
-        assert w.channel <= 8
+        assert w_o.channels < (1 << 8)
         assert 8 + w.dly <= w.coeff
 
         # latched adc selection
-        sel = Signal(w.channel, reset_less=True)
+        sel = Signal(max=w_i.channels, reset_less=True)
         # iir enable SR
         en = Signal(2, reset_less=True)
 
@@ -389,13 +410,13 @@ class IIR(Module):
                 sel_profile.eq(m_coeff.dat_r[w.coeff:]),
                 dly_profile.eq(m_coeff.dat_r[w.coeff + 8:]),
                 If(self.shifting,
-                    m_state.adr.eq(state | (1 << w.profile + w.channel)),
+                    m_state.adr.eq(t_current_step + (1 << w.profile)*w_o.channels),
                     m_state.dat_w.eq(m_state.dat_r),
-                    m_state.we.eq(state[0])
+                    m_state.we.eq(t_current_step[0])
                 ),
                 If(self.loading,
-                    m_state.adr.eq((state << 1) | (1 << w.profile + w.channel)),
-                    m_state.dat_w[-w.adc - 1:-1].eq(Array(self.adc)[state]),
+                    m_state.adr.eq((t_current_step << 1) + (1 << w.profile)*w_o.channels),
+                    m_state.dat_w[-w.adc - 1:-1].eq(Array(self.adc)[t_current_step]),
                     m_state.dat_w[-1].eq(m_state.dat_w[-2]),
                     m_state.we.eq(1)
                 ),
@@ -405,22 +426,24 @@ class IIR(Module):
                         Cat(profile[1], channel[2]),
                         # read old y
                         Cat(profile[0], channel[0]),
-                        # x0 (recent)
-                        0 | (sel_profile << 1) | (1 << w.profile + w.channel),
-                        # x1 (old)
-                        1 | (sel << 1) | (1 << w.profile + w.channel),
-                    ])[phase]),
+                        # read x0 (recent)
+                        0 | (sel_profile << 1) + (1 << w.profile)*w_o.channels,
+                        # read x1 (old)
+                        1 | (sel << 1) + (1 << w.profile)*w_o.channels,
+                    ])[pipeline_phase]),
                     m_state.dat_w.eq(dsp.output),
-                    m_state.we.eq((phase == 0) & stage[2] & en[1]),
+                    m_state.we.eq((pipeline_phase == 0) & stages_active[2] & en[1]),
                 )
         ]
 
-        # internal channel delay counters
-        dlys = Array([Signal(w.dly)
-            for i in range(1 << w.channel)])
-        self._dlys = dlys  # expose for debugging only
+        #
+        # Compute auxiliary signals (delayed servo enable, clip indicators, etc.).
+        #
 
-        for i in range(1 << w.channel):
+        # internal channel delay counters
+        dlys = Array([Signal(w.dly) for i in range(w_o.channels)])
+
+        for i in range(w_o.channels):
             self.sync += [
                     # (profile != profile_old) | ~en_out
                     If(self.ctrl[i].stb,
@@ -434,52 +457,72 @@ class IIR(Module):
         en_out = Signal(reset_less=True)
         # latched channel en_iir
         en_iir = Signal(reset_less=True)
+
+        self.sync += [
+            Case(pipeline_phase, {
+                0: [
+                    dly.eq(dlys[channel[0]]),
+                    en_out.eq(en_outs[channel[0]]),
+                    en_iir.eq(en_iirs[channel[0]]),
+                    If(stages_active[2] & en[1] & dsp.clip,
+                        clips[channel[2]].eq(1)
+                    )
+                ],
+                2: [
+                    en[0].eq(0),
+                    en[1].eq(en[0]),
+                    sel.eq(sel_profile),
+                    If(stages_active[0] & en_out,
+                        If(dly != dly_profile,
+                            dlys[channel[0]].eq(dly + 1)
+                        ).Elif(en_iir,
+                            en[0].eq(1)
+                        )
+                    )
+                ],
+            }),
+        ]
+
+        #
+        # Update DDS profile with FTW/POW/ASF (including phase tracking, if
+        # enabled). Stage 0 loads the POW, stage 1 the FTW, and stage 2 writes
+        # the ASF computed by the IIR filter.
+        #
+
         # muxing
         ddss = Array(self.dds)
 
         self.sync += [
-                Case(phase, {
-                    0: [
-                        dly.eq(dlys[channel[0]]),
-                        en_out.eq(en_outs[channel[0]]),
-                        en_iir.eq(en_iirs[channel[0]]),
-                        If(stage[1],
-                            ddss[channel[1]][:w.word].eq(m_coeff.dat_r)
-                        ),
-                        If(stage[2] & en[1] & dsp.clip,
-                            clips[channel[2]].eq(1)
-                        )
-                    ],
-                    1: [
-                        If(stage[1],
-                            ddss[channel[1]][w.word:2*w.word].eq(
-                                m_coeff.dat_r),
-                        ),
-                        If(stage[2],
-                            ddss[channel[2]][3*w.word:].eq(
-                                m_state.dat_r[w.state - w.asf - 1:w.state - 1])
-                        )
-                    ],
-                    2: [
-                        en[0].eq(0),
-                        en[1].eq(en[0]),
-                        sel.eq(sel_profile),
-                        If(stage[0],
-                            ddss[channel[0]][2*w.word:3*w.word].eq(
-                                m_coeff.dat_r),
-                            If(en_out,
-                                If(dly != dly_profile,
-                                    dlys[channel[0]].eq(dly + 1)
-                                ).Elif(en_iir,
-                                    en[0].eq(1)
-                                )
-                            )
-                        )
-                    ],
-                    3: [
-                    ],
-                }),
+            Case(pipeline_phase, {
+                0: [
+                    If(stages_active[1],
+                        ddss[channel[1]][:w.word].eq(m_coeff.dat_r),  # ftw0
+                    ),
+                ],
+                1: [
+                    If(stages_active[1],
+                        ddss[channel[1]][w.word:2 * w.word].eq(m_coeff.dat_r),  # ftw1
+                    ),
+                    If(stages_active[2],
+                        ddss[channel[2]][3*w.word:].eq(  # asf
+                            m_state.dat_r[w.state - w.asf - 1:w.state - 1])
+                    )
+                ],
+                2: [
+                    If(stages_active[0],
+                        ddss[channel[0]][2*w.word:3*w.word].eq(m_coeff.dat_r),  # pow
+                    ),
+                ],
+                3: [
+                ],
+            }),
         ]
+
+        # expose for simulation and debugging only
+        self.widths = w
+        self.widths_adc = w_i
+        self.widths_dds = w_o
+        self._dlys = dlys
 
     def _coeff(self, channel, profile, coeff):
         """Return ``high_word``, ``address`` and bit ``mask`` for the
@@ -528,31 +571,33 @@ class IIR(Module):
     def set_state(self, channel, val, profile=None, coeff="y1"):
         """Set a state value."""
         w = self.widths
+        w_o = self.widths_dds
         if coeff == "y1":
             assert profile is not None
             yield self.m_state[profile | (channel << w.profile)].eq(val)
         elif coeff == "x0":
             assert profile is None
-            yield self.m_state[(channel << 1) |
-                    (1 << w.profile + w.channel)].eq(val)
+            yield self.m_state[(channel << 1) +
+                    (1 << w.profile)*w_o.channels].eq(val)
         elif coeff == "x1":
             assert profile is None
-            yield self.m_state[1 | (channel << 1) |
-                    (1 << w.profile + w.channel)].eq(val)
+            yield self.m_state[1 | (channel << 1) +
+                    (1 << w.profile)*w_o.channels].eq(val)
         else:
             raise ValueError("no such state", coeff)
 
     def get_state(self, channel, profile=None, coeff="y1"):
         """Get a state value."""
         w = self.widths
+        w_o = self.widths_dds
         if coeff == "y1":
             val = yield self.m_state[profile | (channel << w.profile)]
         elif coeff == "x0":
-            val = yield self.m_state[(channel << 1) |
-                    (1 << w.profile + w.channel)]
+            val = yield self.m_state[(channel << 1) +
+                    (1 << w.profile)*w_o.channels]
         elif coeff == "x1":
-            val = yield self.m_state[1 | (channel << 1) |
-                    (1 << w.profile + w.channel)]
+            val = yield self.m_state[1 | (channel << 1) +
+                    (1 << w.profile)*w_o.channels]
         else:
             raise ValueError("no such state", coeff)
         return signed(val, w.state)
@@ -571,6 +616,8 @@ class IIR(Module):
         """Perform a single processing iteration while verifying
         the behavior."""
         w = self.widths
+        w_i = self.widths_adc
+        w_o = self.widths_dds
 
         while not (yield self.done):
             yield
@@ -586,16 +633,16 @@ class IIR(Module):
 
         x0s = []
         # check adc loading
-        for i in range(1 << w.channel):
+        for i in range(w_i.channels):
             v_adc = signed((yield self.adc[i]), w.adc)
             x0 = yield from self.get_state(i, coeff="x0")
             x0s.append(x0)
-            assert v_adc << (w.state - w.adc - 1) == x0, (hex(v_adc), hex(x0))
             logger.debug("adc[%d] adc=%x x0=%x", i, v_adc, x0)
+            assert v_adc << (w.state - w.adc - 1) == x0, (hex(v_adc), hex(x0))
 
         data = []
         # predict output
-        for i in range(1 << w.channel):
+        for i in range(w_o.channels):
             j = yield self.ctrl[i].profile
             en_iir = yield self.ctrl[i].en_iir
             en_out = yield self.ctrl[i].en_out
@@ -604,7 +651,7 @@ class IIR(Module):
                     i, j, en_iir, en_out, dly_i)
 
             cfg = yield from self.get_coeff(i, j, "cfg")
-            k_j = cfg & ((1 << w.channel) - 1)
+            k_j = cfg & ((1 << bitlen(w_i.channels)) - 1)
             dly_j = (cfg >> 8) & 0xff
             logger.debug("cfg[%d,%d] sel=%d dly=%d", i, j, k_j, dly_j)
 
@@ -658,7 +705,7 @@ class IIR(Module):
             logger.debug("adc[%d] x0=%x x1=%x", i, x0, x1)
 
         # check new state
-        for i in range(1 << w.channel):
+        for i in range(w_o.channels):
             j = yield self.ctrl[i].profile
             logger.debug("ch[%d] profile=%d", i, j)
             y1 = yield from self.get_state(i, j, "y1")
@@ -666,7 +713,7 @@ class IIR(Module):
             assert y1 == y0, (hex(y1), hex(y0))
 
         # check dds output
-        for i in range(1 << w.channel):
+        for i in range(w_o.channels):
             ftw0, ftw1, pow, y0, x1, x0 = data[i]
             asf = y0 >> (w.state - w.asf - 1)
             dds = (ftw0 | (ftw1 << w.word) |

--- a/artiq/gateware/suservo/iir.py
+++ b/artiq/gateware/suservo/iir.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 import logging
 from migen import *
+from migen.genlib.coding import Encoder
 
 logger = logging.getLogger(__name__)
 
@@ -161,6 +162,7 @@ class IIR(Module):
 
         * The active profile, PROFILE
         * Whether to perform IIR filter iterations, EN_IIR
+        * Whether to track the DDS phase coherently, EN_PT
         * The RF switch state enabling output from the channel, EN_OUT
 
     Delayed IIR processing
@@ -216,12 +218,22 @@ class IIR(Module):
     --/--: signal with a given bit width always includes a sign bit
     -->--: flow is to the right and down unless otherwise indicated
     """
-    def __init__(self, w, w_i, w_o):
+    def __init__(self, w, w_i, w_o, t_cycle):
         for v in (w, w_i, w_o):
             for i, j in enumerate(v):
                 assert j > 0, (i, j, v)
         assert w.word <= w.coeff  # same memory
         assert w.state + w.coeff + 3 <= w.accu
+
+        # Reference counter for coherent phase tracking (we assume this doesn't
+        # roll over – a good assumption, as the period is, for a typical clock
+        # frequency, 2^48 / 125 MHz = ~26 days).
+        self.t_running = Signal(48, reset_less=True)
+
+        # If true, internal DDS phase tracking state is reset, matching DDS
+        # chips with phase cleared (and zero FTW) before the start of the
+        # iteration. Automatically reset at the end of the iteration.
+        self.reset_dds_phase = Signal()
 
         # m_coeff of active profiles should only be accessed externally during
         # ~processing
@@ -239,9 +251,24 @@ class IIR(Module):
                 ("profile", w.profile),
                 ("en_out", 1),
                 ("en_iir", 1),
+                ("en_pt", 1),
                 ("clip", 1),
                 ("stb", 1)])
                 for i in range(w_o.channels)]
+        # "Shadow copy" of phase accumulator in DDS accumulator for each output
+        # channel.
+        self.specials.m_accum_ftw = Memory(
+                width=2 * w.word,
+                depth=w_o.channels)
+        # ctrl_reftime should only be updated synchronously
+        self.ctrl_reftime = [Record([
+                ("sysclks_fine", bitlen(w_o.sysclk_per_clk)),
+                ("stb", 1)])
+                for i in range(w_o.channels)]
+        # Reference time for each output channel.
+        self.specials.m_t_ref = Memory(
+                width=len(self.t_running),
+                depth=w_o.channels)
         # only update during ~loading
         self.adc = [Signal((w.adc, True), reset_less=True)
                 for i in range(w_i.channels)]
@@ -268,7 +295,14 @@ class IIR(Module):
         profiles = Array([ch.profile for ch in self.ctrl])
         en_outs = Array([ch.en_out for ch in self.ctrl])
         en_iirs = Array([ch.en_iir for ch in self.ctrl])
+        en_pts = Array([ch.en_pt for ch in self.ctrl])
         clips = Array([ch.clip for ch in self.ctrl])
+
+        # Sample of the reference counter at the start of the current iteration,
+        # such that a common reference time is used for phase calculations
+        # across all channels, in DDS sysclk units.
+        sysclks_to_iter_start = Signal(
+            len(self.t_running) + bitlen(w_o.sysclk_per_clk))
 
         # Main state machine sequencing the steps of each servo iteration. The
         # module IDLEs until self.start is asserted, and then runs through LOAD,
@@ -296,6 +330,7 @@ class IIR(Module):
                 self.done.eq(1),
                 t_current_step_clr.eq(1),
                 If(self.start,
+                    NextValue(sysclks_to_iter_start, self.t_running * w_o.sysclk_per_clk),
                     NextState("LOAD")
                 )
         )
@@ -314,6 +349,7 @@ class IIR(Module):
                 If(stages_active == 0,
                     t_current_step_clr.eq(1),
                     NextState("SHIFT"),
+                    NextValue(self.reset_dds_phase, 0)
                 )
         )
         fsm.act("SHIFT",
@@ -324,7 +360,7 @@ class IIR(Module):
         )
 
         self.sync += [
-                If(t_current_step_clr,
+                If(t_current_step_clr, 
                     t_current_step.eq(0)
                 ).Else(
                     t_current_step.eq(t_current_step + 1)
@@ -483,25 +519,81 @@ class IIR(Module):
             }),
         ]
 
+        # Update coarse reference time from t_running upon ctrl_reftime strobe
+        ref_stb_encoder = Encoder(w_o.channels)
+        m_t_ref_stb = self.m_t_ref.get_port(write_capable=True)
+        self.specials += m_t_ref_stb
+        self.submodules += ref_stb_encoder
+        self.comb += [
+                ref_stb_encoder.i.eq(Cat([ch.stb for ch in self.ctrl_reftime])),
+                m_t_ref_stb.adr.eq(ref_stb_encoder.o),
+                m_t_ref_stb.we.eq(~ref_stb_encoder.n),
+                m_t_ref_stb.dat_w.eq(self.t_running),
+        ]
+
         #
         # Update DDS profile with FTW/POW/ASF (including phase tracking, if
         # enabled). Stage 0 loads the POW, stage 1 the FTW, and stage 2 writes
-        # the ASF computed by the IIR filter.
+        # the ASF computed by the IIR filter (and adds any phase correction).
         #
 
         # muxing
         ddss = Array(self.dds)
+        sysclks_ref_fine = Array([ch.sysclks_fine for ch in self.ctrl_reftime])
 
+        # registered copy of FTW on channel[1]
+        current_ftw = Signal(2 * w.word, reset_less=True)
+        # target effective DDS phase (accumulator + POW) at the coming io_update
+        target_dds_phase = Signal.like(current_ftw)
+        # DDS-internal phase accumulated until the coming io_update
+        accum_dds_phase = Signal.like(current_ftw)
+        # correction to add to the bare POW to yield a phase-coherent DDS output
+        correcting_pow = Signal(w.word, reset_less=True)
+        # sum of all FTWs on channel[1], updated with current FTW during the
+        # calculation
+        accum_ftw = Signal.like(current_ftw)
+        # sum of previous FTWs on channel[1] (or 0 on phase coherence reference
+        # reset)
+        prev_accum_ftw = Signal.like(current_ftw)
+        # time since reference time at coming io_update in DDS sysclk units
+        sysclks_to_ref = Signal.like(sysclks_to_iter_start)
+        # t_ref in DDS sysclk units
+        sysclks_ref_to_iter_start = Signal.like(sysclks_to_iter_start)
+
+        m_t_ref = self.m_t_ref.get_port()
+        m_accum_ftw = self.m_accum_ftw.get_port(write_capable=True, mode=READ_FIRST)
+        self.specials += m_accum_ftw, m_t_ref
+        prev_accum_ftw = Signal.like(accum_ftw)
+        self.comb += [
+            prev_accum_ftw.eq(Mux(self.reset_dds_phase, 0, m_accum_ftw.dat_r)),
+            m_accum_ftw.adr.eq(channel[1]),
+            m_accum_ftw.we.eq((pipeline_phase == 3) & stages_active[1]),
+            m_accum_ftw.dat_w.eq(accum_ftw),
+            m_t_ref.adr.eq(channel[0]),
+        ]
+
+        sysclks_per_iter = t_cycle * w_o.sysclk_per_clk
         self.sync += [
             Case(pipeline_phase, {
                 0: [
                     If(stages_active[1],
                         ddss[channel[1]][:w.word].eq(m_coeff.dat_r),  # ftw0
+                        current_ftw[:w.word].eq(m_coeff.dat_r),
+                        sysclks_ref_to_iter_start.eq(m_t_ref.dat_r * w_o.sysclk_per_clk),
+                    ),
+                    If(stages_active[2] & en_pts[channel[2]],
+                        # add pow correction if phase tracking enabled
+                        ddss[channel[2]][2*w.word:3*w.word].eq(
+                            ddss[channel[2]][2*w.word:3*w.word] + correcting_pow),
                     ),
                 ],
                 1: [
                     If(stages_active[1],
                         ddss[channel[1]][w.word:2 * w.word].eq(m_coeff.dat_r),  # ftw1
+                        current_ftw[w.word:].eq(m_coeff.dat_r),
+                        sysclks_to_ref.eq(sysclks_to_iter_start - (
+                            sysclks_ref_to_iter_start + sysclks_ref_fine[channel[1]])),
+                        accum_dds_phase.eq(prev_accum_ftw * sysclks_per_iter),
                     ),
                     If(stages_active[2],
                         ddss[channel[2]][3*w.word:].eq(  # asf
@@ -510,10 +602,21 @@ class IIR(Module):
                 ],
                 2: [
                     If(stages_active[0],
-                        ddss[channel[0]][2*w.word:3*w.word].eq(m_coeff.dat_r),  # pow
+                        # Load bare POW from profile memory.
+                        ddss[channel[0]][2*w.word:3*w.word].eq(m_coeff.dat_r),
+                    ),
+                    If(stages_active[1],
+                        target_dds_phase.eq(current_ftw * sysclks_to_ref),
+                        accum_ftw.eq(prev_accum_ftw + current_ftw),
                     ),
                 ],
                 3: [
+                    If(stages_active[1],
+                        # Prepare most-significant word to add to POW from
+                        # profile for phase tracking.
+                        correcting_pow.eq(
+                            (target_dds_phase - accum_dds_phase)[w.word:]),
+                    ),
                 ],
             }),
         ]
@@ -522,6 +625,15 @@ class IIR(Module):
         self.widths = w
         self.widths_adc = w_i
         self.widths_dds = w_o
+        self.t_cycle = t_cycle
+        self._state = t_current_step
+        self._stages = stages_active
+        self._dt_start = sysclks_to_iter_start
+        self._sysclks_to_ref = sysclks_to_ref
+        self._sysclks_ref_to_iter_start = sysclks_ref_to_iter_start
+        self._sysclks_ref_fine = sysclks_ref_fine
+        self._ph_acc = accum_dds_phase
+        self._ph_coh = target_dds_phase
         self._dlys = dlys
 
     def _coeff(self, channel, profile, coeff):
@@ -602,6 +714,14 @@ class IIR(Module):
             raise ValueError("no such state", coeff)
         return signed(val, w.state)
 
+    def get_accum_ftw(self, channel):
+        val = yield self.m_accum_ftw[channel]
+        return val
+
+    def get_t_ref(self, channel):
+        val = yield self.m_t_ref[channel]
+        return val
+
     def fast_iter(self):
         """Perform a single processing iteration."""
         assert (yield self.done)
@@ -643,12 +763,20 @@ class IIR(Module):
         data = []
         # predict output
         for i in range(w_o.channels):
+            t0 = yield self._dt_start
+            dds_ftw_accu = yield from self.get_accum_ftw(i)
+            sysclks_ref = (yield from self.get_t_ref(i)) * self.widths_dds.sysclk_per_clk\
+                           + (yield self.ctrl_reftime[i].sysclks_fine)
+            logger.debug("dt_start=%d dt_ref=%d t_cycle=%d ftw_accu=%#x",
+                         t0, sysclks_ref, self.t_cycle, dds_ftw_accu)
+
             j = yield self.ctrl[i].profile
             en_iir = yield self.ctrl[i].en_iir
             en_out = yield self.ctrl[i].en_out
+            en_pt = yield self.ctrl[i].en_pt
             dly_i = yield self._dlys[i]
-            logger.debug("ctrl[%d] profile=%d en_iir=%d en_out=%d dly=%d",
-                    i, j, en_iir, en_out, dly_i)
+            logger.debug("ctrl[%d] profile=%d en_iir=%d en_out=%d en_pt=%d dly=%d",
+                    i, j, en_iir, en_out, en_pt, dly_i)
 
             cfg = yield from self.get_coeff(i, j, "cfg")
             k_j = cfg & ((1 << bitlen(w_i.channels)) - 1)
@@ -668,9 +796,13 @@ class IIR(Module):
 
             ftw0 = yield from self.get_coeff(i, j, "ftw0")
             ftw1 = yield from self.get_coeff(i, j, "ftw1")
-            pow = yield from self.get_coeff(i, j, "pow")
-            logger.debug("dds[%d,%d] ftw0=%#x ftw1=%#x pow=%#x",
-                    i, j, ftw0, ftw1, pow)
+            _pow = yield from self.get_coeff(i, j, "pow")
+            ph_coh = ((ftw0 | (ftw1 << w.word)) * (t0 - sysclks_ref))
+            ph_accu = dds_ftw_accu * self.t_cycle * self.widths_dds.sysclk_per_clk
+            ph = ph_coh - ph_accu
+            pow = (_pow + (ph >> w.word)) & 0xffff if en_pt else _pow
+            logger.debug("dds[%d,%d] ftw0=%#x ftw1=%#x ph_coh=%#x _pow=%#x pow=%#x",
+                    i, j, ftw0, ftw1, ph_coh, _pow, pow)
 
             y1 = yield from self.get_state(i, j, "y1")
             x1 = yield from self.get_state(k_j, coeff="x1")
@@ -692,6 +824,10 @@ class IIR(Module):
         # wait for output
         assert (yield self.processing)
         while (yield self.processing):
+            logger.debug("sysclks_to_ref=%d sysclks_ref_to_iter_start=%d",
+                         (yield self._sysclks_to_ref),
+                         (yield self._sysclks_ref_to_iter_start))
+            # logger.debug("%d %d %d %d", *[x for x in (yield self._sysclks_ref_fine)])
             yield
 
         assert (yield self.shifting)

--- a/artiq/gateware/suservo/servo.py
+++ b/artiq/gateware/suservo/servo.py
@@ -95,6 +95,9 @@ class Servo(Module):
                     cnt.eq(t_restart - 1)
                 )
         ]
+
+        self.sync += dds_pads.passthrough.eq(active == 0)
+
         self.comb += [
                 cnt_done.eq(cnt == 0),
                 self.adc.start.eq(self.start & cnt_done),

--- a/artiq/gateware/suservo/servo.py
+++ b/artiq/gateware/suservo/servo.py
@@ -5,32 +5,76 @@ from .iir import IIR, IIRWidths
 from .dds_ser import DDS, DDSParams
 
 
+def predict_timing(adc_p, iir_p, dds_p):
+    """
+    The following is a sketch of the timing for 1 Sampler (8 ADCs) and N Urukuls
+    Shown here, the cycle duration is limited by the IIR loading+processing time.
+
+    ADC|CONVH|CONV|READ|RTT|IDLE|CONVH|CONV|READ|RTT|IDLE|CONVH|CONV|READ|RTT|...
+       |4    |57  |16  |8  | .. |4    |57  |16  |8  | .. |4    |57  |16  |8  |...
+    ---+-------------------+------------------------+------------------------+---
+    IIR|                   |LOAD|PROC         |SHIFT|LOAD|PROC         |SHIFT|...
+       |                   |8   |16*N+9       |16   |8   |16*N+9       |16   |...
+    ---+--------------------------------------+------------------------+---------
+    DDS|                                      |CMD|PROF|WAIT|IO_UP|IDLE|CMD|PR...
+       |                                      |16 |128 |1   |1    | .. |16 |  ...
+
+    IIR loading starts once the ADC presents its data, the DDSes are updated
+    once the IIR processing is over. These are the only blocking processes.
+    IIR shifting happens in parallel to writing to the DDSes and ADC conversions
+    take place while the IIR filter is processing or the DDSes are being
+    written to, depending on the cycle duration (given by whichever module
+    takes the longest).
+    """
+    t_adc = (adc_p.t_cnvh + adc_p.t_conv + adc_p.t_rtt +
+        adc_p.channels*adc_p.width//adc_p.lanes) + 1
+    # load adc_p.channels values, process dds_p.channels
+    # (4 processing phases and 2 additional stages à 4 phases
+    # to complete the processing of the last channel)
+    t_iir = adc_p.channels + 4*dds_p.channels + 8 + 1
+    t_dds = (dds_p.width*2 + 1)*dds_p.clk + 1
+    t_cycle = max(t_adc, t_iir, t_dds)
+    return t_adc, t_iir, t_dds, t_cycle
+
 class Servo(Module):
     def __init__(self, adc_pads, dds_pads, adc_p, iir_p, dds_p):
+        t_adc, t_iir, t_dds, t_cycle = predict_timing(adc_p, iir_p, dds_p)
+        assert t_iir + 2*adc_p.channels < t_cycle, "need shifting time"
+
         self.submodules.adc = ADC(adc_pads, adc_p)
-        self.submodules.iir = IIR(iir_p)
+        self.submodules.iir = IIR(iir_p, adc_p, dds_p)
         self.submodules.dds = DDS(dds_pads, dds_p)
 
         # adc channels are reversed on Sampler
-        for i, j, k, l in zip(reversed(self.adc.data), self.iir.adc,
-                self.iir.dds, self.dds.profile):
-            self.comb += j.eq(i), l.eq(k)
+        for iir, adc in zip(self.iir.adc, reversed(self.adc.data)):
+            self.comb += iir.eq(adc)
+        for dds, iir in zip(self.dds.profile, self.iir.dds):
+            self.comb += dds.eq(iir)
 
-        t_adc = (adc_p.t_cnvh + adc_p.t_conv + adc_p.t_rtt +
-            adc_p.channels*adc_p.width//adc_p.lanes) + 1
-        t_iir = ((1 + 4 + 1) << iir_p.channel) + 1
-        t_dds = (dds_p.width*2 + 1)*dds_p.clk + 1
-
-        t_cycle = max(t_adc, t_iir, t_dds)
-        assert t_iir + (2 << iir_p.channel) < t_cycle, "need shifting time"
-
+        # If high, a new cycle is started if the current cycle (if any) is
+        # finished. Consequently, if low, servo iterations cease after the
+        # current cycle is finished. Don't care while the first step (ADC)
+        # is active.
         self.start = Signal()
+
+        # Counter for delay between end of ADC cycle and start of next one,
+        # depending on the duration of the other steps.
         t_restart = t_cycle - t_adc + 1
         assert t_restart > 1
         cnt = Signal(max=t_restart)
         cnt_done = Signal()
-        active = Signal(3)
+
+        # Indicates whether different steps (0: ADC, 1: IIR, 2: DDS) are
+        # currently active (exposed for simulation only), with each bit being
+        # reset once the successor step is launched. Depending on the
+        # timing details of the different steps, any number can be concurrently
+        # active (e.g. ADC read from iteration n, IIR computation from iteration
+        # n - 1, and DDS write from iteration n - 2).
+        self._active = active = Signal(3)
+
+        # Asserted once per cycle when the DDS write has been completed.
         self.done = Signal()
+
         self.sync += [
                 If(self.dds.done,
                     active[2].eq(0)

--- a/artiq/gateware/targets/kasli.py
+++ b/artiq/gateware/targets/kasli.py
@@ -216,9 +216,9 @@ class SUServo(StandaloneBase):
             ttl_serdes_7series.Output_8X, ttl_serdes_7series.Output_8X)
 
         # EEM3/2: Sampler, EEM5/4: Urukul, EEM7/6: Urukul
-        eem.SUServo.add_std(
-            self, eems_sampler=(3, 2),
-            eems_urukul0=(5, 4), eems_urukul1=(7, 6))
+        eem.SUServo.add_std(self, 
+                            eems_sampler=(3, 2), 
+                            eems_urukul=[[5, 4], [7, 6]])
 
         for i in (1, 2):
             sfp_ctl = self.platform.request("sfp_ctl", i)

--- a/artiq/gateware/test/suservo/__init__.py
+++ b/artiq/gateware/test/suservo/__init__.py
@@ -1,0 +1,10 @@
+"""Gateware implementation of the Sampler-Urukul (AD9910) DDS amplitude servo.
+
+General conventions:
+
+ - ``t_...`` signals and constants refer to time spans measured in the gateware
+   module's default clock (typically a 125 MHz RTIO clock).
+ - ``start`` signals cause modules to proceed with the next servo iteration iff
+   they are currently idle (i.e. their value is irrelevant while the module is
+   busy, so they are not necessarily one-clock-period strobes).
+"""

--- a/artiq/gateware/test/suservo/test_iir.py
+++ b/artiq/gateware/test/suservo/test_iir.py
@@ -2,16 +2,21 @@ import logging
 import unittest
 
 from migen import *
-from artiq.gateware.suservo import iir
+from artiq.gateware.suservo import servo
+from collections import namedtuple
 
+logger = logging.getLogger(__name__)
+
+ADCParamsSim = namedtuple("ADCParams", ["channels"])
+DDSParamsSim = namedtuple("ADCParams", ["channels"])
 
 def main():
-    w_kasli = iir.IIRWidths(state=25, coeff=18, adc=16,
-            asf=14, word=16, accu=48, shift=11,
-            channel=3, profile=5, dly=8)
-    w = iir.IIRWidths(state=17, coeff=16, adc=16,
-            asf=14, word=16, accu=48, shift=11,
-            channel=2, profile=1, dly=8)
+    w_kasli = servo.IIRWidths(state=25, coeff=18, adc=16, asf=14,
+            word=16, accu=48, shift=11, profile=5, dly=8)
+    p_adc = ADCParamsSim(channels=8)
+    p_dds = DDSParamsSim(channels=4)
+    w = servo.IIRWidths(state=17, coeff=16, adc=16, asf=14,
+            word=16, accu=48, shift=11, profile=2, dly=8)
 
     def run(dut):
         for i, ch in enumerate(dut.adc):
@@ -20,29 +25,31 @@ def main():
             yield ch.en_iir.eq(1)
             yield ch.en_out.eq(1)
             yield ch.profile.eq(i)
-        for i in range(1 << w.channel):
+        for i in range(p_adc.channels):
             yield from dut.set_state(i, i << 8, coeff="x1")
             yield from dut.set_state(i, i << 8, coeff="x0")
+        for i in range(p_dds.channels):
             for j in range(1 << w.profile):
                 yield from dut.set_state(i,
                         (j << 1) | (i << 8), profile=j, coeff="y1")
                 for k, l in enumerate("pow offset ftw0 ftw1".split()):
                     yield from dut.set_coeff(i, profile=j, coeff=l,
-                            value=(i << 12) | (j << 8) | (k << 4))
+                            value=(i << 10) | (j << 8) | (k << 4))
         yield
-        for i in range(1 << w.channel):
+        for i in range(p_dds.channels):
             for j in range(1 << w.profile):
-                for k, l in enumerate("cfg a1 b0 b1".split()):
+                for k, l in enumerate("a1 b0 b1".split()):
                     yield from dut.set_coeff(i, profile=j, coeff=l,
-                            value=(i << 12) | (j << 8) | (k << 4))
+                            value=(i << 10) | (j << 8) | (k << 4))
                 yield from dut.set_coeff(i, profile=j, coeff="cfg",
-                        value=(i << 0) | (j << 8))  # sel, dly
+                        value=(i % p_adc.channels) | (j << 8))  # sel, dly
         yield
-        for i in range(10):
+        for i in range(4):
+            logger.debug("check_iter {}".format(i))
             yield from dut.check_iter()
             yield
 
-    dut = iir.IIR(w)
+    dut = servo.IIR(w, p_adc, p_dds)
     run_simulation(dut, [run(dut)], vcd_name="iir.vcd")
 
 

--- a/artiq/gateware/test/suservo/test_servo.py
+++ b/artiq/gateware/test/suservo/test_servo.py
@@ -18,13 +18,108 @@ class ServoSim(servo.Servo):
         iir_p = servo.IIRWidths(state=25, coeff=18, adc=16, asf=14, word=16,
                 accu=48, shift=11, profile=5, dly=8)
         dds_p = servo.DDSParams(width=8 + 32 + 16 + 16,
-                channels=4, clk=1)
+                channels=4, clk=1, sysclk_per_clk=8)
 
         self.submodules.adc_tb = test_adc.TB(adc_p)
         self.submodules.dds_tb = test_dds.TB(dds_p)
 
         servo.Servo.__init__(self, self.adc_tb, self.dds_tb,
                 adc_p, iir_p, dds_p)
+
+        self.dds_output = []
+
+    def log_flow(self, cycle):
+        su_start = yield self.start
+        adc_start = yield self.adc.start
+        iir_start = yield self.iir.start
+        dds_start = yield self.dds.start
+        su_done = yield self.done
+        adc_done = yield self.adc.done
+        iir_done = yield self.iir.done
+        dds_done = yield self.dds.done
+        active = yield self._active
+        io_update = yield self.dds_tb.io_update
+        passthrough = yield self.dds_tb.passthrough
+        iir_loading = yield self.iir.loading
+        iir_processing = yield self.iir.processing
+        iir_shifting = yield self.iir.shifting
+        dt = yield self.iir.t_running
+        dt_iir = yield self.iir._dt_start
+        state = yield self.iir._state
+        stage0 = yield self.iir._stages[0]
+        stage1 = yield self.iir._stages[1]
+        stage2 = yield self.iir._stages[2]
+        logger.debug(
+            "cycle=%d "
+            #"start=[su=%d adc=%d iir=%d dds=%d] "
+            #"done=[su=%d adc=%d iir=%d dds=%d] "
+            "active=%s load_proc_shft=%d%d%d stages_active=%d%d%d "
+            "io_update=%d passthrough=%d "
+            "dt=%d dt_iir=%d state=%d",
+            cycle, 
+            #su_start, adc_start, iir_start, dds_start,
+            #su_done, adc_done, iir_done, dds_done, 
+            '{:03b}'.format(active), iir_loading, iir_processing, iir_shifting, stage0, stage1, stage2,
+            io_update, passthrough, 
+            dt, dt_iir//8, state
+        )
+
+    def log_state(self, channel, profile, calls=[0]):
+        calls[0] += 1
+        # if not (yield self._active[1]):
+        #     return
+        yield from self.log_flow(calls[0] - 2)
+        return
+        cfg = yield from self.iir.get_coeff(channel, profile, "cfg")
+        sel = cfg & 0x7
+        x0 = yield from self.iir.get_state(sel, coeff="x0")
+        x1 = yield from self.iir.get_state(sel, coeff="x1")
+        y1 = yield from self.iir.get_state(channel, profile, coeff="y1")
+        _pow = yield from self.iir.get_coeff(channel, profile, "pow")
+        pow_iir = yield self.iir.dds[channel][2*self.iir.widths.word:3*self.iir.widths.word]
+        pow_dds = yield self.dds_tb.ddss[channel].pow
+        asf_dds = yield self.dds_tb.ddss[channel].asf
+        ftw_dds = yield self.dds_tb.ddss[channel].ftw
+        accu_dds = yield self.dds_tb.ddss[channel].accu
+        phase_dds = (yield self.dds_tb.ddss[channel].phase)
+        dds_output = np.cos(2*np.pi*phase_dds/2**19)
+        ph_coh = yield self.iir._ph_coh
+        ph_acc = yield self.iir._ph_acc
+        offset = yield from self.iir.get_coeff(channel, profile, "offset")
+        ftw0 = yield from self.iir.get_coeff(channel, profile, "ftw0")
+        ftw1 = yield from self.iir.get_coeff(channel, profile, "ftw1")
+        m_phase = yield from self.iir.get_accum_ftw(channel)
+        iir_adc = yield self.iir.adc[sel]
+        logger.debug("\t"
+                     "ch=%d pr=%d "
+                     # "x0=%d x1=%d adc=%d y1=%d sel=%d "
+                     "ftw=%#x pow_coeff=%#x ftw_accu=%#x "
+                     "ph_coh=%#x ph_acc=%#x "
+                     "pow_iir=%#x pow_dds=%#x ftw_dds=%#x asf_dds=%#x accu_dds=%#x phase_dds=%#x dds_output=%04.3f",
+                     channel, profile, 
+                     # x0, x1, iir_adc, y1, sel,
+                     ftw0 | (ftw1 << 16), _pow, m_phase,
+                     ph_coh, ph_acc,  
+                     pow_iir, pow_dds, ftw_dds, asf_dds, accu_dds, phase_dds >> 3, dds_output
+        )
+        self.dds_output.append(dds_output)
+        # yield from self.log_registers(profile)
+
+    def log_registers(self, profile):
+        adc_channels = self.iir.widths_adc.channels
+        dds_channels = self.iir.widths_dds.channels
+        x0s = [0]*adc_channels
+        x1s = [0]*adc_channels
+        y1s = [0]*dds_channels
+        for ch in range(adc_channels):
+            x0s[ch] = yield from self.iir.get_state(ch, coeff="x0")
+            x1s[ch] = yield from self.iir.get_state(ch, coeff="x1")
+        for ch in range(dds_channels):
+            y1s[ch] = yield from self.iir.get_state(ch, profile, coeff="y1")
+
+        logger.debug(("x0s = " + '{:05X} ' * adc_channels).format(*x0s))
+        logger.debug(("x1s = " + '{:05X} ' * adc_channels).format(*x1s))
+        logger.debug(("y1s = " + '{:05X} ' * dds_channels).format(*y1s))
 
     def test(self):
         assert (yield self.done)
@@ -35,6 +130,7 @@ class ServoSim(servo.Servo):
         channel = 0
         yield self.iir.ctrl[channel].en_iir.eq(1)
         yield self.iir.ctrl[channel].en_out.eq(1)
+        yield self.iir.ctrl[channel].en_pt.eq(1)
         profile = 31
         yield self.iir.ctrl[channel].profile.eq(profile)
         x1 = 0x0743
@@ -42,21 +138,47 @@ class ServoSim(servo.Servo):
         y1 = 0x1145
         yield from self.iir.set_state(channel, y1,
                 profile=profile, coeff="y1")
-        coeff = dict(pow=0x1333, offset=0x1531, ftw0=0x1727, ftw1=0x1929,
-                a1=0x0135, b0=0x0337, b1=0x0539, cfg=adc | (0 << 3))
+        coeff = dict(pow=0, offset=0x1531, ftw0=0xeb85, ftw1=0x51,
+                a1=0x0135, b0=0x0337, b1=0x0539, cfg=adc)
         for ks in "pow offset ftw0 ftw1", "a1 b0 b1 cfg":
             for k in ks.split():
                 yield from self.iir.set_coeff(channel, value=coeff[k],
                         profile=profile, coeff=k)
             yield
 
+        num_it = 1
+        num_proc_its = [0]*num_it # number of iterations while iir.processing
+        yield from self.log_state(channel, profile)
         yield self.start.eq(1)
         yield
-        yield self.start.eq(0)
-        while not (yield self.dds_tb.io_update):
-            yield
-        yield  # io_update
+        for i in range(num_it):
+            if i == 1:  # change ftw
+                yield from self.iir.set_coeff(channel,
+                    profile=profile, coeff='ftw0', value=coeff['ftw1'])
+                yield from self.iir.set_coeff(channel,
+                    profile=profile, coeff='ftw1', value=coeff['ftw0'])
+            if i == 2:  # change ftw back
+                yield from self.iir.set_coeff(channel,
+                    profile=profile, coeff='ftw0', value=coeff['ftw0'])
+                yield from self.iir.set_coeff(channel,
+                    profile=profile, coeff='ftw1', value=coeff['ftw1'])
+            logger.debug("iteration {}".format(i))
+            yield from self.log_state(channel, profile)
+            if i == num_it-1:
+                yield self.start.eq(0)
+            while not (yield self.dds_tb.io_update):
+                yield
+                if (yield self.iir.processing):
+                    num_proc_its[i] += 1
+                if (yield self.iir._stages) != 0:
+                    yield from self.log_state(channel, profile)
+            yield  # io_update
+        yield from self.log_state(channel, profile)
+        yield
+        yield from self.log_state(channel, profile)
 
+        np.savetxt('dds_output.dat', self.dds_output, fmt="%10.10f")
+        logger.debug("number of iterations while iir.processing: {}".format(num_proc_its))
         w = self.iir.widths
 
         x0 = x0 << (w.state - w.adc - 1)
@@ -65,6 +187,8 @@ class ServoSim(servo.Servo):
 
         offset = coeff["offset"] << (w.state - w.coeff - 1)
         a1, b0, b1 = coeff["a1"], coeff["b0"], coeff["b1"]
+
+        # works only for 1 iteration
         out = (
                 0*(1 << w.shift - 1) +  # rounding
                 a1*(y1 + 0) + b0*(x0 + offset) + b1*(x1 + offset)
@@ -78,8 +202,15 @@ class ServoSim(servo.Servo):
         ftw = (coeff["ftw1"] << 16) | coeff["ftw0"]
         assert _ == ftw, (hex(_), hex(ftw))
 
+        t0 = yield self.iir._dt_start
+        # todo: include phase accumulator
+        ph = (ftw * t0) >> 16
+        if (yield self.iir.ctrl[channel].en_pt):
+            pow = (coeff["pow"] + ph) & 0xffff
+        else:
+            pow = coeff["pow"]
         _ = yield self.dds_tb.ddss[channel].pow
-        assert _ == coeff["pow"], (hex(_), hex(coeff["pow"]))
+        assert _ == pow, (hex(_), hex(pow))
 
         _ = yield self.dds_tb.ddss[channel].asf
         asf = y1 >> (w.state - w.asf - 1)


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

SUServo upgrade:
 - Refactoring of the pipelined IIR processing core, accepting any number of ADC input channels and DDS output channels with minimal ressource usage. (Previously restricted to a power of 2.)
 - Using half-duplex SPI mode for readback from Urukul CPLDs in NU-mode (DIP switches configured for SUServo operation). To use this feature, the CPLDs require the corresponding update.
 - Extension of the per-channel control interface by a flag `en_pt`, serving to enable coherent DDS phase mode. This works by tracking the DDS-internal phase accumulator as well as the servo runtime to calculate the POW accordingly.
 - Reverse-compatible extension of the channel RTIO addresses for setting the reference time of a channel for coherent phase mode in real time (intended for use in DMA sequences).
 - To ensure coherent phase updates, the io_update line of an Urukul is converted into a SERDES output. The I/O update alignment delays can be configured by writing to servo memory. The optimal alignment delay can be found using the existing method, relying on half-duplex CPLD readback capability.
 - Further, to ensure coherent phase updates, the sync_in line of all Urukuls is connected to a `ClockGen` phy. The optimal sync settings can be found using the existing method, relying on half-duplex CPLD readback capability.
 - Restructuring of the servo RTIO addresses to make space for the I/O update alignment delay memory. This is done efficiently and does not increase the address width.

### Related Issue

Resolves #1339

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |

## Steps
### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Update [RELEASE_NOTES.md](../RELEASE_NOTES.md) if there are noteworthy changes, especially if there are changes to existing APIs.
- [ ] Close/update issues.
- [ ] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [ ] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them (@dnadlinger). Report is in preparation.
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

- [ ] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). 

### Licensing
Credits for this also to @dnadlinger !
See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
