### PR TITLE
fixes with statement with multiple items

### DIFF
--- a/artiq/compiler/transforms/artiq_ir_generator.py
+++ b/artiq/compiler/transforms/artiq_ir_generator.py
@@ -883,8 +883,8 @@ class ARTIQIRGenerator(algorithm.Visitor):
                     self.current_assign = None
 
                 none = self.append(ir.Alloc([], builtins.TNone()))
-                cleanup.append(lambda:
-                    self._user_call(exit_fn, [none, none, none], {}))
+                call = self._user_call(exit_fn, [none, none, none], {})
+                cleanup.append(lambda: call)
 
         self._try_finally(
             body_gen=lambda: self.visit(node.body),


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
Fixes incorrect behavior for with statements with multiple items.

It seems that the lambda expression is lazily evaluated, and the exit function that it binds to changes to the one of the last item.

### Related Issue
Closes #1478

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Close/update issues.

### Code Changes

- [ ] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [ ] Add and check docstrings and comments
- [ ] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
