### PR TITLE
jsonschema: only allow enable_sata_drtio=true for Kasli if v1.0/1.1

### DIFF
--- a/artiq/coredevice/coredevice_generic.schema.json
+++ b/artiq/coredevice/coredevice_generic.schema.json
@@ -71,6 +71,26 @@
             }
         }
     },
+    "if": {
+        "properties": {
+            "target": { "const": "kasli" },
+            "hw_rev": {
+                "not": {
+                    "oneOf": [
+                        { "const": "v1.0" },
+                        { "const": "v1.1" }
+                    ]
+                }
+            }
+        }
+    },
+    "then": {
+        "properties": {
+            "enable_sata_drtio": {
+                "const": false
+            }
+        }
+    },
     "required": ["target", "variant", "hw_rev", "base", "peripherals"],
     "additionalProperties": false,
 


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

When validating with jsonschema, if `target` is `kasli`, `enable_sata_drtio` must be `false` (which is the default value) unless `hw_rev` is v1.0 or v1.1.

This respects the FPGA bank I/O definitions on [Migen](https://github.com/m-labs/migen/blob/master/migen/build/platforms/sinara/kasli.py). For example, v2.0 in fact does not have a SATA connector.

Prior to this PR, if `enable_sata_drtio` is `true` for Kasli v2.0 targets, simply a `Resource not found` error is raised from Migen when the SoC builder is called from `gateware.targets.kasli_generic`. An error raised from JSON validation, instead, might be more helpful than the error raised by Migen.

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |
