### PR TITLE
sayma: Rewrite JESD code with renewed JESD core

### DIFF
--- a/artiq/gateware/targets/sayma_amc.py
+++ b/artiq/gateware/targets/sayma_amc.py
@@ -192,6 +192,8 @@ class SatelliteBase(MiniSoC):
 # JESD204 DAC Channel Group
 class JDCGSAWG(Module, AutoCSR):
     def __init__(self, platform, sys_crg, jesd_crg, dac):
+        # Kintex Ultrascale GTH, speed grade -1C:
+        # CPLL linerate (D=1): 4.0 - 8.5 Gb/s
         self.submodules.jesd = jesd204_tools.UltrascaleTX(
             platform, sys_crg, jesd_crg, dac)
 


### PR DESCRIPTION
## Description of Changes

This is to make the Sayma satellite code on `master`, which is running at an RTIO frequency of 150 MHz and DAC rate of 600 MS/s (with 4x interpolation), adapt to a proposed renewal of our [JESD204B core](https://github.com/m-labs/jesd204b) (PR: https://github.com/m-labs/jesd204b/pull/14), which has introduced new syntax for instantiating GTH transceivers.

In general, all changes for `jesd204_tools` in this PR are compatible with all kinds of target line rates (corresponding to either CPLL or QPLL defined by Xilinx). In the file, the only lines that needs to be changed for different JESD settings are [63-65](https://github.com/m-labs/artiq/blob/eac5d5fc8cf5efb39a5f6f5ffda4ce6e62a20531/artiq/gateware/jesd204_tools.py#L63-L65).
