### PR TITLE
runtime: Stop kernel CPU before restarting comms CPU on panic

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -21,6 +21,8 @@ Highlights:
      be brought up Ctrl-P (Ctrl+Return to immediately submit the selected entry
      with the default arguments).
 * Experiment results are now always saved to HDF5, even if run() fails.
+* Core device: ``panic_reset 1`` now correctly resets the kernel CPU as well if
+  communication CPU panic occurs.
 
 Breaking changes:
 

--- a/artiq/firmware/runtime/main.rs
+++ b/artiq/firmware/runtime/main.rs
@@ -323,7 +323,10 @@ pub fn panic_impl(info: &core::panic::PanicInfo) -> ! {
 
     if config::read_str("panic_reset", |r| r == Ok("1")) {
         println!("restarting...");
-        unsafe { boot::reset() }
+        unsafe {
+            kernel::stop();
+            boot::reset();
+        }
     } else {
         println!("halting.");
         println!("use `artiq_coremgmt config write -s panic_reset 1` to restart instead");


### PR DESCRIPTION
Before, the system would enter a boot loop when a panic occurred
while the kernel CPU was active (and panic_reset == 1), as
kernel::start() for the startup kernel would panic.
