### PR TITLE
kasli v2.0: drive TX_DISABLE low on all SFPs (fixes #1570)

### DIFF
--- a/artiq/firmware/runtime/main.rs
+++ b/artiq/firmware/runtime/main.rs
@@ -106,9 +106,18 @@ fn startup() {
         io_expander1 = board_misoc::io_expander::IoExpander::new(1);
         io_expander0.init().expect("I2C I/O expander #0 initialization failed");
         io_expander1.init().expect("I2C I/O expander #1 initialization failed");
+
+        // Actively drive TX_DISABLE to false on SFP0..3
         io_expander0.set_oe(0, 1 << 1).unwrap();
+        io_expander0.set_oe(1, 1 << 1).unwrap();
+        io_expander1.set_oe(0, 1 << 1).unwrap();
+        io_expander1.set_oe(1, 1 << 1).unwrap();
         io_expander0.set(0, 1, false);
+        io_expander0.set(1, 1, false);
+        io_expander1.set(0, 1, false);
+        io_expander1.set(1, 1, false);
         io_expander0.service().unwrap();
+        io_expander1.service().unwrap();
     }
     rtio_clocking::init();
 

--- a/artiq/firmware/satman/main.rs
+++ b/artiq/firmware/satman/main.rs
@@ -475,9 +475,18 @@ pub extern fn main() -> i32 {
             io_expander1.set(1, 7, true);
             io_expander1.service().unwrap();
         }
+
+        // Actively drive TX_DISABLE to false on SFP0..3
         io_expander0.set_oe(0, 1 << 1).unwrap();
+        io_expander0.set_oe(1, 1 << 1).unwrap();
+        io_expander1.set_oe(0, 1 << 1).unwrap();
+        io_expander1.set_oe(1, 1 << 1).unwrap();
         io_expander0.set(0, 1, false);
+        io_expander0.set(1, 1, false);
+        io_expander1.set(0, 1, false);
+        io_expander1.set(1, 1, false);
         io_expander0.service().unwrap();
+        io_expander1.service().unwrap();
     }
 
     #[cfg(has_si5324)]


### PR DESCRIPTION
#1570 was caused by the same problem as #1508, in that the SFP1..3 TX_DISABLE lines were not driven low, and hence the SFP transmit was disabled.

This patch has been tested on a pair of Kasli 2.0, using all possible downstream ports on the master Kasli.