### PR TITLE
fixed value scaling issue for the center scan gui widget

### DIFF
--- a/artiq/gui/entries.py
+++ b/artiq/gui/entries.py
@@ -301,7 +301,7 @@ class _CenterScan(LayoutWidget):
         apply_properties(center)
         center.setPrecision()
         center.setRelativeStep()
-        center.setValue(state["center"])
+        center.setValue(state["center"]/scale)
         self.addWidget(center, 0, 1)
         self.addWidget(QtWidgets.QLabel("Center:"), 0, 0)
 
@@ -311,7 +311,7 @@ class _CenterScan(LayoutWidget):
         span.setPrecision()
         span.setRelativeStep()
         span.setMinimum(0)
-        span.setValue(state["span"])
+        span.setValue(state["span"]/scale)
         self.addWidget(span, 1, 1)
         self.addWidget(QtWidgets.QLabel("Span:"), 1, 0)
 
@@ -321,7 +321,7 @@ class _CenterScan(LayoutWidget):
         step.setPrecision()
         step.setRelativeStep()
         step.setMinimum(0)
-        step.setValue(state["step"])
+        step.setValue(state["step"]/scale)
         self.addWidget(step, 2, 1)
         self.addWidget(QtWidgets.QLabel("Step:"), 2, 0)
 


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Fixed a bug in the center scan widget that causes scaling to be applied twice.
Fix applies both to master and release-5 branch, I would like to have the patch on the release-5 branch.

### Related Issue

No related issues.

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.md](../RELEASE_NOTES.md) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Close/update issues.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

Changes too small to affect the points below.

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

Changes too small to affect the points below.

- [x] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
