### PR TITLE
Use tools.file_import to load the device_db

### DIFF
--- a/artiq/test/test_device_db.py
+++ b/artiq/test/test_device_db.py
@@ -1,0 +1,78 @@
+"""Test device DB interface"""
+
+import unittest
+import tempfile
+
+from artiq.master.databases import DeviceDB
+from artiq.tools import file_import
+
+
+DUMMY_DDB_FILE = """
+device_db = {
+    "core": {
+        "type": "local",
+        "module": "artiq.coredevice.core",
+        "class": "Core",
+        "arguments": {"host": "::1", "ref_period": 1e-09},
+    },
+
+    "core-alias": "core",
+    "unresolved-alias": "dummy",
+}
+"""
+
+
+class TestInvalidDeviceDB(unittest.TestCase):
+    def test_no_device_db_in_file(self):
+        with tempfile.NamedTemporaryFile(mode="w+", suffix=".py") as f:
+            print("", file=f, flush=True)
+
+            with self.assertRaisesRegex(KeyError, "device_db"):
+                DeviceDB(f.name)
+
+
+class TestDeviceDB(unittest.TestCase):
+    def setUp(self):
+        self.ddb_file = tempfile.NamedTemporaryFile(mode="w+", suffix=".py")
+        print(DUMMY_DDB_FILE, file=self.ddb_file, flush=True)
+
+        self.ddb = DeviceDB(self.ddb_file.name)
+
+    def test_get(self):
+        core = self.ddb.get("core")
+        self.assertEqual(core["class"], "Core")
+
+    def test_get_alias(self):
+        with self.assertRaises(TypeError):  # str indexing on str
+            self.ddb.get("core-alias")["class"]
+
+        self.assertEqual(
+            self.ddb.get("core-alias", resolve_alias=True), self.ddb.get("core")
+        )
+
+    def test_get_unresolved_alias(self):
+        with self.assertRaisesRegex(KeyError, "dummy"):
+            self.ddb.get("unresolved-alias", resolve_alias=True)
+
+    def test_update(self):
+        with self.assertRaises(KeyError):
+            self.ddb.get("core_log")
+
+        update = """
+device_db["core_log"] = {
+    "type": "controller",
+    "host": "::1",
+    "port": 1068,
+    "command": "aqctl_corelog -p {port} --bind {bind} ::1",
+}"""
+
+        print(update, file=self.ddb_file, flush=True)
+        self.ddb.scan()
+
+        self.assertEqual(self.ddb.get("core_log")["type"], "controller")
+
+    def test_get_ddb(self):
+        ddb = self.ddb.get_device_db()
+        raw = file_import(self.ddb_file.name).device_db
+
+        self.assertEqual(ddb, raw)


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Refactor ``artiq.master.databases:device_db_from_file`` and make use of ``artiq.tools.file_import`` instead of manual file execution.

This conveniently simplifies splitting the ``device_db`` over multiple files, as is commonly (?) done when augmenting the template generated by ``artiq_ddb_template`` (see e.g. [#1410 (comment)](https://github.com/m-labs/artiq/issues/1410#issuecomment-567752076)). Prior to this patch, one needed to add the location of the imported module to ``sys.path`` manually in the top-level ``device_db.py``.

This patch also adds basic interface unittests for ``artiq.master.databases.DeviceDB``. All new tests except ``test_import_same_level`` pass prior to applying the patch.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
|   | :bug: Bug fix  |
|   | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |
|   | :scroll: Docs |

## Steps 

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
