### PR TITLE
coredevice: use device endian for kernel and RPC

### DIFF
--- a/artiq/coredevice/core.py
+++ b/artiq/coredevice/core.py
@@ -76,15 +76,17 @@ class Core:
         self.ref_multiplier = ref_multiplier
         if target == "or1k":
             self.target_cls = OR1KTarget
+            endian = ">"
         elif target == "cortexa9":
             self.target_cls = CortexA9Target
+            endian = "<"
         else:
             raise ValueError("Unsupported target")
         self.coarse_ref_period = ref_period*ref_multiplier
         if host is None:
             self.comm = CommKernelDummy()
         else:
-            self.comm = CommKernel(host)
+            self.comm = CommKernel(host, endian)
 
         self.first_run = True
         self.dmgr = dmgr


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
Use device endian for kernel and RPC protocol. 

Note: This breaks the protocol for artiq-zynq, users must update the zynq firmware after this change.

This improves the performance of integer array transfer for zynq. For large integer array transfer, the throughput difference:
| Test                 | Prev (MiB/s) | Now (MiB/s)  |  Diff  |
| -------------------- | ------------ | ------------ | ------ |
| I32 Array (1MB) H2D  |        44.08 |        47.47 | +7.69% |
| I32 Array (1MB) D2H  |        44.72 |        59.36 | +32.7% |
| Bytes List (1MB) H2D |        36.87 |        34.82 | -5.56% |
| Bytes List (1MB) D2H |        45.92 |        43.03 | -6.29% |
| Bytes (1MB) H2D      |        54.24 |        54.03 | -0.39% |
| Bytes (1MB) D2H      |        61.61 |        61.21 | -0.65% |
| I32 List (1MB) H2D   |        33.69 |        38.78 | +15.1% |
| I32 List (1MB) D2H   |        35.93 |        47.79 | +33.0% |

(I can't get stable result for small transfers from zeus, so comparing them would likely just be noise)
(updated after removing redundant allocation in firmware)

There is no visible effect for or1k as or1k uses big endian, and the bottlenect is the device side for transfer so little overhead in the host side did not reflect on the performance. This PR only affects kernel and RPC protocol, other protocols like coremgmt or analyzer would not be affected as they are not performance critical.

Improvement for or1k device to host integer array transfer is planned, and should be simple. 

### Related Issue
https://github.com/m-labs/artiq/issues/1255#issuecomment-686223846

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
