### PR TITLE
compiler: Raise exception on failed assert()s rather than panic

### DIFF
--- a/artiq/compiler/module.py
+++ b/artiq/compiler/module.py
@@ -40,7 +40,8 @@ class Source:
             return cls(source.Buffer(f.read(), filename, 1), engine=engine)
 
 class Module:
-    def __init__(self, src, ref_period=1e-6, attribute_writeback=True, remarks=False):
+    def __init__(self, src, ref_period=1e-6, attribute_writeback=True, remarks=False,
+                 raise_assertion_errors=False):
         self.attribute_writeback = attribute_writeback
         self.engine = src.engine
         self.embedding_map = src.embedding_map
@@ -55,9 +56,11 @@ class Module:
         iodelay_estimator = transforms.IODelayEstimator(engine=self.engine,
                                                         ref_period=ref_period)
         constness_validator = validators.ConstnessValidator(engine=self.engine)
-        artiq_ir_generator = transforms.ARTIQIRGenerator(engine=self.engine,
-                                                         module_name=src.name,
-                                                         ref_period=ref_period)
+        artiq_ir_generator = transforms.ARTIQIRGenerator(
+            engine=self.engine,
+            module_name=src.name,
+            ref_period=ref_period,
+            raise_assertion_errors=raise_assertion_errors)
         dead_code_eliminator = transforms.DeadCodeEliminator(engine=self.engine)
         local_access_validator = validators.LocalAccessValidator(engine=self.engine)
         local_demoter = transforms.LocalDemoter()

--- a/artiq/compiler/targets.py
+++ b/artiq/compiler/targets.py
@@ -80,6 +80,9 @@ class Target:
         determined from data_layout due to JIT.
     :var now_pinning: (boolean)
         Whether the target implements the now-pinning RTIO optimization.
+    :var raise_assertion_errors: (bool)
+        Whether to raise an AssertionError on failed assertions or abort/panic
+        instead.
     """
     triple = "unknown"
     data_layout = ""
@@ -87,6 +90,7 @@ class Target:
     print_function = "printf"
     little_endian = False
     now_pinning = True
+    raise_assertion_errors = False
 
     tool_ld = "ld.lld"
     tool_strip = "llvm-strip"
@@ -276,6 +280,10 @@ class CortexA9Target(Target):
     print_function = "core_log"
     little_endian = True
     now_pinning = False
+
+    # Support for marshalling kernel CPU panics as RunAborted errors is not
+    # implemented in the ARTIQ Zynq runtime.
+    raise_assertion_errors = True
 
     tool_ld = "armv7-unknown-linux-gnueabihf-ld"
     tool_strip = "armv7-unknown-linux-gnueabihf-strip"

--- a/artiq/coredevice/core.py
+++ b/artiq/coredevice/core.py
@@ -106,7 +106,8 @@ class Core:
 
             module = Module(stitcher,
                 ref_period=self.ref_period,
-                attribute_writeback=attribute_writeback)
+                attribute_writeback=attribute_writeback,
+                raise_assertion_errors=self.target_cls.raise_assertion_errors)
             target = self.target_cls()
 
             library = target.compile_and_link([module])

--- a/artiq/coredevice/exceptions.py
+++ b/artiq/coredevice/exceptions.py
@@ -11,6 +11,7 @@ ZeroDivisionError = builtins.ZeroDivisionError
 ValueError = builtins.ValueError
 IndexError = builtins.IndexError
 RuntimeError = builtins.RuntimeError
+AssertionError = builtins.AssertionError
 
 
 class CoreException:

--- a/artiq/test/coredevice/test_embedding.py
+++ b/artiq/test/coredevice/test_embedding.py
@@ -79,11 +79,11 @@ class RoundtripTest(ExperimentCase):
         self.assertArrayRoundtrip(numpy.array([["a", "b"], ["c", "d"]]))
 
     # FIXME: This should work, but currently passes as the argument is just
-    # synthesised as the same call to array(), instead of using the "type
-    # inference" result from the host NumPy implementation.
+    # synthesised as a call to array() without forwarding the dype form the host
+    # NumPy object.
     @unittest.expectedFailure
     def test_array_jagged(self):
-        self.assertArrayRoundtrip(numpy.array([[1, 2], [3]]))
+        self.assertArrayRoundtrip(numpy.array([[1, 2], [3]], dtype=object))
 
 
 class _DefaultArg(EnvExperiment):

--- a/artiq/test/lit/integration/instance.py
+++ b/artiq/test/lit/integration/instance.py
@@ -6,9 +6,9 @@ class c:
 
 i = c()
 
-assert i.a == 1
-
 def f():
     c = None
     assert i.a == 1
+
+assert i.a == 1
 f()


### PR DESCRIPTION
This allows assert() to be used on Zynq, where abort() is not
currently implemented for kernels. Furthermore, this is arguably
the more natural implementation of assertions on all kernel targets
(i.e. where embedding into host Python is used), as this way, the
exception information actually makes it to the user.

Since this does not implement printing of the subexpressions, I
left the old print+abort implementation as default for the time
being.

GitHub: Fixes #1539.

---

Needs testing still. (Even if Zynq was the specific motivation here, I've wanted something like this for a while, as assert()s are phenomenally undebuggable with core log forwarding as unreliable as it currently is.)