### PR TITLE
tools/file_import: simplify, remove deprecated load_module() call

### DIFF
--- a/artiq/tools.py
+++ b/artiq/tools.py
@@ -1,7 +1,8 @@
 import asyncio
-import importlib.machinery
+import importlib.util
 import logging
 import os
+import pathlib
 import string
 import sys
 
@@ -69,20 +70,16 @@ def short_format(v):
 
 
 def file_import(filename, prefix="file_import_"):
-    modname = filename
-    i = modname.rfind("/")
-    if i > 0:
-        modname = modname[i+1:]
-    i = modname.find(".")
-    if i > 0:
-        modname = modname[:i]
-    modname = prefix + modname
+    filename = pathlib.Path(filename)
+    modname = prefix + filename.stem
 
-    path = os.path.dirname(os.path.realpath(filename))
+    path = str(filename.resolve().parent)
     sys.path.insert(0, path)
+
     try:
-        loader = importlib.machinery.SourceFileLoader(modname, filename)
-        module = loader.load_module()
+        spec = importlib.util.spec_from_file_location(modname, filename)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
     finally:
         sys.path.remove(path)
 


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

This patch is a rewrite of ``artiq.tools.file_import`` with the following changes:

  - simplify the calculation of the loaded module's name. The new code is equivalent to the old one except if the filename has multiple extensions (e.g. ``exp.test.py``) in which case the resulting module name is not a valid Python identifier but the loader should still work as expected. This should not happen in practice since the filename also doesn't stick to Python module naming conventions. One can revert to the old code if this is an issue (not the core of the PR) but the new one-liner is much more explicit than the old code;
  - remove the deprecated call to ``load_module()`` by applying the ``exec_module()``-based recipe from the [docs](https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly).

I tested for basic functionality with ``artiq_client`` (with and without git support) and ``artiq_run``.

### Related Issue

Closes #1203 

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |
|   | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Close/update issues.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [ ] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)


### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
