### PR TITLE
added max_kernel_size argument to core driver

### DIFF
--- a/artiq/test/coredevice/test_core.py
+++ b/artiq/test/coredevice/test_core.py
@@ -1,0 +1,92 @@
+import unittest
+import logging
+import numpy as np
+
+from artiq.experiment import kernel
+
+import artiq.coredevice.core
+
+
+class _Core(artiq.coredevice.core.Core):
+    def __init__(self, *args, **kwargs):
+        super(_Core, self).__init__(*args, **kwargs)
+        self.dmgr['core'] = self
+        self.kernel_size = 0
+
+    def compile(self, *args, **kwargs):
+        embedding_map, kernel_library, symbolizer, demangler = \
+            super(_Core, self).compile(*args, **kwargs)
+        self.kernel_size = len(kernel_library)
+        return embedding_map, kernel_library, symbolizer, demangler
+
+
+class CoreTestCase(unittest.TestCase):
+
+    def test_string_to_bytes(self):
+        data = [
+            ('0b', 0),
+            ('15b', 15),
+            ('1kb', 1 * 1000 ** 1),
+            ('1 kb', 1 * 1000 ** 1),
+            ('   1   kb  ', 1 * 1000 ** 1),
+            ('1KB', 1 * 1000 ** 1),
+            ('1kB', 1 * 1000 ** 1),
+            ('2kb', 2 * 1000 ** 1),
+            ('323 kb', 323 * 1000 ** 1),
+            ('3 mb', 3 * 1000 ** 2),
+            ('77gb', 77 * 1000 ** 3),
+            ('7kib', 7 * 1024 ** 1),
+            ('7mib', 7 * 1024 ** 2),
+            ('7gib', 7 * 1024 ** 3),
+            ('7 gib', 7 * 1024 ** 3),
+            ('7 GiB', 7 * 1024 ** 3),
+        ]
+
+        for s, r in data:
+            self.assertEqual(artiq.coredevice.core._str_to_bytes(s), r)
+
+
+class CoreCompilingTestCase(unittest.TestCase):
+
+    def _set_core(self, **kwargs):
+        kwargs.setdefault('host', None)
+        kwargs.setdefault('ref_period', 1e-9)
+        self._update_kernel_invariants('core', clear=True)
+        self.core = _Core({}, **kwargs)
+
+    def _update_kernel_invariants(self, *args: str, clear: bool = False) -> None:
+        kernel_invariants = set() if clear else getattr(self, 'kernel_invariants', set())
+        self.kernel_invariants = kernel_invariants | set(args)
+
+    def test_max_kernel_size(self):
+        # Calculate reference size
+        self._set_core()
+        self.data = np.empty(1, dtype=np.int32)
+        self._update_kernel_invariants('data')
+        self._kernel()
+        ref_size = self.core.kernel_size - 4  # Minus the one element used for testing the size
+
+        sizes = [100, 256, 300, 512]
+
+        for size in sizes:
+            self._set_core(max_kernel_size='{}b'.format(size * 4 + ref_size))
+            self.data = np.empty(size, dtype=np.int32)
+            self._update_kernel_invariants('data')
+            self._kernel()  # Fits exactly, does not raise
+            with self.assertRaises(artiq.coredevice.core.KernelSizeException,
+                                   msg='Kernel size exception did not raise'):
+                self.data = np.empty(size + 1, dtype=np.int32)
+                self._kernel()  # One byte too big, should raise
+
+    def test_log(self):
+        self._set_core()
+        self.data = np.empty(1, dtype=np.int32)
+        self._update_kernel_invariants('data')
+        with self.assertLogs(artiq.coredevice.core.logger, logging.DEBUG):
+            self._kernel()
+
+    @kernel
+    def _kernel(self):
+        # Address `data` to get it compiled
+        for d in self.data:
+            print(d)


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Add an option to the core driver to limit the maximum (static) kernel size before it is loaded to the core device.

I do not know if there is any interest in such a feature, feel free to close this PR if there is not.

### Related Issue

A way to prevent loading kernels that are too large while waiting for #544.

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Close/update issues.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

- [x] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
