### PR TITLE
artiq_ddb_template: Rename adf5355 to adf5356, add Mirny CPLD arguments

### DIFF
--- a/artiq/frontend/artiq_ddb_template.py
+++ b/artiq/frontend/artiq_ddb_template.py
@@ -257,8 +257,8 @@ class PeripheralManager:
             self.gen("""
                 device_db["{name}_ch{mchn}"] = {{
                     "type": "local",
-                    "module": "artiq.coredevice.adf5355",
-                    "class": "ADF5355",
+                    "module": "artiq.coredevice.adf5356",
+                    "class": "ADF5356",
                     "arguments": {{
                         "channel": {mchn},
                         "sw_device": "ttl_{name}_sw{mchn}",

--- a/artiq/frontend/artiq_ddb_template.py
+++ b/artiq/frontend/artiq_ddb_template.py
@@ -273,9 +273,15 @@ class PeripheralManager:
                 "type": "local",
                 "module": "artiq.coredevice.mirny",
                 "class": "Mirny",
-                "arguments": {{"spi_device": "spi_{name}"}},
+                "arguments": {{
+                    "spi_device": "spi_{name}",
+                    "refclk": {refclk},
+                    "clk_sel": {clk_sel}
+                }},
             }}""",
-            name=mirny_name)
+            name=mirny_name,
+            refclk=peripheral.get("refclk", self.master_description.get("rtio_frequency", 125e6)),
+            clk_sel=peripheral["clk_sel"])
 
         return next(channel)
 


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
The following changes complement #1530.
- Rename ADF5355 to ADF5356 in `artiq_ddb_template.py`.
- Propagate `clk_sel`, `refclk` arguments from JSON file to `device_db.py`.

### Testing
A JSON snippet with the following Mirny v1.1 configuration created.
```json
        {
            "type": "mirny",
            "ports": [8],
            "clk_sel": 1
        },
```
`artiq_ddb_template.py` then generates the following Mirny entries in `device_db.py`.
```python
device_db["spi_mirny0"]={
    "type": "local",
    "module": "artiq.coredevice.spi2",
    "class": "SPIMaster",
    "arguments": {"channel": 0x01001f}
}

device_db["ttl_mirny0_sw0"] = {
    "type": "local",
    "module": "artiq.coredevice.ttl",
    "class": "TTLOut",
    "arguments": {"channel": 0x010020}
}

device_db["ttl_mirny0_sw1"] = {
    "type": "local",
    "module": "artiq.coredevice.ttl",
    "class": "TTLOut",
    "arguments": {"channel": 0x010021}
}

device_db["ttl_mirny0_sw2"] = {
    "type": "local",
    "module": "artiq.coredevice.ttl",
    "class": "TTLOut",
    "arguments": {"channel": 0x010022}
}

device_db["ttl_mirny0_sw3"] = {
    "type": "local",
    "module": "artiq.coredevice.ttl",
    "class": "TTLOut",
    "arguments": {"channel": 0x010023}
}

device_db["mirny0_ch0"] = {
    "type": "local",
    "module": "artiq.coredevice.adf5356",
    "class": "ADF5356",
    "arguments": {
        "channel": 0,
        "sw_device": "ttl_mirny0_sw0",
        "cpld_device": "mirny0_cpld",
    }
}

device_db["mirny0_ch1"] = {
    "type": "local",
    "module": "artiq.coredevice.adf5356",
    "class": "ADF5356",
    "arguments": {
        "channel": 1,
        "sw_device": "ttl_mirny0_sw1",
        "cpld_device": "mirny0_cpld",
    }
}

device_db["mirny0_ch2"] = {
    "type": "local",
    "module": "artiq.coredevice.adf5356",
    "class": "ADF5356",
    "arguments": {
        "channel": 2,
        "sw_device": "ttl_mirny0_sw2",
        "cpld_device": "mirny0_cpld",
    }
}

device_db["mirny0_ch3"] = {
    "type": "local",
    "module": "artiq.coredevice.adf5356",
    "class": "ADF5356",
    "arguments": {
        "channel": 3,
        "sw_device": "ttl_mirny0_sw3",
        "cpld_device": "mirny0_cpld",
    }
}

device_db["mirny0_cpld"] = {
    "type": "local",
    "module": "artiq.coredevice.mirny",
    "class": "Mirny",
    "arguments": {
        "spi_device": "spi_mirny0",
        "refclk": 125000000.0,
        "clk_sel": 1
    },
}
```
`clk_sel` is set to the internal MMCX connection (Mirny v1.1).
This is further tested in issue #1560, which shows that Mirny CPLD can indeed select MMCX clock source with 125MHz.

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [ ] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [ ] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
