### PR TITLE
build_soc: override identifier_str only for gateware

### DIFF
--- a/artiq/build_soc.py
+++ b/artiq/build_soc.py
@@ -47,12 +47,11 @@ class ReprogrammableIdentifier(Module, AutoCSR):
 def add_identifier(soc, *args, identifier_str=None, **kwargs):
     if hasattr(soc, "identifier"):
         raise ValueError
-    if identifier_str is None:
-        # not overridden with --identifier-str
-        identifier_str = get_identifier_string(soc, *args, **kwargs)
-    soc.submodules.identifier = ReprogrammableIdentifier(identifier_str)
-    soc.config["IDENTIFIER_STR"] = identifier_str
+    software_identifier_str = get_identifier_string(soc, *args, **kwargs)
+    gateware_identifier_str = identifier_str or software_identifier_str
 
+    soc.submodules.identifier = ReprogrammableIdentifier(gateware_identifier_str)
+    soc.config["IDENTIFIER_STR"] = software_identifier_str
 
 
 def build_artiq_soc(soc, argdict):


### PR DESCRIPTION
Actually, we want to override the identifier_str just for the gateware but not the for the firmware.

This fixes the `software ident` output. Should we change the arg into `gateware_identifier_str` in all callers for more clarity?