### PR TITLE
enables custom length input FIFOs with DIOs

### DIFF
--- a/artiq/coredevice/coredevice_generic.schema.json
+++ b/artiq/coredevice/coredevice_generic.schema.json
@@ -168,6 +168,10 @@
                         "bank_direction_high": {
                             "type": "string",
                             "enum": ["input", "output"]
+                        },
+                        "custom_ififo_lengths": {
+                            "type": "object",
+                            "default": {}
                         }
                     },
                     "required": ["ports", "bank_direction_low", "bank_direction_high"]

--- a/artiq/gateware/eem_7series.py
+++ b/artiq/gateware/eem_7series.py
@@ -16,7 +16,8 @@ def peripheral_dio(module, peripheral, **kwargs):
     eem.DIO.add_std(module, peripheral["ports"][0],
         ttl_classes[peripheral["bank_direction_low"]],
         ttl_classes[peripheral["bank_direction_high"]],
-        edge_counter_cls=edge_counter_cls, **kwargs)
+        edge_counter_cls=edge_counter_cls,
+        custom_ififo_lengths=peripheral["custom_ififo_lengths"], **kwargs)
 
 
 def peripheral_urukul(module, peripheral, **kwargs):


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Enables the user to set a custom length input FIFO on DIO channels.

Added a new `custom_ififo_lengths` key in `dio` objects in the "`__variant__.json`" description file to set custom input FIFO lengths for some channels. The value is a JSON key value object of `{"channel_index": ififo_length}`. See an example below

```json
{
    "type": "dio",
    "ports": [1],
    "bank_direction_low": "input",
    "bank_direction_high": "output",
    "edge_counter": true,
    "custom_ififo_lengths": {"0": 1024}
},
```

I tested the above code on a Kasli and it increases the input FIFO length of the first channel (index 0) of the DIO to 1024. I don't think this change would work on KC705 or ZC706 boards though.

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

Closes #1693 

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Close/update issues.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
