### PR TITLE
compiler: added error message for object comparison

### DIFF
--- a/artiq/compiler/transforms/artiq_ir_generator.py
+++ b/artiq/compiler/transforms/artiq_ir_generator.py
@@ -1914,7 +1914,13 @@ class ARTIQIRGenerator(algorithm.Visitor):
 
             return result
         else:
-            assert False
+            loc = lhs.loc
+            loc.end = rhs.loc.end
+            diag = diagnostic.Diagnostic("error",
+                "Custom object comparison is not supported",
+                {},
+                loc)
+            self.engine.process(diag)
 
     def polymorphic_compare_pair_inclusion(self, needle, haystack):
         if builtins.is_range(haystack.type):
@@ -1958,7 +1964,13 @@ class ARTIQIRGenerator(algorithm.Visitor):
 
             result = phi
         else:
-            assert False
+            loc = needle.loc
+            loc.end = haystack.loc.end
+            diag = diagnostic.Diagnostic("error",
+                "Custom object inclusion test is not supported",
+                {},
+                loc)
+            self.engine.process(diag)
 
         return result
 

--- a/artiq/test/lit/codegen/custom_comparison.py
+++ b/artiq/test/lit/codegen/custom_comparison.py
@@ -1,0 +1,13 @@
+# RUN: %python -m artiq.compiler.testbench.signature +diag %s >%t
+# RUN: OutputCheck %s --file-to-check=%t
+
+class Foo:
+    def __init__(self):
+        pass
+
+a = Foo()
+b = Foo()
+
+# CHECK-L: ${LINE:+1}: error: Custom object comparison is not supported
+a > b
+

--- a/artiq/test/lit/codegen/custom_inclusion.py
+++ b/artiq/test/lit/codegen/custom_inclusion.py
@@ -1,0 +1,13 @@
+# RUN: %python -m artiq.compiler.testbench.signature +diag %s >%t
+# RUN: OutputCheck %s --file-to-check=%t
+
+class Foo:
+    def __init__(self):
+        pass
+
+a = Foo()
+b = Foo()
+
+# CHECK-L: ${LINE:+1}: error: Custom object inclusion test is not supported
+a in b
+


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
Added error messages for object comparison, instead of assert fail.

Example output:
```
eq.py:16:16-16:35: error: Custom object comparison is not supported
        return self.bar > self.baz
               ^^^^^^^^^^^^^^^^^^^^

eq.py:16:16-16:36: error: Custom object comparison is not supported
        return self.bar == self.baz
               ^^^^^^^^^^^^^^^^^^^^
```

### Related Issue
Closes #1396.

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
