### PR TITLE
Kasli: Added front panel user LED (#1623)

### DIFF
--- a/artiq/frontend/artiq_ddb_template.py
+++ b/artiq/frontend/artiq_ddb_template.py
@@ -550,7 +550,7 @@ def process(output, master_description, satellites):
     for peripheral in master_description["peripherals"]:
         n_channels = pm.process(rtio_offset, peripheral)
         rtio_offset += n_channels
-    kasli_with_leds = (master_description["target"] == "kasli" and master_description["hw_rev"] in ("v1.0", "v1.1"))
+    kasli_with_leds = (master_description["target"] == "kasli" and master_description["hw_rev"] in ("v1.0", "v1.1", "v2.0"))
     kasli_soc = master_description["target"] == "kasli_soc"
     if base == "standalone" and kasli_with_leds or kasli_soc:
         n_channels = pm.add_board_leds(rtio_offset)

--- a/artiq/frontend/artiq_ddb_template.py
+++ b/artiq/frontend/artiq_ddb_template.py
@@ -550,9 +550,7 @@ def process(output, master_description, satellites):
     for peripheral in master_description["peripherals"]:
         n_channels = pm.process(rtio_offset, peripheral)
         rtio_offset += n_channels
-    kasli_with_leds = (master_description["target"] == "kasli")
-    kasli_soc = master_description["target"] == "kasli_soc"
-    if base == "standalone" and kasli_with_leds or kasli_soc:
+    if base == "standalone":
         n_channels = pm.add_board_leds(rtio_offset)
         rtio_offset += n_channels
 

--- a/artiq/frontend/artiq_ddb_template.py
+++ b/artiq/frontend/artiq_ddb_template.py
@@ -550,7 +550,7 @@ def process(output, master_description, satellites):
     for peripheral in master_description["peripherals"]:
         n_channels = pm.process(rtio_offset, peripheral)
         rtio_offset += n_channels
-    kasli_with_leds = (master_description["target"] == "kasli" and master_description["hw_rev"] in ("v1.0", "v1.1", "v2.0"))
+    kasli_with_leds = (master_description["target"] == "kasli")
     kasli_soc = master_description["target"] == "kasli_soc"
     if base == "standalone" and kasli_with_leds or kasli_soc:
         n_channels = pm.add_board_leds(rtio_offset)

--- a/artiq/gateware/targets/kasli_generic.py
+++ b/artiq/gateware/targets/kasli_generic.py
@@ -46,6 +46,11 @@ class GenericStandalone(StandaloneBase):
                 phy = ttl_simple.Output(sfp_ctl.led)
                 self.submodules += phy
                 self.rtio_channels.append(rtio.Channel.from_phy(phy))
+        if hw_rev == "v2.0":
+            for i in (1, 2):
+                phy = ttl_simple.Output(self.platform.request("user_led", i))
+                self.submodules += phy
+                self.rtio_channels.append(rtio.Channel.from_phy(phy)) 
 
         self.config["HAS_RTIO_LOG"] = None
         self.config["RTIO_LOG_CHANNEL"] = len(self.rtio_channels)


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
Fix the problem described by issue #1623. Now we can control 2 LEDs on the front panel of Kasli v2.0 like the documentation of ARTIQ

### Related Issue
Closes #1623 

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Close/update issues.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.

### Documentation Changes

- [ ] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
