### PR TITLE
metlino: support EEPROM & EUI48 reading

### DIFF
--- a/artiq/firmware/libboard_misoc/i2c_eeprom.rs
+++ b/artiq/firmware/libboard_misoc/i2c_eeprom.rs
@@ -1,6 +1,7 @@
 use i2c;
 
-/// [Hardware manual](http://ww1.microchip.com/downloads/en/DeviceDoc/24AA02E48-24AA025E48-24AA02E64-24AA025E64-Data-Sheet-20002124H.pdf)
+/// [Hardware manual for Kasli's 24AA02E48](http://ww1.microchip.com/downloads/en/DeviceDoc/24AA02E48-24AA025E48-24AA02E64-24AA025E64-Data-Sheet-20002124H.pdf)
+/// [Hardware manual for Metlino's AT24MAC402](http://ww1.microchip.com/downloads/en/devicedoc/Atmel-8807-SEEPROM-AT24MAC402-602-Datasheet.pdf)
 pub struct EEPROM {
     busno: u8,
     port: u8,
@@ -28,11 +29,27 @@ impl EEPROM {
         }
     }
 
+    #[cfg(soc_platform = "metlino")]
+    pub fn new() -> Self {
+        EEPROM {
+            busno: 0,
+            port: 5,
+            address: 0xa2,  // == 0x51 << 1
+        }
+    }
+
     #[cfg(soc_platform = "kasli")]
     fn select(&self) -> Result<(), &'static str> {
         let mask: u16 = 1 << self.port;
         i2c::pca9548_select(self.busno, 0x70, mask as u8)?;
         i2c::pca9548_select(self.busno, 0x71, (mask >> 8) as u8)?;
+        Ok(())
+    }
+
+    #[cfg(soc_platform = "metlino")]
+    fn select(&self) -> Result<(), &'static str> {
+        let mask: u16 = 1 << self.port;
+        i2c::pca9548_select(self.busno, 0x70, mask as u8)?;     // FPGA_I2C
         Ok(())
     }
 
@@ -55,6 +72,7 @@ impl EEPROM {
         Ok(())
     }
 
+    #[cfg(soc_platform = "kasli")]
     /// > The 24AA02XEXX is programmed at the factory with a
     /// > globally unique node address stored in the upper half
     /// > of the array and permanently write-protected.
@@ -63,4 +81,37 @@ impl EEPROM {
         self.read(0xFA, &mut buffer)?;
         Ok(buffer)
     }
+
+    #[cfg(soc_platform = "metlino")]
+    /// The AT24MAC402 requires a special EUI Address Read instruction;
+    /// see Figure 12-5: EUI Address Read.
+    /// For the EUI48 address, see Section 7.1 EUI-48 Support.
+    pub fn read_eui48<'a>(&self) -> Result<[u8; 6], &'static str> {
+        self.select()?;
+
+        // Emit START condition
+        i2c::start(self.busno)?;
+        // Write 0b[1011 A2 A1 A0] as device address
+        i2c::write(self.busno, 0b10110000 | (self.address & 0b1110))?;
+        // Write EUI word start address
+        i2c::write(self.busno, 0x9A)?;
+
+        // Re-emit START condition
+        i2c::restart(self.busno)?;
+        // Write 0b[1011 A2 A1 A0] as device address
+        i2c::write(self.busno, 0b10110001 | (self.address & 0b1110))?;
+
+        // Read 6 bytes, expect NACK at the final byte
+        let mut buffer = [0u8; 6];
+        let buf_len = buffer.len();
+        for (i, byte) in buffer.iter_mut().enumerate() {
+            *byte = i2c::read(self.busno, i < buf_len - 1)?;
+        }
+
+        // Emit STOP condition
+        i2c::stop(self.busno)?;
+
+        Ok(buffer)
+    }
+
 }

--- a/artiq/firmware/libboard_misoc/lib.rs
+++ b/artiq/firmware/libboard_misoc/lib.rs
@@ -35,7 +35,7 @@ pub mod uart_logger;
 #[cfg(all(has_ethmac, feature = "smoltcp"))]
 pub mod ethmac;
 pub mod i2c;
-#[cfg(soc_platform = "kasli")]
+#[cfg(any(soc_platform = "kasli", soc_platform = "metlino"))]
 pub mod i2c_eeprom;
 #[cfg(all(soc_platform = "kasli", hw_rev = "v2.0"))]
 pub mod io_expander;

--- a/artiq/firmware/libboard_misoc/net_settings.rs
+++ b/artiq/firmware/libboard_misoc/net_settings.rs
@@ -3,7 +3,7 @@ use core::fmt;
 use smoltcp::wire::{EthernetAddress, IpAddress};
 
 use config;
-#[cfg(soc_platform = "kasli")]
+#[cfg(any(soc_platform = "kasli", soc_platform = "metlino"))]
 use i2c_eeprom;
 
 
@@ -37,12 +37,18 @@ pub fn get_adresses() -> NetAddresses {
                 hardware_addr =
                     eeprom.read_eui48()
                     .map(|addr_buf| EthernetAddress(addr_buf))
-                    .unwrap_or_else(|_e| EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x21]));
+                    .expect("Failed to read MAC address from EEPROM");
             }
             #[cfg(soc_platform = "sayma_amc")]
             { hardware_addr = EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x11]); }
             #[cfg(soc_platform = "metlino")]
-            { hardware_addr = EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x19]); }
+            {
+                let eeprom = i2c_eeprom::EEPROM::new();
+                hardware_addr =
+                    eeprom.read_eui48()
+                    .map(|addr_buf| EthernetAddress(addr_buf))
+                    .expect("Failed to read MAC address from EEPROM");
+            }
             #[cfg(soc_platform = "kc705")]
             { hardware_addr = EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]); }
         }


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

This adds firmware code for Metlino to read the MAC address from the EEPROM's EUI-48 address.

## Details

It is worth noting that AT24MAC402, which is the EEPROM connected to Port 5 of Metlino's I2C switch IC43, has a specific sequence of I2C transaction sequence, which consists of a specific slave address byte. Please refer to Fig. 12-5 of the [datasheet](http://ww1.microchip.com/downloads/en/devicedoc/Atmel-8807-SEEPROM-AT24MAC402-602-Datasheet.pdf) for details. Also note that the EUI-48 address on this EEPROM is specified as: FC-C2-3D-xx-xx-xx.

A minor edit on the firmware code for both Kasli and Metlino has been applied: if I2C transactions on the EEPROM fails, instead of using a default MAC address, the firmware will panic.