### PR TITLE
RPC Performance Optimization

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -11,6 +11,7 @@ Highlights:
 * Performance improvements:
   - #1432: SERDES TTL inputs can now detect edges on pulses that are shorter
     than the RTIO period
+  - Improved performance for kernel RPC involving list and array.
 * Coredevice SI to mu conversions now always return valid codes, or raise a `ValueError`.
 * Zotino now exposes `voltage_to_mu()`
 * `ad9910`: The maximum amplitude scale factor is now `0x3fff` (was `0x3ffe`

--- a/artiq/coredevice/comm_kernel.py
+++ b/artiq/coredevice/comm_kernel.py
@@ -43,14 +43,115 @@ class Reply(Enum):
 class UnsupportedDevice(Exception):
     pass
 
+
 class LoadError(Exception):
     pass
+
 
 class RPCReturnValueError(ValueError):
     pass
 
 
 RPCKeyword = namedtuple('RPCKeyword', ['name', 'value'])
+
+
+def _receive_fraction(kernel, embedding_map):
+    numerator = kernel._read_int64()
+    denominator = kernel._read_int64()
+    return Fraction(numerator, denominator)
+
+
+def _receive_list(kernel, embedding_map):
+    length = kernel._read_int32()
+    tag = chr(kernel._read_int8())
+    if tag == "b":
+        buffer = kernel._read(length)
+        return numpy.ndarray((length, ), 'B', buffer).tolist()
+    elif tag == "i":
+        buffer = kernel._read(4 * length)
+        return numpy.ndarray((length, ), '>i4', buffer).tolist()
+    elif tag == "I":
+        buffer = kernel._read(8 * length)
+        return numpy.ndarray((length, ), '>i8', buffer).tolist()
+    elif tag == "f":
+        buffer = kernel._read(8 * length)
+        return numpy.ndarray((length, ), '>d', buffer).tolist()
+    else:
+        fn = receivers[tag]
+        elems = []
+        for _ in range(length):
+            # discard tag, as our device would still send the tag for each
+            # non-primitive elements.
+            kernel._read_int8()
+            item = fn(kernel, embedding_map)
+            elems.append(item)
+        return elems
+
+
+def _receive_array(kernel, embedding_map):
+    num_dims = kernel._read_int8()
+    shape = tuple(kernel._read_int32() for _ in range(num_dims))
+    tag = chr(kernel._read_int8())
+    fn = receivers[tag]
+    length = numpy.prod(shape)
+    if tag == "b":
+        buffer = kernel._read(length)
+        elems = numpy.ndarray((length, ), 'B', buffer)
+    elif tag == "i":
+        buffer = kernel._read(4 * length)
+        elems = numpy.ndarray((length, ), '>i4', buffer)
+    elif tag == "I":
+        buffer = kernel._read(8 * length)
+        elems = numpy.ndarray((length, ), '>i8', buffer)
+    elif tag == "f":
+        buffer = kernel._read(8 * length)
+        elems = numpy.ndarray((length, ), '>d', buffer)
+    else:
+        fn = receivers[tag]
+        elems = []
+        for _ in range(numpy.prod(shape)):
+            # discard the tag
+            kernel._read_int8()
+            item = fn(kernel, embedding_map)
+            elems.append(item)
+        elems = numpy.array(elems)
+    return elems.reshape(shape)
+
+
+def _receive_range(kernel, embedding_map):
+    start = kernel._receive_rpc_value(embedding_map)
+    stop = kernel._receive_rpc_value(embedding_map)
+    step = kernel._receive_rpc_value(embedding_map)
+    return range(start, stop, step)
+
+
+def _receive_keyword(kernel, embedding_map):
+    name = kernel._read_string()
+    value = kernel._receive_rpc_value(embedding_map)
+    return RPCKeyword(name, value)
+
+
+receivers = {
+    "\x00": lambda kernel, embedding_map: kernel._rpc_sentinel,
+    "t": lambda kernel, embedding_map:
+    tuple(kernel._receive_rpc_value(embedding_map)
+          for _ in range(kernel._read_int8())),
+    "n": lambda kernel, embedding_map: None,
+    "b": lambda kernel, embedding_map: bool(kernel._read_int8()),
+    "i": lambda kernel, embedding_map: numpy.int32(kernel._read_int32()),
+    "I": lambda kernel, embedding_map: numpy.int32(kernel._read_int64()),
+    "f": lambda kernel, embedding_map: kernel._read_float64(),
+    "s": lambda kernel, embedding_map: kernel._read_string(),
+    "B": lambda kernel, embedding_map: kernel._read_bytes(),
+    "A": lambda kernel, embedding_map: kernel._read_bytes(),
+    "O": lambda kernel, embedding_map:
+    embedding_map.retrieve_object(kernel._read_int32()),
+    "F": _receive_fraction,
+    "l": _receive_list,
+    "a": _receive_array,
+    "r": _receive_range,
+    "k": _receive_keyword
+}
 
 
 class CommKernelDummy:
@@ -247,50 +348,8 @@ class CommKernel:
     # See rpc_proto.rs and compiler/ir.py:rpc_tag.
     def _receive_rpc_value(self, embedding_map):
         tag = chr(self._read_int8())
-        if tag == "\x00":
-            return self._rpc_sentinel
-        elif tag == "t":
-            length = self._read_int8()
-            return tuple(self._receive_rpc_value(embedding_map) for _ in range(length))
-        elif tag == "n":
-            return None
-        elif tag == "b":
-            return bool(self._read_int8())
-        elif tag == "i":
-            return numpy.int32(self._read_int32())
-        elif tag == "I":
-            return numpy.int64(self._read_int64())
-        elif tag == "f":
-            return self._read_float64()
-        elif tag == "F":
-            numerator   = self._read_int64()
-            denominator = self._read_int64()
-            return Fraction(numerator, denominator)
-        elif tag == "s":
-            return self._read_string()
-        elif tag == "B":
-            return self._read_bytes()
-        elif tag == "A":
-            return self._read_bytes()
-        elif tag == "l":
-            length = self._read_int32()
-            return [self._receive_rpc_value(embedding_map) for _ in range(length)]
-        elif tag == "a":
-            num_dims = self._read_int8()
-            shape = tuple(self._read_int32() for _ in range(num_dims))
-            elems = [self._receive_rpc_value(embedding_map) for _ in range(numpy.prod(shape))]
-            return numpy.array(elems).reshape(shape)
-        elif tag == "r":
-            start = self._receive_rpc_value(embedding_map)
-            stop  = self._receive_rpc_value(embedding_map)
-            step  = self._receive_rpc_value(embedding_map)
-            return range(start, stop, step)
-        elif tag == "k":
-            name  = self._read_string()
-            value = self._receive_rpc_value(embedding_map)
-            return RPCKeyword(name, value)
-        elif tag == "O":
-            return embedding_map.retrieve_object(self._read_int32())
+        if tag in receivers:
+            return receivers.get(tag)(self, embedding_map)
         else:
             raise IOError("Unknown RPC value tag: {}".format(repr(tag)))
 
@@ -357,8 +416,8 @@ class CommKernel:
             self._write_float64(value)
         elif tag == "F":
             check(isinstance(value, Fraction) and
-                    (-2**63 < value.numerator < 2**63-1) and
-                    (-2**63 < value.denominator < 2**63-1),
+                  (-2**63 < value.numerator < 2**63-1) and
+                  (-2**63 < value.denominator < 2**63-1),
                   lambda: "64-bit Fraction")
             self._write_int64(value.numerator)
             self._write_int64(value.denominator)
@@ -378,21 +437,47 @@ class CommKernel:
             check(isinstance(value, list),
                   lambda: "list")
             self._write_int32(len(value))
-            for elt in value:
-                tags_copy = bytearray(tags)
-                self._send_rpc_value(tags_copy, elt, root, function)
+            tag_element = chr(tags[0])
+            if tag_element == "b":
+                self._write(bytes(value))
+            elif tag_element == "i":
+                array = numpy.array(value, '>i4')
+                self._write(array.tobytes())
+            elif tag_element == "I":
+                array = numpy.array(value, '>i8')
+                self._write(array.tobytes())
+            elif tag_element == "f":
+                array = numpy.array(value, '>d')
+                self._write(array.tobytes())
+            else:
+                for elt in value:
+                    tags_copy = bytearray(tags)
+                    self._send_rpc_value(tags_copy, elt, root, function)
             self._skip_rpc_value(tags)
         elif tag == "a":
             check(isinstance(value, numpy.ndarray),
                   lambda: "numpy.ndarray")
             num_dims = tags.pop(0)
             check(num_dims == len(value.shape),
-                lambda: "{}-dimensional numpy.ndarray".format(num_dims))
+                  lambda: "{}-dimensional numpy.ndarray".format(num_dims))
             for s in value.shape:
                 self._write_int32(s)
-            for elt in value.reshape((-1,), order="C"):
-                tags_copy = bytearray(tags)
-                self._send_rpc_value(tags_copy, elt, root, function)
+            tag_element = chr(tags[0])
+            if tag_element == "b":
+                self._write(value.reshape((-1,), order="C").tobytes())
+            elif tag_element == "i":
+                array = value.reshape((-1,), order="C").astype('>i4')
+                self._write(array.tobytes())
+            elif tag_element == "I":
+                array = value.reshape((-1,), order="C").astype('>i8')
+                self._write(array.tobytes())
+            elif tag_element == "f":
+                array = value.reshape((-1,), order="C").astype('>d')
+                self._write(array.tobytes())
+            else:
+                for elt in value.reshape((-1,), order="C"):
+                    tags_copy = bytearray(tags)
+                    self._send_rpc_value(tags_copy, elt, root, function)
             self._skip_rpc_value(tags)
         elif tag == "r":
             check(isinstance(value, range),
@@ -414,15 +499,15 @@ class CommKernel:
             return msg
 
     def _serve_rpc(self, embedding_map):
-        is_async     = self._read_bool()
-        service_id   = self._read_int32()
+        is_async = self._read_bool()
+        service_id = self._read_int32()
         args, kwargs = self._receive_rpc_args(embedding_map)
-        return_tags  = self._read_bytes()
+        return_tags = self._read_bytes()
 
         if service_id == 0:
-            service  = lambda obj, attr, value: setattr(obj, attr, value)
+            def service(obj, attr, value): return setattr(obj, attr, value)
         else:
-            service  = embedding_map.retrieve_object(service_id)
+            service = embedding_map.retrieve_object(service_id)
         logger.debug("rpc service: [%d]%r%s %r %r -> %s", service_id, service,
                      (" (async)" if is_async else ""), args, kwargs, return_tags)
 
@@ -432,15 +517,18 @@ class CommKernel:
 
         try:
             result = service(*args, **kwargs)
-            logger.debug("rpc service: %d %r %r = %r", service_id, args, kwargs, result)
+            logger.debug("rpc service: %d %r %r = %r",
+                         service_id, args, kwargs, result)
 
             self._write_header(Request.RPCReply)
             self._write_bytes(return_tags)
-            self._send_rpc_value(bytearray(return_tags), result, result, service)
+            self._send_rpc_value(bytearray(return_tags),
+                                 result, result, service)
         except RPCReturnValueError as exn:
             raise
         except Exception as exn:
-            logger.debug("rpc service: %d %r %r ! %r", service_id, args, kwargs, exn)
+            logger.debug("rpc service: %d %r %r ! %r",
+                         service_id, args, kwargs, exn)
 
             self._write_header(Request.RPCException)
 
@@ -479,23 +567,23 @@ class CommKernel:
                     assert False
                 self._write_string(filename)
                 self._write_int32(line)
-                self._write_int32(-1) # column not known
+                self._write_int32(-1)  # column not known
                 self._write_string(function)
 
     def _serve_exception(self, embedding_map, symbolizer, demangler):
-        name      = self._read_string()
-        message   = self._read_string()
-        params    = [self._read_int64() for _ in range(3)]
+        name = self._read_string()
+        message = self._read_string()
+        params = [self._read_int64() for _ in range(3)]
 
-        filename  = self._read_string()
-        line      = self._read_int32()
-        column    = self._read_int32()
-        function  = self._read_string()
+        filename = self._read_string()
+        line = self._read_int32()
+        column = self._read_int32()
+        function = self._read_string()
 
         backtrace = [self._read_int32() for _ in range(self._read_int32())]
 
         traceback = list(reversed(symbolizer(backtrace))) + \
-                    [(filename, line, column, *demangler([function]), None)]
+            [(filename, line, column, *demangler([function]), None)]
         core_exn = exceptions.CoreException(name, message, params, traceback)
 
         if core_exn.id == 0:

--- a/artiq/firmware/libproto_artiq/lib.rs
+++ b/artiq/firmware/libproto_artiq/lib.rs
@@ -11,6 +11,7 @@ extern crate cslice;
 #[macro_use]
 extern crate log;
 
+extern crate byteorder;
 extern crate io;
 extern crate dyld;
 

--- a/artiq/firmware/libproto_artiq/rpc_proto.rs
+++ b/artiq/firmware/libproto_artiq/rpc_proto.rs
@@ -1,6 +1,7 @@
 use core::str;
+use core::slice;
 use cslice::{CSlice, CMutSlice};
-
+use byteorder::{NetworkEndian, ByteOrder};
 use io::{ProtoRead, Read, Write, ProtoWrite, Error};
 use self::tag::{Tag, TagIterator, split_tag};
 
@@ -53,13 +54,34 @@ unsafe fn recv_value<R, E>(reader: &mut R, tag: Tag, data: &mut *mut (),
             struct List { elements: *mut (), length: u32 };
             consume_value!(List, |ptr| {
                 (*ptr).length = reader.read_u32()?;
+                let length = (*ptr).length as usize;
 
                 let tag = it.clone().next().expect("truncated tag");
                 (*ptr).elements = alloc(tag.size() * (*ptr).length as usize)?;
 
                 let mut data = (*ptr).elements;
-                for _ in 0..(*ptr).length as usize {
-                    recv_value(reader, tag, &mut data, alloc)?
+                match tag {
+                    Tag::Bool => {
+                        let dest = slice::from_raw_parts_mut(data as *mut u8, length);
+                        reader.read_exact(dest)?;
+                    },
+                    Tag::Int32 => {
+                        let dest = slice::from_raw_parts_mut(data as *mut u8, length * 4);
+                        reader.read_exact(dest)?;
+                        let dest = slice::from_raw_parts_mut(data as *mut i32, length);
+                        NetworkEndian::from_slice_i32(dest);
+                    },
+                    Tag::Int64 | Tag::Float64 => {
+                        let dest = slice::from_raw_parts_mut(data as *mut u8, length * 8);
+                        reader.read_exact(dest)?;
+                        let dest = slice::from_raw_parts_mut(data as *mut i64, length);
+                        NetworkEndian::from_slice_i64(dest);
+                    },
+                    _ => {
+                        for _ in 0..length {
+                            recv_value(reader, tag, &mut data, alloc)?
+                        }
+                    }
                 }
                 Ok(())
             })
@@ -72,13 +94,34 @@ unsafe fn recv_value<R, E>(reader: &mut R, tag: Tag, data: &mut *mut (),
                     total_len *= len;
                     consume_value!(u32, |ptr| *ptr = len )
                 }
+                let length = total_len as usize;
 
                 let elt_tag = it.clone().next().expect("truncated tag");
                 *buffer = alloc(elt_tag.size() * total_len as usize)?;
 
                 let mut data = *buffer;
-                for _ in 0..total_len {
-                    recv_value(reader, elt_tag, &mut data, alloc)?
+                match elt_tag {
+                    Tag::Bool => {
+                        let dest = slice::from_raw_parts_mut(data as *mut u8, length);
+                        reader.read_exact(dest)?;
+                    },
+                    Tag::Int32 => {
+                        let dest = slice::from_raw_parts_mut(data as *mut u8, length * 4);
+                        reader.read_exact(dest)?;
+                        let dest = slice::from_raw_parts_mut(data as *mut i32, length);
+                        NetworkEndian::from_slice_i32(dest);
+                    },
+                    Tag::Int64 | Tag::Float64 => {
+                        let dest = slice::from_raw_parts_mut(data as *mut u8, length * 8);
+                        reader.read_exact(dest)?;
+                        let dest = slice::from_raw_parts_mut(data as *mut i64, length);
+                        NetworkEndian::from_slice_i64(dest);
+                    },
+                    _ => {
+                        for _ in 0..length {
+                            recv_value(reader, elt_tag, &mut data, alloc)?
+                        }
+                    }
                 }
                 Ok(())
             })
@@ -155,11 +198,33 @@ unsafe fn send_value<W>(writer: &mut W, tag: Tag, data: &mut *const ())
             #[repr(C)]
             struct List { elements: *const (), length: u32 };
             consume_value!(List, |ptr| {
+                let length = (*ptr).length as usize;
                 writer.write_u32((*ptr).length)?;
                 let tag = it.clone().next().expect("truncated tag");
                 let mut data = (*ptr).elements;
-                for _ in 0..(*ptr).length as usize {
-                    send_value(writer, tag, &mut data)?;
+                writer.write_u8(tag.as_u8())?;
+                match tag {
+                    Tag::Bool => {
+                        let slice = slice::from_raw_parts(data as *const u8, length);
+                        writer.write_all(slice)?;
+                    },
+                    Tag::Int32 => {
+                        let slice = slice::from_raw_parts(data as *const u32, length);
+                        for v in slice.iter() {
+                            writer.write_u32(*v)?;
+                        }
+                    },
+                    Tag::Int64 | Tag::Float64 => {
+                        let slice = slice::from_raw_parts(data as *const u64, length);
+                        for v in slice.iter() {
+                            writer.write_u64(*v)?;
+                        }
+                    },
+                    _ => {
+                        for _ in 0..length {
+                            send_value(writer, tag, &mut data)?;
+                        }
+                    }
                 }
                 Ok(())
             })
@@ -176,9 +241,31 @@ unsafe fn send_value<W>(writer: &mut W, tag: Tag, data: &mut *const ())
                         total_len *= *len;
                     })
                 }
+                let length = total_len as usize;
                 let mut data = *buffer;
-                for _ in 0..total_len as usize {
-                    send_value(writer, elt_tag, &mut data)?;
+                writer.write_u8(elt_tag.as_u8())?;
+                match elt_tag {
+                    Tag::Bool => {
+                        let slice = slice::from_raw_parts(data as *const u8, length);
+                        writer.write_all(slice)?;
+                    },
+                    Tag::Int32 => {
+                        let slice = slice::from_raw_parts(data as *const u32, length);
+                        for v in slice.iter() {
+                            writer.write_u32(*v)?;
+                        }
+                    },
+                    Tag::Int64 | Tag::Float64 => {
+                        let slice = slice::from_raw_parts(data as *const u64, length);
+                        for v in slice.iter() {
+                            writer.write_u64(*v)?;
+                        }
+                    },
+                    _ => {
+                        for _ in 0..length {
+                            send_value(writer, elt_tag, &mut data)?;
+                        }
+                    }
                 }
                 Ok(())
             })

--- a/artiq/test/coredevice/test_performance.py
+++ b/artiq/test/coredevice/test_performance.py
@@ -1,6 +1,7 @@
 import os
 import time
 import unittest
+import numpy
 
 from artiq.experiment import *
 from artiq.test.hardware_testbench import ExperimentCase
@@ -15,18 +16,55 @@ class _Transfer(EnvExperiment):
     def source(self) -> TBytes:
         return self.data
 
-    @rpc(flags={"async"})
-    def sink(self, data):
-        assert data == self.data
+    @rpc
+    def source_byte_list(self) -> TList(TBool):
+        return [True] * (1 << 15)
 
-    @rpc(flags={"async"})
+    @rpc
+    def source_list(self) -> TList(TInt32):
+        return [123] * (1 << 15)
+
+    @rpc
+    def source_array(self) -> TArray(TInt32):
+        return numpy.array([0] * (1 << 15), numpy.int32)
+
+    @rpc
+    def sink(self, data):
+        pass
+
+    @rpc
+    def sink_list(self, data):
+        pass
+
+    @rpc
     def sink_array(self, data):
-        assert data == [0]*(1 << 15)
+        pass
 
     @kernel
     def host_to_device(self):
         t0 = self.core.get_rtio_counter_mu()
         data = self.source()
+        t1 = self.core.get_rtio_counter_mu()
+        return len(data)/self.core.mu_to_seconds(t1-t0)
+
+    @kernel
+    def host_to_device_list(self):
+        t0 = self.core.get_rtio_counter_mu()
+        data = self.source_list()
+        t1 = self.core.get_rtio_counter_mu()
+        return 4 * len(data)/self.core.mu_to_seconds(t1-t0)
+
+    @kernel
+    def host_to_device_array(self):
+        t0 = self.core.get_rtio_counter_mu()
+        data = self.source_array()
+        t1 = self.core.get_rtio_counter_mu()
+        return 4 * len(data)/self.core.mu_to_seconds(t1-t0)
+
+    @kernel
+    def host_to_device_byte_list(self):
+        t0 = self.core.get_rtio_counter_mu()
+        data = self.source_byte_list()
         t1 = self.core.get_rtio_counter_mu()
         return len(data)/self.core.mu_to_seconds(t1-t0)
 
@@ -38,14 +76,23 @@ class _Transfer(EnvExperiment):
         return len(self.data)/self.core.mu_to_seconds(t1-t0)
 
     @kernel
-    def device_to_host_array(self):
+    def device_to_host_list(self):
         #data = [[0]*8 for _ in range(1 << 12)]
         data = [0]*(1 << 15)
         t0 = self.core.get_rtio_counter_mu()
+        self.sink_list(data)
+        t1 = self.core.get_rtio_counter_mu()
+        return ((len(data)*4) /
+                self.core.mu_to_seconds(t1-t0))
+
+    @kernel
+    def device_to_host_array(self):
+        data = self.source_array()
+        t0 = self.core.get_rtio_counter_mu()
         self.sink_array(data)
         t1 = self.core.get_rtio_counter_mu()
-        return ((len(data)*4)/
-            self.core.mu_to_seconds(t1-t0))
+        return ((len(data)*4) /
+                self.core.mu_to_seconds(t1-t0))
 
 
 class TransferTest(ExperimentCase):
@@ -55,11 +102,35 @@ class TransferTest(ExperimentCase):
         print(host_to_device_rate/(1024*1024), "MiB/s")
         self.assertGreater(host_to_device_rate, 2.0e6)
 
+    def test_host_to_device_byte_list(self):
+        exp = self.create(_Transfer)
+        host_to_device_rate = exp.host_to_device_byte_list()
+        print(host_to_device_rate/(1024*1024), "MiB/s")
+        self.assertGreater(host_to_device_rate, 2.0e6)
+
+    def test_host_to_device_list(self):
+        exp = self.create(_Transfer)
+        host_to_device_rate = exp.host_to_device_list()
+        print(host_to_device_rate/(1024*1024), "MiB/s")
+        self.assertGreater(host_to_device_rate, 2.0e6)
+
+    def test_host_to_device_array(self):
+        exp = self.create(_Transfer)
+        host_to_device_rate = exp.host_to_device_array()
+        print(host_to_device_rate/(1024*1024), "MiB/s")
+        self.assertGreater(host_to_device_rate, 2.0e6)
+
     def test_device_to_host(self):
         exp = self.create(_Transfer)
         device_to_host_rate = exp.device_to_host()
         print(device_to_host_rate/(1024*1024), "MiB/s")
         self.assertGreater(device_to_host_rate, 2.2e6)
+
+    def test_device_to_host_list(self):
+        exp = self.create(_Transfer)
+        rate = exp.device_to_host_list()
+        print(rate/(1024*1024), "MiB/s")
+        self.assertGreater(rate, .15e6)
 
     def test_device_to_host_array(self):
         exp = self.create(_Transfer)


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
Optimized performance for RPC list and array transfer of primitive types. Added some more tests for performance of RPC.

Tested on kc705 and zynq platform with `test_performance`, `test_embedding` and `test_numpy`. No regression.

### Notes
- Lists/arrays with non-primitive types (not Bool/Int32/Int64/Float) are not optimized that well and are in general hard to optimize well.
- This patch changes the RPC protocol for list and array, users should ensure they have the same firmware and compiler version.
- The performance test would no longer assert the data correctness. Use `test_embedding` and `test_numpy` for correctness check.
- The performance test now uses normal RPC instead of async RPC now, as this could better represent the actual throughput, and async RPC cannot be used to test for performance in artiq-zynq port. The performance number could a lot smaller than the tests before, but should be reflect the real throughput.

### RPC Performance
| Type | KC705 (previously) | KC705 (now) | Zynq (previously) | Zynq (now) |
| --- | --- | --- | --- | --- |
| test_device_to_host (bytes) | 2.0989389396479927 MiB/s | 2.099773561838202 MiB/s | 43.09186402640445 MiB/s | 43.8887923867646 MiB/s |
|  test_device_to_host_array (int32 array) | 0.19622426586254357 MiB/s | 0.4754803820141763 MiB/s | 0.4794607308006433 MiB/s | 31.9846882900218 MiB/s |
| test_device_to_host_list (int32 list) | 0.19756234991899502 MiB/s | 0.47681566599308245 MiB/s | 0.7028557219158196 MiB/s | 30.071787370811602 MiB/s |
| test_host_to_device (bytes) | 2.095725556708547 MiB/s | 2.121632685383121 MiB/s | 44.71234780449521 MiB/s | 48.77840068856528 MiB/s |
| test_host_to_device_array (int32 array) | 0.3525974608153646 MiB/s | 1.9586889006584327 MiB/s  | 0.4533021473060521 MiB/s | 21.507019202843193 MiB/s |
| test_host_to_device_byte_list (bool list) | 0.09882486389808119 MiB/s | 1.8457782297161671 MiB/s | 0.11275899857943146 MiB/s | 20.907261409677954 MiB/s |
| test_host_to_device_list (int32 list) | 0.34771873366556477 MiB/s | 1.9939231602629297 MiB/s | 0.42312216824642657 MiB/s | 21.732297044685772 MiB/s |

* The performance for `device_to_host` list/array can be optimized further in targets with allocation enabled, but this is currently only done for zynq. The performance is poor because we are calling the write function for every single element.
* There should be no significant difference in throughput for byte array, as the original implementation is already very efficient.
* The throughput of `host_to_device` list/array for zynq can be further increased to somewhere around 30MiB/s if we increase the data length, but that is just difference in numbers so I prefer to use the same length for all transactions.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.md](../RELEASE_NOTES.md) if there are noteworthy changes, especially if there are changes to existing APIs.
- [ ] Close/update issues.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [ ] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

- [ ] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
