### PR TITLE
compiler: allows string annotation

### DIFF
--- a/artiq/compiler/embedding.py
+++ b/artiq/compiler/embedding.py
@@ -949,6 +949,27 @@ class Stitcher:
         if annot is None:
             annot = builtins.TNone()
 
+        if isinstance(function, SpecializedFunction):
+            host_function = function.host_function
+        else:
+            host_function = function
+
+        embedded_function = host_function.artiq_embedded.function
+
+        if isinstance(embedded_function, str):
+            embedded_function = host_function
+
+        if isinstance(annot, str):
+            if annot not in embedded_function.__globals__:
+                diag = diagnostic.Diagnostic(
+                        "error",
+                        "type annotation for {kind}, {annot}, is not defined",
+                        {"kind": kind, "annot": repr(annot)},
+                        self._function_loc(function),
+                        notes=self._call_site_note(call_loc, fn_kind))
+                self.engine.process(diag)
+            annot = embedded_function.__globals__[annot]
+
         if not isinstance(annot, types.Type):
             diag = diagnostic.Diagnostic("error",
                 "type annotation for {kind}, '{annot}', is not an ARTIQ type",


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

According to PEP484, type hint can be a string literal for forward references. With PEP563, type hint would be preserved in annotations in string form.

### Related Issue

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [ ] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

Test cases:
```python
from artiq.experiment import *

class ArtiqTest(EnvExperiment):

    def build(self):
        self.setattr_device('core')

    @kernel
    def run(self):
        self.foo(1)

    @kernel
    def foo(self, v: 'TInt32'):
        self.core.reset()
        print('foo=', v)
```

The original version would fail with error message
```
test.py:14:1: error: type annotation for argument 'v', ''TInt32'', is not an ARTIQ type
def foo(self, v: 'TInt32'):
^                          
test.py:14:1: note: in kernel function here
def foo(self, v: 'TInt32'):
^                          
test.py:11:9-11:17: note: while inferring a type for an attribute 'foo' of a host object
        self.foo(1)
        ^^^^^^^^
```
while the fixed version would pass successfully run the code.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
