### PR TITLE
Fix AD99xx instance kernel invariants

### DIFF
--- a/artiq/coredevice/ad9910.py
+++ b/artiq/coredevice/ad9910.py
@@ -137,8 +137,10 @@ class AD9910:
     def __init__(self, dmgr, chip_select, cpld_device, sw_device=None,
                  pll_n=40, pll_cp=7, pll_vco=5, sync_delay_seed=-1,
                  io_update_delay=0, pll_en=1):
-        self.kernel_invariants = {"chip_select", "cpld", "core", "bus",
-                                  "ftw_per_hz", "sysclk_per_mu"}
+        self.kernel_invariants = {"cpld", "core", "bus", "chip_select",
+                                  "pll_en", "pll_n", "pll_vco", "pll_cp",
+                                  "ftw_per_hz", "sysclk_per_mu", "sysclk",
+                                  "sync_data"}
         self.cpld = dmgr.get(cpld_device)
         self.core = self.cpld.core
         self.bus = self.cpld.bus

--- a/artiq/coredevice/ad9910.py
+++ b/artiq/coredevice/ad9910.py
@@ -133,12 +133,12 @@ class AD9910:
         value from a I2C EEPROM; in which case, `sync_delay_seed` must be set
         to the same string value.
     """
-    kernel_invariants = {"chip_select", "cpld", "core", "bus",
-                         "ftw_per_hz", "sysclk_per_mu"}
 
     def __init__(self, dmgr, chip_select, cpld_device, sw_device=None,
                  pll_n=40, pll_cp=7, pll_vco=5, sync_delay_seed=-1,
                  io_update_delay=0, pll_en=1):
+        self.kernel_invariants = {"chip_select", "cpld", "core", "bus",
+                                  "ftw_per_hz", "sysclk_per_mu"}
         self.cpld = dmgr.get(cpld_device)
         self.core = self.cpld.core
         self.bus = self.cpld.bus

--- a/artiq/coredevice/ad9912.py
+++ b/artiq/coredevice/ad9912.py
@@ -26,10 +26,11 @@ class AD9912:
         is the reference clock divider (both set in the parent Urukul CPLD
         instance).
     """
-    kernel_invariants = {"chip_select", "cpld", "core", "bus", "ftw_per_hz"}
 
     def __init__(self, dmgr, chip_select, cpld_device, sw_device=None,
                  pll_n=10):
+        self.kernel_invariants = {"chip_select", "cpld", "core", "bus",
+                                  "ftw_per_hz"}
         self.cpld = dmgr.get(cpld_device)
         self.core = self.cpld.core
         self.bus = self.cpld.bus

--- a/artiq/coredevice/ad9912.py
+++ b/artiq/coredevice/ad9912.py
@@ -29,8 +29,8 @@ class AD9912:
 
     def __init__(self, dmgr, chip_select, cpld_device, sw_device=None,
                  pll_n=10):
-        self.kernel_invariants = {"chip_select", "cpld", "core", "bus",
-                                  "ftw_per_hz"}
+        self.kernel_invariants = {"cpld", "core", "bus", "chip_select",
+                                  "pll_n", "ftw_per_hz"}
         self.cpld = dmgr.get(cpld_device)
         self.core = self.cpld.core
         self.bus = self.cpld.bus


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

AD9910/AD9912 drivers have an optional switch. If the switch is added, the kernel invariants are updated to include this switch. Because the static kernel invariants are defined as a class variable and sets are mutable, the switch is added as a kernel invariant for all instances of the class instead of just one instance. This change makes the kernel invariants an instance variable.

At the same time, additional variables were marked kernel invariant for the same drivers.

This fix should probably also be applied to `release-6` and maybe even older releases.

Closes #1654 

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Close/update issues.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

- [x] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
