### PR TITLE
Fixes for AD9910 and AD9912 drivers

### DIFF
--- a/artiq/coredevice/ad9910.py
+++ b/artiq/coredevice/ad9910.py
@@ -324,7 +324,7 @@ class AD9910:
         self.bus.write(data_low)
 
     @kernel
-    def write_ram(self, data: TList(int32)):
+    def write_ram(self, data: TList(TInt32)):
         """Write data to RAM.
 
         The profile to write to and the step, start, and end address
@@ -345,7 +345,7 @@ class AD9910:
         self.bus.write(data[len(data) - 1])
 
     @kernel
-    def read_ram(self, data: TList(int32)):
+    def read_ram(self, data: TList(TInt32)):
         """Read data from RAM.
 
         The profile to read from and the step, start, and end address
@@ -481,7 +481,7 @@ class AD9910:
     @kernel
     def set_mu(self, ftw: TInt32, pow_: TInt32 = 0, asf: TInt32 = 0x3fff,
                phase_mode: TInt32 = _PHASE_MODE_DEFAULT,
-               ref_time_mu: TInt64 = int64(-1), profile: TInt32 = 0):
+               ref_time_mu: TInt64 = int64(-1), profile: TInt32 = 0) -> TInt32:
         """Set profile 0 data in machine units.
 
         This uses machine units (FTW, POW, ASF). The frequency tuning word
@@ -786,7 +786,7 @@ class AD9910:
     @kernel
     def set(self, frequency: TFloat, phase: TFloat = 0.0,
             amplitude: TFloat = 1.0, phase_mode: TInt32 = _PHASE_MODE_DEFAULT,
-            ref_time_mu: TInt64 = int64(-1), profile: TInt32 = 0):
+            ref_time_mu: TInt64 = int64(-1), profile: TInt32 = 0) -> TFloat:
         """Set profile 0 data in SI units.
 
         .. seealso:: :meth:`set_mu`

--- a/artiq/coredevice/ad9912.py
+++ b/artiq/coredevice/ad9912.py
@@ -156,7 +156,7 @@ class AD9912:
         return self.cpld.get_channel_att(self.chip_select - 4)
 
     @kernel
-    def set_mu(self, ftw: TInt64, pow_: TInt32):
+    def set_mu(self, ftw: TInt64, pow_: TInt32 = 0):
         """Set profile 0 data in machine units.
 
         After the SPI transfer, the shared IO update pin is pulsed to


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

1. Fixed typing errors in AD9910 driver and added a few return types
2. Added default pow to `set_mu()` for AD9912 (to match other `set()` function(s))

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Close/update issues.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

- [x] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
