### PR TITLE
master: unify experiments enumeration (+ some tooling unit tests)

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -64,6 +64,8 @@ Breaking changes:
 * ``quamash`` has been replaced with ``qasync``.
 * Protocols are updated to use device endian.
 * Analyzer dump format includes a byte for device endianness.
+* Experiment classes with underscore-prefixed names are now ignored when ``artiq_client``
+  determines which experiment to submit (consistent with ``artiq_run``).
 
 ARTIQ-5
 -------

--- a/artiq/language/environment.py
+++ b/artiq/language/environment.py
@@ -488,3 +488,10 @@ def is_experiment(o):
         and issubclass(o, Experiment)
         and o is not Experiment
         and o is not EnvExperiment)
+
+
+def is_public_experiment(o):
+    """Checks if a Pyhton object is a top-level,
+    non underscore-prefixed, experiment class.
+    """
+    return is_experiment(o) and not o.__name__.startswith("_")

--- a/artiq/master/worker_impl.py
+++ b/artiq/master/worker_impl.py
@@ -9,6 +9,7 @@ process via IPC.
 import sys
 import time
 import os
+import inspect
 import logging
 import traceback
 from collections import OrderedDict
@@ -20,10 +21,11 @@ from sipyco.packed_exceptions import raise_packed_exc
 from sipyco.logging_tools import multiline_log_config
 
 import artiq
-from artiq.tools import file_import
+from artiq import tools
 from artiq.master.worker_db import DeviceManager, DatasetManager, DummyDevice
-from artiq.language.environment import (is_experiment, TraceArgumentManager,
-                                        ProcessArgumentManager)
+from artiq.language.environment import (
+    is_public_experiment, TraceArgumentManager, ProcessArgumentManager
+)
 from artiq.language.core import set_watchdog_factory, TerminationRequested
 from artiq.language.types import TBool
 from artiq.compiler import import_cache
@@ -127,17 +129,9 @@ class CCB:
     issue = staticmethod(make_parent_action("ccb_issue"))
 
 
-def get_exp(file, class_name):
-    module = file_import(file, prefix="artiq_worker_")
-    if class_name is None:
-        exps = [v for k, v in module.__dict__.items()
-                if is_experiment(v)]
-        if len(exps) != 1:
-            raise ValueError("Found {} experiments in module"
-                             .format(len(exps)))
-        return exps[0]
-    else:
-        return getattr(module, class_name)
+def get_experiment(file, class_name):
+    module = tools.file_import(file, prefix="artiq_worker_")
+    return tools.get_experiment(module, class_name)
 
 
 register_experiment = make_parent_action("register_experiment")
@@ -164,24 +158,24 @@ class ExamineDatasetMgr:
 def examine(device_mgr, dataset_mgr, file):
     previous_keys = set(sys.modules.keys())
     try:
-        module = file_import(file)
-        for class_name, exp_class in module.__dict__.items():
-            if class_name[0] == "_":
-                continue
-            if is_experiment(exp_class):
-                if exp_class.__doc__ is None:
-                    name = class_name
-                else:
-                    name = exp_class.__doc__.strip().splitlines()[0].strip()
-                    if name[-1] == ".":
-                        name = name[:-1]
-                argument_mgr = TraceArgumentManager()
-                scheduler_defaults = {}
-                cls = exp_class((device_mgr, dataset_mgr, argument_mgr, scheduler_defaults))
-                arginfo = OrderedDict(
-                    (k, (proc.describe(), group, tooltip))
-                    for k, (proc, group, tooltip) in argument_mgr.requested_args.items())
-                register_experiment(class_name, name, arginfo, scheduler_defaults)
+        module = tools.file_import(file)
+        for class_name, exp_class in inspect.getmembers(module, is_public_experiment):
+            if exp_class.__doc__ is None:
+                name = class_name
+            else:
+                name = exp_class.__doc__.strip().splitlines()[0].strip()
+                if name[-1] == ".":
+                    name = name[:-1]
+            argument_mgr = TraceArgumentManager()
+            scheduler_defaults = {}
+            cls = exp_class(  # noqa: F841 (fill argument_mgr)
+                (device_mgr, dataset_mgr, argument_mgr, scheduler_defaults)
+            )
+            arginfo = OrderedDict(
+                (k, (proc.describe(), group, tooltip))
+                for k, (proc, group, tooltip) in argument_mgr.requested_args.items()
+            )
+            register_experiment(class_name, name, arginfo, scheduler_defaults)
     finally:
         new_keys = set(sys.modules.keys())
         for key in new_keys - previous_keys:
@@ -285,7 +279,7 @@ def main():
                     experiment_file = expid["file"]
                     repository_path = None
                 setup_diagnostics(experiment_file, repository_path)
-                exp = get_exp(experiment_file, expid["class_name"])
+                exp = get_experiment(experiment_file, expid["class_name"])
                 device_mgr.virtual_devices["scheduler"].set_run_info(
                     rid, obj["pipeline_name"], expid, obj["priority"])
                 start_local_time = time.localtime(start_time)

--- a/artiq/test/test_tools.py
+++ b/artiq/test/test_tools.py
@@ -1,0 +1,118 @@
+from contextlib import contextmanager
+import unittest
+from pathlib import Path
+import tempfile
+
+from artiq import tools
+
+
+# Helper to create temporary modules
+# Very simplified version of CPython's
+# Lib/test/test_importlib/util.py:create_modules
+@contextmanager
+def create_modules(*names):
+    mapping = {}
+    with tempfile.TemporaryDirectory() as temp_dir:
+        mapping[".root"] = Path(temp_dir)
+
+        for name in names:
+            file_path = Path(temp_dir) / f"{name}.py"
+            with file_path.open("w") as fp:
+                print(f"_MODULE_NAME = {name!r}", file=fp)
+            mapping[name] = file_path
+
+        yield mapping
+
+
+MODNAME = "modname"
+
+
+class TestFileImport(unittest.TestCase):
+    def test_import_and_prefix_is_present(self):
+        prefix = "prefix_"
+        with create_modules(MODNAME) as mods:
+            mod = tools.file_import(str(mods[MODNAME]), prefix=prefix)
+            self.assertEqual(prefix + MODNAME, mod.__name__)
+
+    def test_can_import_from_same_level(self):
+        m1_name, m2_name = "mod1", "mod2"
+        with create_modules(m1_name, m2_name) as mods:
+            with mods[m2_name].open("a") as fp:
+                print(f"from {m1_name} import _MODULE_NAME as _M1_NAME", file=fp)
+
+            mod1 = tools.file_import(str(mods[m1_name]))
+            mod2 = tools.file_import(str(mods[m2_name]))
+
+            self.assertEqual(mod2._M1_NAME, mod1._MODULE_NAME)
+
+
+class TestGetExperiment(unittest.TestCase):
+    def test_fail_no_experiments(self):
+        with create_modules(MODNAME) as mods:
+            mod = tools.file_import(str(mods[MODNAME]))
+            with self.assertRaises(ValueError):
+                tools.get_experiment(mod)
+
+    def test_fail_hidden_experiment(self):
+        with create_modules(MODNAME) as mods:
+            with mods[MODNAME].open("a") as fp:
+                print(
+                    """
+from artiq.experiment import *
+
+class _Exp1(EnvExperiment):
+    pass
+                """,
+                    file=fp,
+                )
+
+            mod = tools.file_import(str(mods[MODNAME]))
+            with self.assertRaises(ValueError):
+                tools.get_experiment(mod)
+
+    def test_multiple_experiments(self):
+        with create_modules(MODNAME) as mods:
+            with mods[MODNAME].open("a") as fp:
+                print(
+                    """
+from artiq.experiment import *
+
+class Exp1(EnvExperiment):
+    pass
+
+class Exp2(EnvExperiment):
+    pass
+                """,
+                    file=fp,
+                )
+
+            mod = tools.file_import(str(mods[MODNAME]))
+
+            # by class name
+            self.assertIs(mod.Exp1, tools.get_experiment(mod, "Exp1"))
+            self.assertIs(mod.Exp2, tools.get_experiment(mod, "Exp2"))
+
+            # by elimination should fail
+            with self.assertRaises(ValueError):
+                tools.get_experiment(mod)
+
+    def test_single_experiment(self):
+        with create_modules(MODNAME) as mods:
+            with mods[MODNAME].open("a") as fp:
+                print(
+                    """
+from artiq.experiment import *
+
+class Exp1(EnvExperiment):
+    pass
+                """,
+                    file=fp,
+                )
+
+            mod = tools.file_import(str(mods[MODNAME]))
+
+            # by class name
+            self.assertIs(mod.Exp1, tools.get_experiment(mod, "Exp1"))
+
+            # by elimination
+            self.assertIs(mod.Exp1, tools.get_experiment(mod))

--- a/artiq/tools.py
+++ b/artiq/tools.py
@@ -1,5 +1,6 @@
 import asyncio
 import importlib.util
+import inspect
 import logging
 import os
 import pathlib
@@ -12,7 +13,7 @@ from sipyco import pyon
 
 from artiq import __version__ as artiq_version
 from artiq.appdirs import user_config_dir
-from artiq.language.environment import is_experiment
+from artiq.language.environment import is_public_experiment
 
 
 __all__ = ["parse_arguments", "elide", "short_format", "file_import",
@@ -90,12 +91,13 @@ def get_experiment(module, class_name=None):
     if class_name:
         return getattr(module, class_name)
 
-    exps = [(k, v) for k, v in module.__dict__.items()
-            if k[0] != "_" and is_experiment(v)]
+    exps = inspect.getmembers(module, is_public_experiment)
+
     if not exps:
         raise ValueError("No experiments in module")
     if len(exps) > 1:
         raise ValueError("More than one experiment found in module")
+
     return exps[0][1]
 
 


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

This patch:

  - refactors the enumeration of experiments from Python modules in ``artiq.master.worker_impl``. In particular, it now uses ``tools.get_experiment`` instead of an almost literal copy of it. This unifies the behavior with ``artiq_run`` and ``artiq_compile`` (or was there a reason not to exclude underscore-prefixed experiments in the master's ``get_exp``?);

  - rewrites ``tools.get_experiment`` with ``inspect.getmembers`` instead of ``__dict__``. Introduces a new predicate ``language.is_public_experiment``. The existing ``language.is_experiment`` is not used anywhere in the codebase but is part of the public API. These predicates (or maybe only one) should maybe be moved to ``artiq.tools`` (+ release notes entry);

  - rewrites ``master/worker_impl:examine`` with ``inspect.getmembers`` (simpler);

  - adds units tests for ``tools.file_import`` (I almost broke it in #1605)  and ``tools.get_experiment``.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
|   | :bug: Bug fix  |
|   | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |
|   | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)


### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
