### PR TITLE
get_experiment() can get nested experiment classes

### DIFF
--- a/artiq/test/test_tools.py
+++ b/artiq/test/test_tools.py
@@ -116,3 +116,26 @@ class Exp1(EnvExperiment):
 
             # by elimination
             self.assertIs(mod.Exp1, tools.get_experiment(mod))
+
+    def test_nested_experiment(self):
+        with create_modules(MODNAME) as mods:
+            with mods[MODNAME].open("a") as fp:
+                print(
+                    """
+from artiq.experiment import *
+
+class Foo:
+    class Exp1(EnvExperiment):
+        pass
+                """,
+                    file=fp,
+                )
+
+            mod = tools.file_import(str(mods[MODNAME]))
+
+            # by class name
+            self.assertIs(mod.Foo.Exp1, tools.get_experiment(mod, "Foo.Exp1"))
+
+            # by elimination should fail
+            with self.assertRaises(ValueError):
+                tools.get_experiment(mod)

--- a/artiq/tools.py
+++ b/artiq/tools.py
@@ -89,7 +89,10 @@ def file_import(filename, prefix="file_import_"):
 
 def get_experiment(module, class_name=None):
     if class_name:
-        return getattr(module, class_name)
+        obj = module
+        for name in class_name.split('.'):
+            obj = getattr(obj, name)
+        return obj
 
     exps = inspect.getmembers(module, is_public_experiment)
 


### PR DESCRIPTION
Signed-off-by: Leon Riesebos <leon.riesebos@duke.edu>

<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

The `artiq.tools.get_experiment()` function can now get nested experiment classes.
For example: `artiq.tools.get_experiment(mod, 'Foo.Bar')`.

Not sure if other people are interested in such a feature. We are interested because in this way we can "generate" experiment classes inside other classes that are not experiments. We use this in some specific scenario's. Without this feature, we have to mess with the stack frame to insert the nested class into the global name space for ARTIQ to be able to find it.

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Close/update issues.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

- [x] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
