### PR TITLE
coredevice/adf5356: fix initial device detection

### DIFF
--- a/artiq/coredevice/adf5356.py
+++ b/artiq/coredevice/adf5356.py
@@ -82,18 +82,25 @@ class ADF5356:
         """
         if not blind:
             # MUXOUT = VDD
-            self.write(ADF5356_REG4_MUXOUT(1) | 4)
-            delay(5000 * us)
+            self.regs[4] = ADF5356_REG4_MUXOUT_UPDATE(self.regs[4], 1)
+            self.sync()
+            delay(1000 * us)
             if not self.read_muxout():
                 raise ValueError("MUXOUT not high")
-            delay(1000 * us)
+            delay(800 * us)
 
             # MUXOUT = DGND
-            self.write(ADF5356_REG4_MUXOUT(2) | 4)
-            delay(5000 * us)
+            self.regs[4] = ADF5356_REG4_MUXOUT_UPDATE(self.regs[4], 2)
+            self.sync()
+            delay(1000 * us)
             if self.read_muxout():
                 raise ValueError("MUXOUT not low")
-            delay(1000 * us)
+            delay(800 * us)
+
+            # MUXOUT = digital lock-detect
+            self.regs[4] = ADF5356_REG4_MUXOUT_UPDATE(self.regs[4], 6)
+        else:
+            self.sync()
 
     @kernel
     def set_att_mu(self, att):
@@ -430,9 +437,9 @@ class ADF5356:
         self.regs[6] |= ADF5356_REG6_NEGATIVE_BLEED(1)
 
         # charge pump bleed current
-        # self.regs[6] |= ADF5356_REG6_CP_BLEED_CURRENT(
-        #     int32(floor(24 * self.f_pfd / (61.44 * MHz)))
-        # )
+        self.regs[6] |= ADF5356_REG6_CP_BLEED_CURRENT(
+            int32(floor(24 * self.f_pfd() / (61.44 * MHz)))
+        )
 
         # direct feedback from VCO to N counter
         self.regs[6] |= ADF5356_REG6_FB_SELECT(1)
@@ -472,6 +479,10 @@ class ADF5356:
             ADF5356_REG9_SYNTH_LOCK_TIMEOUT(13)
             | ADF5356_REG9_AUTOCAL_TIMEOUT(31)
             | ADF5356_REG9_TIMEOUT(0x67)
+        )
+
+        self.regs[9] |= ADF5356_REG9_VCO_BAND_DIVISION(
+            int32(ceil(self.f_pfd() / 160e3))
         )
 
         # REG10


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

The ADF5356 apparently doesn't appreciate getting register changes without being properly initialized. This patch uses the documented register init sequence ([datasheet](https://www.analog.com/media/en/technical-documentation/data-sheets/ADF5356.pdf) Rev.0 p.32) to perform the detection test (deterministic MUXOUT values).

The slack delays were artificially high so I reduced them. May be that even shorter ones work but this is init so not crucial.

Tested on Mirny v1.0 and v1.1 hardware. Contrary to #1560, the PLL now locks on first try after power up.

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

Closes #1560 

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Close/update issues.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.


### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
