### PR TITLE
fastino: ensure `xxx_to_mu()` methods return int32 on the host

### DIFF
--- a/artiq/coredevice/fastino.py
+++ b/artiq/coredevice/fastino.py
@@ -1,6 +1,7 @@
 """RTIO driver for the Fastino 32channel, 16 bit, 2.5 MS/s per channel,
 streaming DAC.
 """
+from numpy import int32
 
 from artiq.language.core import kernel, portable, delay
 from artiq.coredevice.rtio import (rtio_output, rtio_output_wide,
@@ -112,7 +113,7 @@ class Fastino:
         :param voltage: Voltage in SI Volts.
         :return: DAC data word in machine units, 16 bit integer.
         """
-        data = int(round((0x8000/10.)*voltage)) + 0x8000
+        data = int32(round((0x8000/10.)*voltage)) + int32(0x8000)
         if data < 0 or data > 0xffff:
             raise ValueError("DAC voltage out of bounds")
         return data
@@ -129,7 +130,7 @@ class Fastino:
             v = self.voltage_to_mu(voltage[i])
             if i & 1:
                 v = data[i // 2] | (v << 16)
-            data[i // 2] = v
+            data[i // 2] = int32(v)
 
     @kernel
     def set_dac(self, dac, voltage):


### PR DESCRIPTION

<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request
## Fastino "to_mu" return type fixes
## Description of Changes

Currently running `voltage_to_mu()` or `voltage_group_to_mu()` on the host will
convert all machine unit values to int64. This leads to issues when machine units
are returned from RPCs.

This PR allows `xxx_to_mu()` methods for Fastino to return the required int32 type on the core and host device.

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) Minor bug fix. I'm also not aware of other Fastino users at this time.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Tested by setting and verifying fastino voltages with `xxx_to_mu` calculated on the core and host device.

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
