### PR TITLE
Allow attaching child dataset managers

### DIFF
--- a/artiq/master/worker_db.py
+++ b/artiq/master/worker_db.py
@@ -115,6 +115,8 @@ class DatasetManager:
         self.ddb = ddb
         self._broadcaster.publish = ddb.update
 
+        self.attached_managers = {}
+
     def set(self, key, value, broadcast=False, persist=False, archive=True):
         if key in self.archive:
             logger.warning("Modifying dataset '%s' which is in archive, "
@@ -176,6 +178,16 @@ class DatasetManager:
         archive_group = f.create_group("archive")
         for k, v in self.archive.items():
             _write(archive_group, k, v)
+
+        for k, dataset_mgr in self.attached_managers.items():
+            dataset_mgr.write_hdf5(f.create_group(k))
+
+    def attach(self, key, dataset_mgr):
+        """Attach a child dataset manager to this dataset manager."""
+        if key in {"datasets", "archive"}:
+            raise ValueError("Name can not be the same as the standard group "
+                             "names used by ARTIQ")
+        self.attached_managers[key] = dataset_mgr
 
 
 def _write(group, k, v):

--- a/artiq/master/worker_db.py
+++ b/artiq/master/worker_db.py
@@ -11,7 +11,6 @@ import logging
 from sipyco.sync_struct import Notifier
 from sipyco.pc_rpc import AutoTarget, Client, BestEffortClient
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -56,6 +55,7 @@ class DeviceError(Exception):
 class DeviceManager:
     """Handles creation and destruction of local device drivers and controller
     RPC clients."""
+
     def __init__(self, ddb, virtual_devices=dict()):
         self.ddb = ddb
         self.virtual_devices = virtual_devices
@@ -143,7 +143,8 @@ class DatasetManager:
                 assert target is self._broadcaster.raw_view[key][1]
             return self._broadcaster[key][1]
         if target is None:
-            raise KeyError("Cannot mutate nonexistent dataset '{}'".format(key))
+            raise KeyError("Cannot mutate nonexistent dataset '{}'".
+                           format(key))
         return target
 
     def mutate(self, key, index, value):
@@ -161,7 +162,7 @@ class DatasetManager:
     def get(self, key, archive=False):
         if key in self.local:
             return self.local[key]
-        
+
         data = self.ddb.get(key)
         if archive:
             if key in self.archive:

--- a/artiq/master/worker_db.py
+++ b/artiq/master/worker_db.py
@@ -56,7 +56,9 @@ class DeviceManager:
     """Handles creation and destruction of local device drivers and controller
     RPC clients."""
 
-    def __init__(self, ddb, virtual_devices=dict()):
+    def __init__(self, ddb, virtual_devices=None):
+        if virtual_devices is None:
+            virtual_devices = {}
         self.ddb = ddb
         self.virtual_devices = virtual_devices
         self.active_devices = []

--- a/artiq/test/test_datasets.py
+++ b/artiq/test/test_datasets.py
@@ -54,7 +54,7 @@ class ExperimentDatasetCase(unittest.TestCase):
         with self.assertRaises(KeyError):
             self.exp.get(KEY)
 
-        for i in range(2):    
+        for i in range(2):
             self.exp.set(KEY, i)
             self.assertEqual(self.exp.get(KEY), i)
             with self.assertRaises(KeyError):


### PR DESCRIPTION
Signed-off-by: Leon Riesebos <leon.riesebos@duke.edu>

<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Allow a child dataset manager to be attached to an existing dataset manager. This allows transparent data-separation in experiment archives.

Not sure if there is interest in this feature, but we do use this to clone or isolate dataset managers in various cases. See https://gitlab.com/duke-artiq/dax/-/blob/master/dax/util/artiq.py#L289 . Now we basically [hack our way around it](https://gitlab.com/duke-artiq/dax/-/blob/master/dax/util/artiq.py#L347).

Note that this is for data separation within a single experiment and specifically the (HDF5) archive. It is NOT similar to #1614 .

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Close/update issues.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

- [x] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
