### PR TITLE
build_soc: remove assertion that was used for test runs

### DIFF
--- a/artiq/build_soc.py
+++ b/artiq/build_soc.py
@@ -47,9 +47,6 @@ class ReprogrammableIdentifier(Module, AutoCSR):
 def add_identifier(soc, *args, gateware_identifier_str=None, **kwargs):
     if hasattr(soc, "identifier"):
         raise ValueError
-    if gateware_identifier_str is None:
-        # not overridden with --identifier-str
-        raise ValueError("gateware_identifier_str not overridden")
     identifier_str = get_identifier_string(soc, *args, **kwargs)
     soc.submodules.identifier = ReprogrammableIdentifier(gateware_identifier_str or identifier_str)
     soc.config["IDENTIFIER_STR"] = identifier_str


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

### Related Issue

#1515

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
