### PR TITLE
ad9910: fix `turns_to_pow` return-type on host

### DIFF
--- a/artiq/coredevice/ad9910.py
+++ b/artiq/coredevice/ad9910.py
@@ -596,7 +596,7 @@ class AD9910:
     def turns_to_pow(self, turns) -> TInt32:
         """Return the 16-bit phase offset word corresponding to the given phase
         in turns."""
-        return int32(round(turns*0x10000)) & 0xffff
+        return int32(round(turns*0x10000)) & int32(0xffff)
 
     @portable(flags={"fast-math"})
     def pow_to_turns(self, pow_):


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
When run on the host, the 16-bit word from `turns_to_pow` retruns a `numpy.int64`. Meanwhile, all other machine unit return types of the ad9910 are the more appropreate `numpy.int32`. 

Sensibly, the compiler does not attempt to convert `numpy.int64` to `int32`. These bahaviours combine to give compiler errors when attempting to cache the machine unit parameters in a list, as mixed-type lists are not supported. Currently this needs to be worked around by casting the pow to `numpy.int32`.

This behaviour will also occur for ad9912. However, I do not have the hardware to test this fix on an ad9912. In light of #1463 and #1468 it seems unwise to modify this without testing on hardware.

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|  | :sparkles: New feature |
|  | :hammer: Refactoring  |
|  | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.md](../RELEASE_NOTES.md) if there are noteworthy changes. This does not seem noteworthy.
- [x] Close/update issues. N/A
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). No change
- [x] Test your changes or have someone test them. Mention what was tested and how. I've tested correct amplitude and and frequency operation on an ad9910 urukul. Printing the machine unit value from the core device shows the result to be unchanged. *ToDo: Test phase coherence on hardware*
- [x] Add and check docstrings and comments. N/A
- [ ] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test). Todo: I'll need to setup a suitable core-device.

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
