### PR TITLE
jsonschema: Accept String for mirny clk_sel, and fix styling

### DIFF
--- a/artiq/coredevice/coredevice_generic.schema.json
+++ b/artiq/coredevice/coredevice_generic.schema.json
@@ -364,17 +364,26 @@
                             "minItems": 1,
                             "maxItems": 1
                         },
-		        "refclk": {
-		            "type": "number",
-		            "exclusiveMinimum": 0,
+        		        "refclk": {
+        		            "type": "number",
+        		            "exclusiveMinimum": 0,
                             "default": 100e6
-		        },
-		        "clk_sel": {
-		            "type": "integer",
-		            "minimum": 0,
-		            "maximum": 3,
-                            "default": 0
-		       }
+        		        },
+        		        "clk_sel": {
+                            "oneOf": [
+                                {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "maximum": 3,
+                                    "default": 0
+                                },
+                                {
+                                    "type": "string",
+                                    "enum": ["xo", "mmcx", "sma"],
+                                    "default": "xo"
+                                }
+                            ]
+    		            }
                     },
                     "required": ["ports"]
                 }

--- a/artiq/coredevice/coredevice_generic.schema.json
+++ b/artiq/coredevice/coredevice_generic.schema.json
@@ -175,24 +175,24 @@
                             "type": "boolean",
                             "default": false
                         },
-		        "refclk": {
-		            "type": "number",
-		            "minimum": 0
-		        },
-		        "clk_sel": {
-		            "type": "integer",
-		            "minimum": 0,
-		            "maximum": 3
-		        },
-		        "clk_div": {
-		            "type": "integer",
-		            "minimum": 0,
-		            "maximum": 3
-		        },
-		        "pll_n": {
+                        "refclk": {
+                            "type": "number",
+                            "minimum": 0
+                        },
+                        "clk_sel": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 3
+                        },
+                        "clk_div": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 3
+                        },
+                        "pll_n": {
                             "type": "integer"
                         },
-		        "pll_vco": {
+                        "pll_vco": {
                             "type": "integer"
                         },
                         "dds": {
@@ -282,20 +282,20 @@
                             "minItems": 2,
                             "maxItems": 2
                         },
-		        "refclk": {
-		            "type": "number",
-		            "minimum": 0
-		        },
-		        "clk_sel": {
-		            "type": "integer",
-		            "minimum": 0,
-		            "maximum": 3
-		        },
-		        "pll_n": {
+                        "refclk": {
+                            "type": "number",
+                            "minimum": 0
+                        },
+                        "clk_sel": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 3
+                        },
+                        "pll_n": {
                             "type": "integer",
                             "default": 32
                         },
-		        "pll_vco": {
+                        "pll_vco": {
                             "type": "integer"
                         }
                     },
@@ -364,12 +364,12 @@
                             "minItems": 1,
                             "maxItems": 1
                         },
-        		        "refclk": {
-        		            "type": "number",
-        		            "exclusiveMinimum": 0,
+                        "refclk": {
+                            "type": "number",
+                            "exclusiveMinimum": 0,
                             "default": 100e6
-        		        },
-        		        "clk_sel": {
+                        },
+                        "clk_sel": {
                             "oneOf": [
                                 {
                                     "type": "integer",
@@ -383,7 +383,7 @@
                                     "default": "xo"
                                 }
                             ]
-    		            }
+                        }
                     },
                     "required": ["ports"]
                 }

--- a/artiq/frontend/artiq_ddb_template.py
+++ b/artiq/frontend/artiq_ddb_template.py
@@ -268,6 +268,9 @@ class PeripheralManager:
                 name=mirny_name,
                 mchn=i)
 
+        clk_sel = peripheral["clk_sel"]
+        if isinstance(peripheral["clk_sel"], str):
+            clk_sel = '"' + peripheral["clk_sel"] + '"'
         self.gen("""
             device_db["{name}_cpld"] = {{
                 "type": "local",
@@ -281,7 +284,7 @@ class PeripheralManager:
             }}""",
             name=mirny_name,
             refclk=peripheral["refclk"],
-            clk_sel=peripheral["clk_sel"])
+            clk_sel=clk_sel)
 
         return next(channel)
 


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Added by #1601, Mirny now allows the user to indicate the clock selection by one of the following:

* Integer: must be 0, 1, 2 or 3, where the user must choose according to the Mirny board version
* String enum: must be `xo`, `mmcx` or `sma`, where the driver code finds the correct integer value by reading the Mirny board version at initialisation.

Therefore, it is reasonable to add support for both types when validating with jsonschema. This PR also changes `artiq_ddb_template` to ensure double-quoting `clk_sel` when it is a string.

This PR also fixes some styling on jsonschema where `\t` and space characters were mixed.

## Type of Changes

|   | Type |
| ------------- | ------------- |
|   | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |
