### PR TITLE
jsonschema: mirny: fix clk_sel default value

### DIFF
--- a/artiq/coredevice/coredevice_generic.schema.json
+++ b/artiq/coredevice/coredevice_generic.schema.json
@@ -374,15 +374,14 @@
                                 {
                                     "type": "integer",
                                     "minimum": 0,
-                                    "maximum": 3,
-                                    "default": 0
+                                    "maximum": 3
                                 },
                                 {
                                     "type": "string",
-                                    "enum": ["xo", "mmcx", "sma"],
-                                    "default": "xo"
+                                    "enum": ["xo", "mmcx", "sma"]
                                 }
-                            ]
+                            ],
+                            "default": 0
                         }
                     },
                     "required": ["ports"]


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

In #1646, I made a mistake by misplacing the default value for Mirny `clk_sel` in the schema, which rendered the `default` keyword useless. This PR fixes this bug and takes the integer value `0` (representing `xo` for both Mirny versions 1.0 and 1.1) as default.

I chose the integer value as default simply so as to be consistent with the original schema. Should we use `xo` instead?
https://github.com/m-labs/artiq/blob/3844cde97b6445410b95976403ea49cb75914d79/artiq/coredevice/coredevice_generic.schema.json#L372-L377

*This fix is also applicable to ARTIQ-6 as of dbeea7605b8becdace69c893d83a08e10b93a95e, though rebasing would be required.*

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓ | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |
