### PR TITLE
Prevent traceback at exit

### DIFF
--- a/artiq/frontend/aqctl_corelog.py
+++ b/artiq/frontend/aqctl_corelog.py
@@ -85,6 +85,8 @@ def main():
                 loop.run_until_complete(get_logs_task)
             except asyncio.CancelledError:
                 pass
+    except KeyboardInterrupt:
+        pass
     finally:
         loop.close()
 

--- a/artiq/frontend/artiq_master.py
+++ b/artiq/frontend/artiq_master.py
@@ -155,7 +155,10 @@ def main():
     atexit_register_coroutine(server_logging.stop)
 
     print("ARTIQ master is now ready.")
-    loop.run_forever()
+    try:
+        loop.run_forever()
+    except KeyboardInterrupt:
+        pass
 
 if __name__ == "__main__":
     main()

--- a/artiq/frontend/artiq_rtiomon.py
+++ b/artiq/frontend/artiq_rtiomon.py
@@ -31,6 +31,8 @@ def main():
             loop.run_forever()
         finally:
             loop.run_until_complete(comm.close())
+    except KeyboardInterrupt:
+        pass
     finally:
         loop.close()
 

--- a/artiq/frontend/artiq_session.py
+++ b/artiq/frontend/artiq_session.py
@@ -35,22 +35,25 @@ def main():
     dashboard_cmd += args.d
     ctlmgr_cmd    += args.c
 
-    with subprocess.Popen(master_cmd,
-                          stdout=subprocess.PIPE, universal_newlines=True,
-                          bufsize=1) as master:
-        master_ready = False
-        for line in iter(master.stdout.readline, ""):
-            sys.stdout.write(line)
-            if line.rstrip() == "ARTIQ master is now ready.":
-                master_ready = True
-                break
-        if master_ready:
-            with subprocess.Popen(dashboard_cmd):
-                with subprocess.Popen(ctlmgr_cmd):
-                    for line in iter(master.stdout.readline, ""):
-                        sys.stdout.write(line)
-        else:
-            print("session: master failed to start, exiting.")
+    try:
+        with subprocess.Popen(master_cmd,
+                              stdout=subprocess.PIPE, universal_newlines=True,
+                              bufsize=1) as master:
+            master_ready = False
+            for line in iter(master.stdout.readline, ""):
+                sys.stdout.write(line)
+                if line.rstrip() == "ARTIQ master is now ready.":
+                    master_ready = True
+                    break
+            if master_ready:
+                with subprocess.Popen(dashboard_cmd):
+                    with subprocess.Popen(ctlmgr_cmd):
+                        for line in iter(master.stdout.readline, ""):
+                            sys.stdout.write(line)
+            else:
+                print("session: master failed to start, exiting.")
+    except KeyboardInterrupt:
+        pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Just catching the `KeyboardInterrupt` in the frontends to prevent a traceback print at exit.

Please also merge https://github.com/m-labs/artiq-comtools/pull/8 .

Applies both to `release-5` and `master`.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.

Signed-off-by: Leon Riesebos <leon.riesebos@duke.edu>