### PR TITLE
Phaser

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -9,8 +9,17 @@ ARTIQ-7
 Highlights:
 * WRPLL
 * ``get()``, ``get_mu()``, ``get_att()``, and ``get_att_mu()`` functions added for AD9910 and AD9912
+* Phaser:
+   - Improved documentation
+   - Expose the DAC coarse mixer and sif_sync
+   - Exposes upconverter calibration and enabling/disabling of upconverter LO & RF outputs.
 
 Breaking changes:
+* Updated Phaser-Upconverter default frequency 2.875 GHz. The new default uses the target PFD
+  frequency of the hardware design.
+* `Phaser.init()` now disables all Kasli-oscillators. This avoids full power RF output being
+  generated for some configurations.
+* Phaser: fixed coarse mixer frequency configuration
 
 
 ARTIQ-6

--- a/artiq/coredevice/dac34h84.py
+++ b/artiq/coredevice/dac34h84.py
@@ -201,7 +201,7 @@ class DAC34H84:
         mmap.append(
             (0x0d << 16) |
             (self.cmix_fs8 << 15) | (self.cmix_fs4 << 14) |
-            (self.cmix_fs2 << 12) | (self.cmix_nfs4 << 11) |
+            (self.cmix_fs2 << 13) | (self.cmix_nfs4 << 12) |
             (self.qmc_gainb << 0))
         mmap.append((0x0e << 16) | (self.qmc_gainc << 0))
         mmap.append(

--- a/artiq/coredevice/dac34h84.py
+++ b/artiq/coredevice/dac34h84.py
@@ -178,7 +178,8 @@ class DAC34H84:
             (self.collisiongone_ena << 12) | (self.sif4_ena << 7) |
             (self.mixer_ena << 6) | (self.mixer_gain << 5) |
             (self.nco_ena << 4) | (self.revbus << 3) | (self.twos << 1))
-        mmap.append((0x03 << 16) | (self.coarse_dac << 12) | (self.sif_txenable << 0))
+        mmap.append((0x03 << 16) | (self.coarse_dac << 12) |
+                    (self.sif_txenable << 0))
         mmap.append(
             (0x07 << 16) |
             (self.mask_alarm_from_zerochk << 15) | (1 << 14) |

--- a/artiq/coredevice/dac34h84.py
+++ b/artiq/coredevice/dac34h84.py
@@ -110,7 +110,7 @@ class DAC34H84:
     syncsel_mixercd = 0b1001  # sif_sync and register write
     syncsel_nco = 0b1000  # sif_sync
     syncsel_fifo_input = 0b10  # external lvds istr
-    sif_sync = 1
+    sif_sync = 0
 
     syncsel_fifoin = 0b0010  # istr
     syncsel_fifoout = 0b0100  # ostr

--- a/artiq/coredevice/phaser.py
+++ b/artiq/coredevice/phaser.py
@@ -1,6 +1,8 @@
+from numpy import int32, int64
+
 from artiq.language.core import kernel, delay_mu, delay
 from artiq.coredevice.rtio import rtio_output, rtio_input_data
-from artiq.language.units import us, ns, ms, MHz, dB
+from artiq.language.units import us, ns, ms, MHz
 from artiq.language.types import TInt32
 from artiq.coredevice.dac34h84 import DAC34H84
 from artiq.coredevice.trf372017 import TRF372017

--- a/artiq/coredevice/phaser.py
+++ b/artiq/coredevice/phaser.py
@@ -889,7 +889,7 @@ class PhaserChannel:
         :param phase: NCO phase in turns
         """
         pow = int32(round(phase*(1 << 16)))
-        self.set_duc_phase_mu(pow)
+        self.set_nco_phase_mu(pow)
 
     @kernel
     def set_att_mu(self, data):

--- a/artiq/coredevice/phaser.py
+++ b/artiq/coredevice/phaser.py
@@ -279,6 +279,16 @@ class Phaser:
             else:
                 raise ValueError("DAC alarm")
 
+        # avoid malformed output for: mixer_ena=1, nco_ena=0 after power up
+        self.dac_write(self.dac_mmap[2] >> 16, self.dac_mmap[2] | (1 << 4))
+        delay(40*us)
+        self.dac_sync()
+        delay(100*us)
+        self.dac_write(self.dac_mmap[2] >> 16, self.dac_mmap[2])
+        delay(40*us)
+        self.dac_sync()
+        delay(100*us)
+
         # power up trfs, release att reset
         self.set_cfg(clk_sel=self.clk_sel, dac_txena=0)
 

--- a/artiq/coredevice/phaser.py
+++ b/artiq/coredevice/phaser.py
@@ -186,6 +186,9 @@ class Phaser:
         is_baseband = hw_rev & PHASER_HW_REV_VARIANT
 
         gw_rev = self.read8(PHASER_ADDR_GW_REV)
+        if debug:
+            print(gw_rev)
+            self.core.break_realtime()
         delay(.1*ms)  # slack
 
         # allow a few errors during startup and alignment since boot

--- a/artiq/coredevice/phaser.py
+++ b/artiq/coredevice/phaser.py
@@ -306,6 +306,9 @@ class Phaser:
             self.duc_stb()
             delay(.1*ms)  # settle link, pipeline and impulse response
             data = channel.get_dac_data()
+            delay(1*us)
+            channel.oscillator[0].set_amplitude_phase_mu(asf=0, pow=0xc000,
+                                                         clr=1)
             delay(.1*ms)
             sqrt2 = 0x5a81  # 0x7fff/sqrt(2)
             data_i = data & 0xffff

--- a/artiq/coredevice/trf372017.py
+++ b/artiq/coredevice/trf372017.py
@@ -11,7 +11,7 @@ class TRF372017:
     icp_double = 0
     cal_clk_sel = 12  # /16, 4b
 
-    ndiv = 420  # 16b
+    nint = 420  # 16b
     pll_div_sel = 0  # /1, 2b
     prsc_sel = 1  # 8/9
     vco_sel = 2  # 2b
@@ -92,7 +92,7 @@ class TRF372017:
             (self.cal_clk_sel << 27))
         mmap.append(
             0xa |
-            (self.ndiv << 5) | (self.pll_div_sel << 21) |
+            (self.nint << 5) | (self.pll_div_sel << 21) |
             (self.prsc_sel << 23) | (self.vco_sel << 26) |
             (self.vcosel_mode << 28) | (self.cal_acc << 29) |
             (self.en_cal << 31))

--- a/artiq/coredevice/trf372017.py
+++ b/artiq/coredevice/trf372017.py
@@ -92,9 +92,10 @@ class TRF372017:
             (self.cal_clk_sel << 27))
         mmap.append(
             0xa |
-            (self.ndiv << 5) | (self.pll_div_sel << 21) | (self.prsc_sel << 23) |
-            (self.vco_sel << 26) | (self.vcosel_mode << 28) |
-            (self.cal_acc << 29) | (self.en_cal << 31))
+            (self.ndiv << 5) | (self.pll_div_sel << 21) |
+            (self.prsc_sel << 23) | (self.vco_sel << 26) |
+            (self.vcosel_mode << 28) | (self.cal_acc << 29) |
+            (self.en_cal << 31))
         mmap.append(0xb | (self.nfrac << 5))
         mmap.append(
             0xc |

--- a/artiq/coredevice/trf372017.py
+++ b/artiq/coredevice/trf372017.py
@@ -17,7 +17,7 @@ class TRF372017:
     vco_sel = 2  # 2b
     vcosel_mode = 0
     cal_acc = 0b00  # 2b
-    en_cal = 1
+    en_cal = 0  # leave at 0 - calibration is performed in `Phaser.init()`
 
     nfrac = 0  # 25b
 
@@ -27,9 +27,9 @@ class TRF372017:
     pwd_vcomux = 0
     pwd_div124 = 0
     pwd_presc = 0
-    pwd_out_buff = 1
-    pwd_lo_div = 1
-    pwd_tx_div = 0
+    pwd_out_buff = 1  # leave at 1 - only enable outputs after calibration
+    pwd_lo_div = 1  # leave at 1 - only enable outputs after calibration
+    pwd_tx_div = 1  # leave at 1 - only enable outputs after calibration
     pwd_bb_vcm = 0
     pwd_dc_off = 0
     en_extvco = 0
@@ -84,6 +84,7 @@ class TRF372017:
             setattr(self, key, value)
 
     def get_mmap(self):
+        """Memory map for TRF372017"""
         mmap = []
         mmap.append(
             0x9 |

--- a/artiq/coredevice/trf372017.py
+++ b/artiq/coredevice/trf372017.py
@@ -4,16 +4,17 @@ class TRF372017:
     For possible values, documentation, and explanation, see the datasheet.
     https://www.ti.com/lit/gpn/trf372017
     """
-    rdiv = 21  # 13b
+    rdiv = 2  # 13b - highest valid f_PFD
     ref_inv = 0
     neg_vco = 1
     icp = 0  # 1.94 mA, 5b
     icp_double = 0
-    cal_clk_sel = 12  # /16, 4b
+    cal_clk_sel = 0b1110  # div64, 4b
 
-    nint = 420  # 16b
-    pll_div_sel = 0  # /1, 2b
-    prsc_sel = 1  # 8/9
+    # default f_vco is 2.875 GHz
+    nint = 23  # 16b - lowest value suitable for fractional & integer mode
+    pll_div_sel = 0b01  # div2, 2b
+    prsc_sel = 0  # 4/5
     vco_sel = 2  # 2b
     vcosel_mode = 0
     cal_acc = 0b00  # 2b
@@ -59,8 +60,8 @@ class TRF372017:
     ioff = 0x80  # 8b
     qoff = 0x80  # 8b
     vref_sel = 4  # 0.85 V, 3b
-    tx_div_sel = 1  # div2, 2b
-    lo_div_sel = 3  # div8, 2b
+    tx_div_sel = 0  # div1, 2b
+    lo_div_sel = 0  # div1, 2b
     tx_div_bias = 1  # 37.5 µA, 2b
     lo_div_bias = 2  # 50 µA, 2b
 


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
Phaser quality of life improvements

1. The current Phaser core device driver requires users perform register level manipulations of the DAC to use/change the frequency of the coarse mixer and NCO. This PR adds methods that allow users to reconfigure the NCO and coarse mixer frequency without needing to refer to the DAC-datasheet.
2. Document the need to enable the DAC mixer in order to use the NCO
2. An offset error for the DAC coarse mixer bits is fixed.
3. `Phaser.channel.oscillator[0]` is no-longer special cased after `init()`. One of the main features of Phaser is the ability to pulse shape. In this context, enabling RF output without specifying an amplitude leads to breakdown of abstraction. 
4. The TRF Phaser-Frequency-Detector (PFD) clock now defaults to the hardware design target of 62.5 MHz. This configuration should offer the lowest phase noise and will be a reasonable starting point for users to perform adjustments. Currently the PFD is set to an arbitrarily chosen frequency.
5. Refactor the TRF calibration procedure to follow that described in the data-sheet.
6. Refactor the `NDIV` -> `NINT` to match the documentation naming. 
7. Work around a bug that leads to malformed output when initialising phaser with `mixer_ena=1` & `nco_ena=0` after a power cycle.


### Related Issue
closes #1651
closes #1650
closes #1648
closes #1643
closes #1638
closes #1630
<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Close/update issues.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Changes were tested by measuring the Phaser output on a 4 GHz scope.
- [x] Add and check docstrings and comments

### Documentation Changes

- [x] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
