### PR TITLE
Use device endian for protocols

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -59,7 +59,8 @@ Breaking changes:
   unchanged with the new implementation, but the behavior might differ slightly in some
   cases (for instance, non-rectangular arrays are not currently supported).
 * ``quamash`` has been replaced with ``qasync``.
-
+* Protocols are updated to use device endian.
+* Analyzer dump format includes a byte for device endianness.
 
 ARTIQ-5
 -------

--- a/artiq/coredevice/comm_analyzer.py
+++ b/artiq/coredevice/comm_analyzer.py
@@ -90,7 +90,17 @@ DecodedDump = namedtuple(
 
 
 def decode_dump(data):
-    parts = struct.unpack(">IQbbb", data[:15])
+    # extract endian byte
+    if data[0] == ord('E'):
+        endian = '>'
+    elif data[0] == ord('e'):
+        endian = '<'
+    else:
+        raise ValueError
+    data = data[1:]
+    # only header is device endian
+    # messages are big endian
+    parts = struct.unpack(endian + "IQbbb", data[:15])
     (sent_bytes, total_byte_count,
      error_occured, log_channel, dds_onehot_sel) = parts
 

--- a/artiq/coredevice/comm_moninj.py
+++ b/artiq/coredevice/comm_moninj.py
@@ -31,6 +31,14 @@ class CommMonInj:
         self._reader, self._writer = await asyncio.open_connection(host, port)
         try:
             self._writer.write(b"ARTIQ moninj\n")
+            # get device endian
+            endian = await self._reader.read(1)
+            if endian == b"e":
+                self.endian = "<"
+            elif endian == b"E":
+                self.endian = ">"
+            else:
+                raise IOError("Incorrect reply from device: expected e/E.")
             self._receive_task = asyncio.ensure_future(self._receive_cr())
         except:
             self._writer.close()
@@ -52,19 +60,19 @@ class CommMonInj:
             del self._writer
 
     def monitor_probe(self, enable, channel, probe):
-        packet = struct.pack(">bblb", 0, enable, channel, probe)
+        packet = struct.pack(self.endian + "bblb", 0, enable, channel, probe)
         self._writer.write(packet)
 
     def monitor_injection(self, enable, channel, overrd):
-        packet = struct.pack(">bblb", 3, enable, channel, overrd)
+        packet = struct.pack(self.endian + "bblb", 3, enable, channel, overrd)
         self._writer.write(packet)
 
     def inject(self, channel, override, value):
-        packet = struct.pack(">blbb", 1, channel, override, value)
+        packet = struct.pack(self.endian + "blbb", 1, channel, override, value)
         self._writer.write(packet)
 
     def get_injection_status(self, channel, override):
-        packet = struct.pack(">blb", 2, channel, override)
+        packet = struct.pack(self.endian + "blb", 2, channel, override)
         self._writer.write(packet)
 
     async def _receive_cr(self):
@@ -75,11 +83,13 @@ class CommMonInj:
                     return
                 if ty == b"\x00":
                     payload = await self._reader.read(9)
-                    channel, probe, value = struct.unpack(">lbl", payload)
+                    channel, probe, value = struct.unpack(
+                        self.endian + "lbl", payload)
                     self.monitor_cb(channel, probe, value)
                 elif ty == b"\x01":
                     payload = await self._reader.read(6)
-                    channel, override, value = struct.unpack(">lbb", payload)
+                    channel, override, value = struct.unpack(
+                        self.endian + "lbb", payload)
                     self.injection_status_cb(channel, override, value)
                 else:
                     raise ValueError("Unknown packet type", ty)

--- a/artiq/coredevice/core.py
+++ b/artiq/coredevice/core.py
@@ -84,8 +84,7 @@ class Core:
         if host is None:
             self.comm = CommKernelDummy()
         else:
-            endian = "<" if self.target_cls.little_endian else ">"
-            self.comm = CommKernel(host, endian)
+            self.comm = CommKernel(host)
 
         self.first_run = True
         self.dmgr = dmgr

--- a/artiq/firmware/runtime/analyzer.rs
+++ b/artiq/firmware/runtime/analyzer.rs
@@ -51,6 +51,7 @@ fn worker(stream: &mut TcpStream) -> Result<(), IoError<SchedError>> {
     };
     debug!("{:?}", header);
 
+    stream.write_all("E".as_bytes())?;
     header.write_to(stream)?;
     if wraparound {
         stream.write_all(&data[pointer..])?;

--- a/artiq/firmware/runtime/mgmt.rs
+++ b/artiq/firmware/runtime/mgmt.rs
@@ -15,6 +15,7 @@ impl From<SchedError> for Error<SchedError> {
 
 fn worker(io: &Io, stream: &mut TcpStream) -> Result<(), Error<SchedError>> {
     read_magic(stream)?;
+    Write::write_all(stream, "E".as_bytes())?;
     info!("new connection from {}", stream.remote_endpoint());
 
     loop {

--- a/artiq/firmware/runtime/moninj.rs
+++ b/artiq/firmware/runtime/moninj.rs
@@ -2,6 +2,7 @@ use alloc::btree_map::BTreeMap;
 use core::cell::RefCell;
 
 use io::Error as IoError;
+use io::Write;
 use moninj_proto::*;
 use sched::{Io, Mutex, TcpListener, TcpStream, Error as SchedError};
 use urc::Urc;
@@ -122,6 +123,7 @@ fn connection_worker(io: &Io, _aux_mutex: &Mutex, _routing_table: &drtio_routing
     let mut next_check = 0;
 
     read_magic(&mut stream)?;
+    stream.write_all("E".as_bytes())?;
     info!("new connection from {}", stream.remote_endpoint());
 
     loop {

--- a/artiq/firmware/runtime/session.rs
+++ b/artiq/firmware/runtime/session.rs
@@ -615,6 +615,14 @@ pub fn thread(io: Io, aux_mutex: &Mutex,
                     continue
                 }
             }
+            match stream.write_all("E".as_bytes()) {
+                Ok(()) => (),
+                Err(_) => {
+                    warn!("cannot send endian byte");
+                    stream.close().expect("session: cannot close");
+                    continue
+                }
+            }
             info!("new connection from {}", stream.remote_endpoint());
 
             let aux_mutex = aux_mutex.clone();


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
Use device endian for protocols, to make protocols consistent and efficient.

The device would now send a byte at the start of the connection (after receiving magic string) indicating whether the device is using big endian or little endian, and the host would adjust the encoding/decoding according to device endian.

Notes:
1. This breaks existing protocols, users would need to update the firmware to match the host software.
2. Messages for analyzer is still big endian, as that seems to be coded in the gateware, and universal across or1k and zynq.

### Related Issue

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
