### PR TITLE
coredevice.comm_kernel: Fix unpacking of lists of int64

### DIFF
--- a/artiq/coredevice/comm_kernel.py
+++ b/artiq/coredevice/comm_kernel.py
@@ -72,7 +72,7 @@ def _receive_list(kernel, embedding_map):
         return list(struct.unpack(kernel.endian + "%sl" % length, buffer))
     elif tag == "I":
         buffer = kernel._read(8 * length)
-        return list(struct.unpack(kernel.endian + "%sq" % length, buffer))
+        return list(numpy.ndarray((length, ), kernel.endian + 'i8', buffer))
     elif tag == "f":
         buffer = kernel._read(8 * length)
         return list(struct.unpack(kernel.endian + "%sd" % length, buffer))


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
Fixes type persistency of int64-based lists across RPCs.

### Actual, undesired behaviour:
```python
class TestListInt64Writeback(EnvExperiment):
    def build(self):
        self.setattr_device("core")
        self.values = [int64(1)] * 2

    def run(self):
        self.print_rpc("Initially", self.values)
        self.messup()
        self.print_rpc("After first writeback", self.values)
        self.stress()
        self.print_rpc("After second writeback", self.values)

    @kernel
    def stress(self):
        self.values[0] = self.core.get_rtio_counter_mu()
        self.print_rpc("RPC from 'stress()'", self.values)

    @kernel
    def messup(self):
        for i in range(len(self.values)):
            self.values[i] = int64(0)
        self.print_rpc("RPC from 'messup()'", self.values)

    def print_rpc(self, msg, values):
        print("{}: type({}): {}".format(msg, values, [type(value) for value in values]))
```
This experiment prints the following:
```
print:Initially: type([1, 1]): [<class 'numpy.int64'>, <class 'numpy.int64'>]
print:RPC from 'messup()': type([0, 0]): [<class 'int'>, <class 'int'>]
print:After first writeback: type([0, 0]): [<class 'int'>, <class 'int'>]
root:While compiling <repository>/tests/imports.py
<artiq>/coredevice/core.py:159:9-159:28: error: cannot unify (self:<instance artiq.coredevice.core.Core>)->numpy.int32 delay('a) with (self:<instance artiq.coredevice.core.Core>)->numpy.int64 delay('b): 32 is incompatible with 64
    def get_rtio_counter_mu(self):
        ^^^^^^^^^^^^^^^^^^^       
<artiq>/coredevice/core.py:159:9-159:28: note: expression of type (self:<instance artiq.coredevice.core.Core>)->numpy.int32 delay('a)
    def get_rtio_counter_mu(self):
        ^^^^^^^^^^^^^^^^^^^       
```
### After applying the patch
The test case prints:
```
print:RPC from 'messup()': type([0, 0]): [<class 'numpy.int64'>, <class 'numpy.int64'>]
print:After first writeback: type([0, 0]): [<class 'numpy.int64'>, <class 'numpy.int64'>]
print:RPC from 'stress()': type([33127891173144, 0]): [<class 'numpy.int64'>, <class 'numpy.int64'>]
print:After second writeback: type([33127891173144, 0]): [<class 'numpy.int64'>, <class 'numpy.int64'>]
```

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). 

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
