### PR TITLE
Expose `wd` via scheduler

### DIFF
--- a/artiq/frontend/artiq_master.py
+++ b/artiq/frontend/artiq_master.py
@@ -123,6 +123,7 @@ def main():
         "scheduler_request_termination": scheduler.request_termination,
         "scheduler_get_status": scheduler.get_status,
         "scheduler_check_pause": scheduler.check_pause,
+        "scheduler_get_wd": scheduler.get_wd,
         "ccb_issue": ccb_issue,
     })
     experiment_db.scan_repository_async()

--- a/artiq/master/scheduler.py
+++ b/artiq/master/scheduler.py
@@ -485,3 +485,11 @@ class Scheduler:
                     return False
                 return r.priority_key() > run.priority_key()
         raise KeyError("RID not found")
+
+    def get_wd(self, rid):
+        """Returns the ``wd`` attribute of the run with the specified RID."""
+        for pipeline in self._pipelines.values():
+            if rid in pipeline.pool.runs:
+                run = pipeline.pool.runs[rid]
+                return run.wd
+        raise KeyError("RID not found")

--- a/artiq/master/worker_impl.py
+++ b/artiq/master/worker_impl.py
@@ -122,6 +122,13 @@ class Scheduler:
         make_parent_action("scheduler_request_termination"))
     get_status = staticmethod(make_parent_action("scheduler_get_status"))
 
+    _get_wd = staticmethod(make_parent_action("scheduler_get_wd"))
+    @host_only
+    def get_wd(self, rid=None):
+        if rid is None:
+            rid = self.rid
+        return self._get_wd(rid)
+
 
 class CCB:
     issue = staticmethod(make_parent_action("ccb_issue"))


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
Add `get_wd(rid)` method to scheduler and scheduler virtual device. For the use case I have in mind, this would retrieve the repository path when using a filesystem backend, but it could also be useful for retrieving the path of the tmpdir when using the git backend.

Hardly a "feature," but not technically a bugfix either.

Signed-off-by: Brad Bondurant <brad.bondurant@duke.edu>

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

This does add to the scheduler API, but I wasn't sure if it was significant enough to warrant updating the release notes.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

Current unit tests pass, no new tests added. Manual testing done with filesystem backend, returns path to repository as expected.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
