### PR TITLE
mirny: hw_rev independent, human readable clk_sel

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -32,6 +32,8 @@ Highlights:
 * Zotino now exposes  ``voltage_to_mu()``
 * ``ad9910``: The maximum amplitude scale factor is now ``0x3fff`` (was ``0x3ffe``
   before).
+* Mirny now supports HW revision independent, human readable ``clk_sel`` parameters:
+  "XO", "SMA", and "MMCX". Passing an integer is backwards compatible.
 * Dashboard:
    - Applets now restart if they are running and a ccb call changes their spec
    - A "Quick Open" dialog to open experiments by typing part of their name can

--- a/artiq/coredevice/mirny.py
+++ b/artiq/coredevice/mirny.py
@@ -28,6 +28,9 @@ SPI_CS = 1
 
 WE = 1 << 24
 
+# supported CPLD code version
+PROTO_REV_MATCH = 0x0
+
 
 class Mirny:
     """
@@ -37,22 +40,39 @@ class Mirny:
     :param refclk: Reference clock (SMA, MMCX or on-board 100 MHz oscillator)
         frequency in Hz
     :param clk_sel: Reference clock selection.
-        valid options are: 0 - internal 100MHz XO; 1 - front-panel SMA; 2 -
-        internal MMCX
+        valid options are: "XO" - onboard crystal oscillator
+                           "SMA" - front-panel SMA connector
+                           "MMCX" - internal MMCX connector
+        Passing an integer writes its two least significant bits as ``clk_sel``
+        in the CPLD's register 1. The effect depends on the hardware revision.
     :param core_device: Core device name (default: "core")
     """
 
-    kernel_invariants = {"bus", "core"}
+    kernel_invariants = {"bus", "core", "refclk", "clk_sel_hw_rev"}
 
     def __init__(self, dmgr, spi_device, refclk=100e6, clk_sel=0, core_device="core"):
         self.core = dmgr.get(core_device)
         self.bus = dmgr.get(spi_device)
 
+        # reference clock frequency
         self.refclk = refclk
         assert 10 <= self.refclk / 1e6 <= 600, "Invalid refclk"
 
-        self.clk_sel = clk_sel & 0b11
-        assert 0 <= self.clk_sel <= 3, "Invalid clk_sel"
+        # reference clock selection
+        if isinstance(clk_sel, str):
+            self.clk_sel_hw_rev = {
+                # clk source: [v1.1, v1.0]
+                "xo": [0, 0],
+                "mmcx": [3, 2],
+                "sma": [2, 3],
+            }[clk_sel.lower()]
+        else:
+            clk_sel = int(clk_sel) & 0x3
+            self.clk_sel_hw_rev = [clk_sel] * 2
+        self.clk_sel = -1
+
+        # board hardware revision
+        self.hw_rev = 0  # v1.0: 0b11, v1.1: 0b10
 
         # TODO: support clk_div on v1.0 boards
 
@@ -78,15 +98,16 @@ class Mirny:
 
         :param blind: Do not attempt to verify presence and compatibility.
         """
+        reg0 = self.read_reg(0)
+        self.hw_rev = reg0 & 0x3
+
         if not blind:
-            reg0 = self.read_reg(0)
-            if reg0 & 0b11 != 0b11:
-                raise ValueError("Mirny HW_REV mismatch")
-            if (reg0 >> 2) & 0b11 != 0b00:
+            if (reg0 >> 2) & 0x3 != PROTO_REV_MATCH:
                 raise ValueError("Mirny PROTO_REV mismatch")
             delay(100 * us)  # slack
 
         # select clock source
+        self.clk_sel = self.clk_sel_hw_rev[self.hw_rev - 2]
         self.write_reg(1, (self.clk_sel << 4))
         delay(1000 * us)
 

--- a/artiq/coredevice/mirny.py
+++ b/artiq/coredevice/mirny.py
@@ -43,36 +43,41 @@ class Mirny:
         valid options are: "XO" - onboard crystal oscillator
                            "SMA" - front-panel SMA connector
                            "MMCX" - internal MMCX connector
-        Passing an integer writes its two least significant bits as ``clk_sel``
-        in the CPLD's register 1. The effect depends on the hardware revision.
+        Passing an integer writes it as ``clk_sel`` in the CPLD's register 1.
+        The effect depends on the hardware revision.
     :param core_device: Core device name (default: "core")
     """
 
     kernel_invariants = {"bus", "core", "refclk", "clk_sel_hw_rev"}
 
-    def __init__(self, dmgr, spi_device, refclk=100e6, clk_sel=0, core_device="core"):
+    def __init__(self, dmgr, spi_device, refclk=100e6, clk_sel="XO", core_device="core"):
         self.core = dmgr.get(core_device)
         self.bus = dmgr.get(spi_device)
 
         # reference clock frequency
         self.refclk = refclk
-        assert 10 <= self.refclk / 1e6 <= 600, "Invalid refclk"
+        if not (10 <= self.refclk / 1e6 <= 600):
+            raise ValueError("Invalid refclk")
 
         # reference clock selection
-        if isinstance(clk_sel, str):
+        try:
             self.clk_sel_hw_rev = {
-                # clk source: [v1.1, v1.0]
-                "xo": [0, 0],
-                "mmcx": [3, 2],
-                "sma": [2, 3],
+            # clk source: [reserved, reserved, v1.1, v1.0]
+                "xo": [-1, -1, 0, 0],
+                "mmcx": [-1, -1, 3, 2],
+                "sma": [-1, -1, 2, 3],
             }[clk_sel.lower()]
-        else:
-            clk_sel = int(clk_sel) & 0x3
-            self.clk_sel_hw_rev = [clk_sel] * 2
+        except AttributeError:  # not a string, fallback to int
+            if clk_sel & 0x3 != clk_sel:
+                raise ValueError("Invalid clk_sel") from None
+            self.clk_sel_hw_rev = [clk_sel] * 4
+        except KeyError:
+            raise ValueError("Invalid clk_sel") from None
+
         self.clk_sel = -1
 
         # board hardware revision
-        self.hw_rev = 0  # v1.0: 0b11, v1.1: 0b10
+        self.hw_rev = 0  # v1.0: 3, v1.1: 2
 
         # TODO: support clk_div on v1.0 boards
 
@@ -96,7 +101,10 @@ class Mirny:
         """
         Initialize and detect Mirny.
 
-        :param blind: Do not attempt to verify presence and compatibility.
+        Select the clock source based the board's hardware revision.
+        Raise ValueError if the board's hardware revision is not supported.
+
+        :param blind: Verify presence and protocol compatibility. Raise ValueError on failure.
         """
         reg0 = self.read_reg(0)
         self.hw_rev = reg0 & 0x3
@@ -107,7 +115,11 @@ class Mirny:
             delay(100 * us)  # slack
 
         # select clock source
-        self.clk_sel = self.clk_sel_hw_rev[self.hw_rev - 2]
+        self.clk_sel = self.clk_sel_hw_rev[self.hw_rev]
+
+        if self.clk_sel < 0:
+            raise ValueError("Hardware revision not supported")
+
         self.write_reg(1, (self.clk_sel << 4))
         delay(1000 * us)
 

--- a/artiq/frontend/artiq_sinara_tester.py
+++ b/artiq/frontend/artiq_sinara_tester.py
@@ -291,18 +291,7 @@ class SinaraTester(EnvExperiment):
     @kernel
     def init_mirny(self, cpld):
         self.core.break_realtime()
-        # Taken from Mirny.init(), to accomodate Mirny v1.1 without blinding
-        reg0 = cpld.read_reg(0)
-        if reg0 & 0b11 != 0b10:         # Modified part
-            raise ValueError("Mirny HW_REV mismatch")
-        if (reg0 >> 2) & 0b11 != 0b00:
-            raise ValueError("Mirny PROTO_REV mismatch")
-        delay(100 * us)  # slack
-
-        # select clock source
-        cpld.write_reg(1, (cpld.clk_sel << 4))
-        delay(1000 * us)
-        # End of modified Mirny.init()
+        cpld.init()
 
     @kernel
     def setup_mirny(self, channel, frequency):


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

This patch allows for hardware-revision independent user strings instead of integers for the Mirny reference clock selection. The relevant integer is calculated from the hardware revision read from the CPLD at ``init()``. The change is fully backwards compatible. The ``clk_sel`` functionality is identical to pre-existing code, but the interface is nicer.

Tested against v1.0 and v1.1 hardware on all three global clock sources.

``hw_rev`` is not tested anymore in ``init()``. Removed corresponding fix in ``artiq_sinara_tester``.

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:
-->

Closes #1559 (updated docstring)

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
|  | :hammer: Refactoring  |
|  | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Close/update issues.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
