### PR TITLE
Fixes AD99xx/Urukul type annotations for cfg_sw()

### DIFF
--- a/artiq/coredevice/ad9910.py
+++ b/artiq/coredevice/ad9910.py
@@ -863,7 +863,7 @@ class AD9910:
         return self.cpld.get_channel_att(self.chip_select - 4)
 
     @kernel
-    def cfg_sw(self, state: TInt32):
+    def cfg_sw(self, state: TBool):
         """Set CPLD CFG RF switch state. The RF switch is controlled by the
         logical or of the CPLD configuration shift register
         RF switch bit and the SW TTL line (if used).

--- a/artiq/coredevice/ad9912.py
+++ b/artiq/coredevice/ad9912.py
@@ -1,6 +1,6 @@
 from numpy import int32, int64
 
-from artiq.language.types import TInt32, TInt64, TFloat, TTuple
+from artiq.language.types import TInt32, TInt64, TFloat, TTuple, TBool
 from artiq.language.core import kernel, delay, portable
 from artiq.language.units import ms, us, ns
 from artiq.coredevice.ad9912_reg import *
@@ -253,7 +253,7 @@ class AD9912:
         return self.ftw_to_frequency(ftw), self.pow_to_turns(pow_)
 
     @kernel
-    def cfg_sw(self, state: TInt32):
+    def cfg_sw(self, state: TBool):
         """Set CPLD CFG RF switch state. The RF switch is controlled by the
         logical or of the CPLD configuration shift register
         RF switch bit and the SW TTL line (if used).

--- a/artiq/frontend/artiq_sinara_tester.py
+++ b/artiq/frontend/artiq_sinara_tester.py
@@ -225,13 +225,13 @@ class SinaraTester(EnvExperiment):
         self.core.break_realtime()
         channel.init()
         channel.set(frequency*MHz)
-        channel.cfg_sw(1)
+        channel.cfg_sw(True)
         channel.set_att(6.)
 
     @kernel
     def cfg_sw_off_urukul(self, channel):
         self.core.break_realtime()
-        channel.cfg_sw(0)
+        channel.cfg_sw(False)
 
     @kernel
     def rf_switch_wave(self, channels):

--- a/artiq/test/coredevice/test_ad9910.py
+++ b/artiq/test/coredevice/test_ad9910.py
@@ -182,7 +182,7 @@ class AD9910Exp(EnvExperiment):
         self.core.break_realtime()
         self.dev.cpld.init()
         self.dev.init()
-        self.dev.cfg_sw(0)
+        self.dev.cfg_sw(False)
         self.dev.sw.on()
         sw_on = (self.dev.cpld.sta_read() >> (self.dev.chip_select - 4)) & 1
         delay(10*us)

--- a/artiq/test/coredevice/test_urukul.py
+++ b/artiq/test/coredevice/test_urukul.py
@@ -39,9 +39,9 @@ class UrukulExp(EnvExperiment):
         self.core.break_realtime()
         self.dev.init()
         self.dev.io_rst()
-        self.dev.cfg_sw(0, 0)
-        self.dev.cfg_sw(0, 1)
-        self.dev.cfg_sw(3, 1)
+        self.dev.cfg_sw(0, False)
+        self.dev.cfg_sw(0, True)
+        self.dev.cfg_sw(3, True)
         self.dev.cfg_switches(0b1010)
 
     @kernel
@@ -51,7 +51,7 @@ class UrukulExp(EnvExperiment):
         n = 10
         t0 = self.core.get_rtio_counter_mu()
         for i in range(n):
-            self.dev.cfg_sw(3, i & 1)
+            self.dev.cfg_sw(3, bool(i & 1))
         self.set_dataset("dt", self.core.mu_to_seconds(
             self.core.get_rtio_counter_mu() - t0) / n)
 


### PR DESCRIPTION
Signed-off-by: Leon Riesebos <leon.riesebos@duke.edu>

<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Fixed bug in type annotations for `cfg_sw()` functions of AD9910/AD9912/Urukul. Now the `state` argument is always a `TBool`. Updated test cases accordingly.
Probably introduced by me in #1618 .

### Related Issue

closes #1642
<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Close/update issues.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

- [x] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
