### PR TITLE
I2C: Duplicate TCA9548 control byte

### DIFF
--- a/artiq/firmware/libboard_misoc/i2c.rs
+++ b/artiq/firmware/libboard_misoc/i2c.rs
@@ -183,8 +183,11 @@ mod imp {
         if !write(busno, address << 1)? {
             return Err("PCA9548 failed to ack write address")
         }
-        if !write(busno, channels)? {
-            return Err("PCA9548 failed to ack control word")
+        // Duplicate control byte: one for SCL, one for SDA
+        for _ in 0..2 {
+            if !write(busno, channels)? {
+                return Err("PCA9548 failed to ack control word")
+            }
         }
         stop(busno)?;
         Ok(())


### PR DESCRIPTION
Duplicate control byte in I<sup>2</sup>C, in accordance with "7. Parameter Measurement Information" in the [TCA9548 datasheet](https://www.ti.com/lit/ds/symlink/tca9548a.pdf?ts=1593747422231&ref_url=https%253A%252F%252Fwww.google.com%252F)