### PR TITLE
Kasli: adding internal API support for writing the flash

### DIFF
--- a/artiq/core_flash.py
+++ b/artiq/core_flash.py
@@ -2,12 +2,15 @@ import os
 import sys
 import logging
 import tempfile
-import shutil
 import shlex
 import subprocess
 import hashlib
 import random
 import getpass
+import atexit
+
+from artiq import __artiq_dir__ as artiq_dir
+from artiq.frontend.bit2bin import bit2bin
 
 __all__ = ["LocalClient", "SSHClient"]
 
@@ -170,3 +173,75 @@ class SSHClient(Client):
 
     def run_command(self, cmd, **kws):
         self.drain(self.spawn_command(cmd, **kws))
+
+def build_dir (args):
+    bin_dir = args.dir
+    if bin_dir is None:
+        bin_dir = os.path.join(artiq_dir, "board-support")
+
+    needs_artifacts = not args.action or any(
+        action in args.action
+        for action in ["gateware", "rtm_gateware", "bootloader", "firmware", "load", "rtm_load"])
+    variant = args.variant
+    if needs_artifacts and variant is None:
+        variants = []
+        if args.srcbuild:
+            for entry in os.scandir(bin_dir):
+                if entry.is_dir():
+                    variants.append(entry.name)
+        else:
+            prefix = args.target + "-"
+            for entry in os.scandir(bin_dir):
+                if entry.is_dir() and entry.name.startswith(prefix):
+                    variants.append(entry.name[len(prefix):])
+        if args.target == "sayma":
+            try:
+                variants.remove("rtm")
+            except ValueError:
+                pass
+        if len(variants) == 0:
+            raise FileNotFoundError("no variants found, did you install a board binary package?")
+        elif len(variants) == 1:
+            variant = variants[0]
+        else:
+            raise ValueError("more than one variant found for selected board, specify -V. "
+                "Found variants: {}".format(" ".join(sorted(variants))))
+    variant_dir = None
+    rtm_variant_dir = None
+    if needs_artifacts:
+        if args.srcbuild:
+            variant_dir = variant
+        else:
+            variant_dir = args.target + "-" + variant
+        if args.target == "sayma":
+            if args.srcbuild:
+                rtm_variant_dir = "rtm"
+            else:
+                rtm_variant_dir = "sayma-rtm"
+    return (variant, bin_dir, variant_dir, rtm_variant_dir)
+
+def artifact_path(args, bin_dir, this_variant_dir, *path_filename):
+    if args.srcbuild:
+        # source tree - use path elements to locate file
+        return os.path.join(bin_dir, this_variant_dir, *path_filename)
+    else:
+        # flat tree - all files in the same directory, discard path elements
+        *_, filename = path_filename
+        return os.path.join(bin_dir, this_variant_dir, filename)
+
+def convert_gateware(bit_filename, header=False):
+    bin_handle, bin_filename = tempfile.mkstemp(
+        prefix="artiq_", suffix="_" + os.path.basename(bit_filename))
+    with open(bit_filename, "rb") as bit_file, \
+            open(bin_handle, "wb") as bin_file:
+        if header:
+            bin_file.write(b"\x00"*8)
+        bit2bin(bit_file, bin_file)
+        if header:
+            magic = 0x5352544d  # "SRTM", see sayma_rtm target
+            length = bin_file.tell() - 8
+            bin_file.seek(0)
+            bin_file.write(magic.to_bytes(4, byteorder="big"))
+            bin_file.write(length.to_bytes(4, byteorder="big"))
+    atexit.register(lambda: os.unlink(bin_filename))
+    return bin_filename

--- a/artiq/frontend/artiq_coremgmt.py
+++ b/artiq/frontend/artiq_coremgmt.py
@@ -1,16 +1,14 @@
 #!/usr/bin/env python3
 
 import argparse
-import struct
 
 from sipyco import common_args
 
 from artiq import __version__ as artiq_version
 from artiq.master.databases import DeviceDB
-from artiq.coredevice.comm_kernel import CommKernel
 from artiq.coredevice.comm_mgmt import CommMgmt
 from artiq.coredevice.profiler import CallgrindWriter
-from artiq.frontend.artiq_flash import *
+from artiq.core_flash import build_dir, artifact_path, convert_gateware
 
 
 def get_argparser():
@@ -127,7 +125,7 @@ def get_argparser():
 
     # flash
     t_flash = tools.add_parser("flash",
-                                help="ARTIQ flashing/deployment tool though internet")
+                        help="ARTIQ flashing/deployment tool though internet")
 
     t_flash.add_argument("action", metavar="ACTION", nargs="*",
                         default=[],
@@ -202,14 +200,11 @@ def main():
     if args.tool == "debug":
         if args.action == "allocator":
             mgmt.debug_allocator()
-    
+
     if args.tool == "flash":
-
         (variant, bin_dir, variant_dir, rtm_variant_dir) = build_dir(args)
-
         if not args.action:
             args.action = "gateware bootloader firmware start".split()
-            
         for action in args.action:
             if action == "gateware":
                 gateware_bin = convert_gateware(
@@ -224,7 +219,8 @@ def main():
                     mgmt.flash_write(action, file)
             elif action == "firmware":
                 firmware = "runtime"
-                firmware_fbi = artifact_path(args, bin_dir, variant_dir, "software", firmware, firmware + ".fbi")
+                firmware_fbi = artifact_path(args, bin_dir,
+                    variant_dir, "software", firmware, firmware + ".fbi")
                 with open(firmware_fbi, "rb") as fi:
                     file = fi.read()
                     mgmt.flash_write(action, file)
@@ -232,11 +228,6 @@ def main():
                 print('Reloading')
                 if mgmt.reload():
                     mgmt.close()
-                    # if(mgmt.awake()):
-                    #     print('Reload success')
-                    # else:
-                    #     print('Device not awake')
-            
 
 if __name__ == "__main__":
     main()

--- a/artiq/frontend/artiq_flash.py
+++ b/artiq/frontend/artiq_flash.py
@@ -6,16 +6,14 @@ import subprocess
 import tempfile
 import shutil
 import re
-import atexit
 from functools import partial
 from collections import defaultdict
 
 from sipyco import common_args
 
 from artiq import __version__ as artiq_version
-from artiq import __artiq_dir__ as artiq_dir
-from artiq.remoting import SSHClient, LocalClient
-from artiq.frontend.bit2bin import bit2bin
+from artiq.core_flash import build_dir, artifact_path, convert_gateware
+from artiq.core_flash import *
 
 
 def get_argparser():
@@ -306,78 +304,6 @@ class ProgrammerAMC(Programmer):
 
     def start(self):
         add_commands(self._script, "xcu_program xcu.tap")
-
-def build_dir (args):
-    bin_dir = args.dir
-    if bin_dir is None:
-        bin_dir = os.path.join(artiq_dir, "board-support")
-
-    needs_artifacts = not args.action or any(
-        action in args.action
-        for action in ["gateware", "rtm_gateware", "bootloader", "firmware", "load", "rtm_load"])
-    variant = args.variant
-    if needs_artifacts and variant is None:
-        variants = []
-        if args.srcbuild:
-            for entry in os.scandir(bin_dir):
-                if entry.is_dir():
-                    variants.append(entry.name)
-        else:
-            prefix = args.target + "-"
-            for entry in os.scandir(bin_dir):
-                if entry.is_dir() and entry.name.startswith(prefix):
-                    variants.append(entry.name[len(prefix):])
-        if args.target == "sayma":
-            try:
-                variants.remove("rtm")
-            except ValueError:
-                pass
-        if len(variants) == 0:
-            raise FileNotFoundError("no variants found, did you install a board binary package?")
-        elif len(variants) == 1:
-            variant = variants[0]
-        else:
-            raise ValueError("more than one variant found for selected board, specify -V. "
-                "Found variants: {}".format(" ".join(sorted(variants))))
-    variant_dir = None
-    rtm_variant_dir = None
-    if needs_artifacts:
-        if args.srcbuild:
-            variant_dir = variant
-        else:
-            variant_dir = args.target + "-" + variant
-        if args.target == "sayma":
-            if args.srcbuild:
-                rtm_variant_dir = "rtm"
-            else:
-                rtm_variant_dir = "sayma-rtm"
-    return (variant, bin_dir, variant_dir, rtm_variant_dir)
-
-def artifact_path(args, bin_dir, this_variant_dir, *path_filename):
-    if args.srcbuild:
-        # source tree - use path elements to locate file
-        return os.path.join(bin_dir, this_variant_dir, *path_filename)
-    else:
-        # flat tree - all files in the same directory, discard path elements
-        *_, filename = path_filename
-        return os.path.join(bin_dir, this_variant_dir, filename)
-
-def convert_gateware(bit_filename, header=False):
-    bin_handle, bin_filename = tempfile.mkstemp(
-        prefix="artiq_", suffix="_" + os.path.basename(bit_filename))
-    with open(bit_filename, "rb") as bit_file, \
-            open(bin_handle, "wb") as bin_file:
-        if header:
-            bin_file.write(b"\x00"*8)
-        bit2bin(bit_file, bin_file)
-        if header:
-            magic = 0x5352544d  # "SRTM", see sayma_rtm target
-            length = bin_file.tell() - 8
-            bin_file.seek(0)
-            bin_file.write(magic.to_bytes(4, byteorder="big"))
-            bin_file.write(length.to_bytes(4, byteorder="big"))
-    atexit.register(lambda: os.unlink(bin_filename))
-    return bin_filename
 
 def main():
     args = get_argparser().parse_args()

--- a/artiq/frontend/artiq_flash.py
+++ b/artiq/frontend/artiq_flash.py
@@ -307,6 +307,77 @@ class ProgrammerAMC(Programmer):
     def start(self):
         add_commands(self._script, "xcu_program xcu.tap")
 
+def build_dir (args):
+    bin_dir = args.dir
+    if bin_dir is None:
+        bin_dir = os.path.join(artiq_dir, "board-support")
+
+    needs_artifacts = not args.action or any(
+        action in args.action
+        for action in ["gateware", "rtm_gateware", "bootloader", "firmware", "load", "rtm_load"])
+    variant = args.variant
+    if needs_artifacts and variant is None:
+        variants = []
+        if args.srcbuild:
+            for entry in os.scandir(bin_dir):
+                if entry.is_dir():
+                    variants.append(entry.name)
+        else:
+            prefix = args.target + "-"
+            for entry in os.scandir(bin_dir):
+                if entry.is_dir() and entry.name.startswith(prefix):
+                    variants.append(entry.name[len(prefix):])
+        if args.target == "sayma":
+            try:
+                variants.remove("rtm")
+            except ValueError:
+                pass
+        if len(variants) == 0:
+            raise FileNotFoundError("no variants found, did you install a board binary package?")
+        elif len(variants) == 1:
+            variant = variants[0]
+        else:
+            raise ValueError("more than one variant found for selected board, specify -V. "
+                "Found variants: {}".format(" ".join(sorted(variants))))
+    variant_dir = None
+    rtm_variant_dir = None
+    if needs_artifacts:
+        if args.srcbuild:
+            variant_dir = variant
+        else:
+            variant_dir = args.target + "-" + variant
+        if args.target == "sayma":
+            if args.srcbuild:
+                rtm_variant_dir = "rtm"
+            else:
+                rtm_variant_dir = "sayma-rtm"
+    return (variant, bin_dir, variant_dir, rtm_variant_dir)
+
+def artifact_path(args, bin_dir, this_variant_dir, *path_filename):
+    if args.srcbuild:
+        # source tree - use path elements to locate file
+        return os.path.join(bin_dir, this_variant_dir, *path_filename)
+    else:
+        # flat tree - all files in the same directory, discard path elements
+        *_, filename = path_filename
+        return os.path.join(bin_dir, this_variant_dir, filename)
+
+def convert_gateware(bit_filename, header=False):
+    bin_handle, bin_filename = tempfile.mkstemp(
+        prefix="artiq_", suffix="_" + os.path.basename(bit_filename))
+    with open(bit_filename, "rb") as bit_file, \
+            open(bin_handle, "wb") as bin_file:
+        if header:
+            bin_file.write(b"\x00"*8)
+        bit2bin(bit_file, bin_file)
+        if header:
+            magic = 0x5352544d  # "SRTM", see sayma_rtm target
+            length = bin_file.tell() - 8
+            bin_file.seek(0)
+            bin_file.write(magic.to_bytes(4, byteorder="big"))
+            bin_file.write(length.to_bytes(4, byteorder="big"))
+    atexit.register(lambda: os.unlink(bin_filename))
+    return bin_filename
 
 def main():
     args = get_argparser().parse_args()
@@ -344,47 +415,7 @@ def main():
         },
     }[args.target]
 
-    bin_dir = args.dir
-    if bin_dir is None:
-        bin_dir = os.path.join(artiq_dir, "board-support")
-
-    needs_artifacts = not args.action or any(
-        action in args.action
-        for action in ["gateware", "rtm_gateware", "bootloader", "firmware", "load", "rtm_load"])
-    variant = args.variant
-    if needs_artifacts and variant is None:
-        variants = []
-        if args.srcbuild:
-            for entry in os.scandir(bin_dir):
-                if entry.is_dir():
-                    variants.append(entry.name)
-        else:
-            prefix = args.target + "-"
-            for entry in os.scandir(bin_dir):
-                if entry.is_dir() and entry.name.startswith(prefix):
-                    variants.append(entry.name[len(prefix):])
-        if args.target == "sayma":
-            try:
-                variants.remove("rtm")
-            except ValueError:
-                pass
-        if len(variants) == 0:
-            raise FileNotFoundError("no variants found, did you install a board binary package?")
-        elif len(variants) == 1:
-            variant = variants[0]
-        else:
-            raise ValueError("more than one variant found for selected board, specify -V. "
-                "Found variants: {}".format(" ".join(sorted(variants))))
-    if needs_artifacts:
-        if args.srcbuild:
-            variant_dir = variant
-        else:
-            variant_dir = args.target + "-" + variant
-        if args.target == "sayma":
-            if args.srcbuild:
-                rtm_variant_dir = "rtm"
-            else:
-                rtm_variant_dir = "sayma-rtm"
+    (variant, bin_dir, variant_dir, rtm_variant_dir) = build_dir(args)
 
     if not args.action:
         if args.target == "sayma" and variant != "simplesatellite" and variant != "master":
@@ -403,44 +434,19 @@ def main():
         programmer_cls = config["programmer"]
     programmer = programmer_cls(client, preinit_script=args.preinit_command)
 
-    def artifact_path(this_variant_dir, *path_filename):
-        if args.srcbuild:
-            # source tree - use path elements to locate file
-            return os.path.join(bin_dir, this_variant_dir, *path_filename)
-        else:
-            # flat tree - all files in the same directory, discard path elements
-            *_, filename = path_filename
-            return os.path.join(bin_dir, this_variant_dir, filename)
-
-    def convert_gateware(bit_filename, header=False):
-        bin_handle, bin_filename = tempfile.mkstemp(
-            prefix="artiq_", suffix="_" + os.path.basename(bit_filename))
-        with open(bit_filename, "rb") as bit_file, \
-                open(bin_handle, "wb") as bin_file:
-            if header:
-                bin_file.write(b"\x00"*8)
-            bit2bin(bit_file, bin_file)
-            if header:
-                magic = 0x5352544d  # "SRTM", see sayma_rtm target
-                length = bin_file.tell() - 8
-                bin_file.seek(0)
-                bin_file.write(magic.to_bytes(4, byteorder="big"))
-                bin_file.write(length.to_bytes(4, byteorder="big"))
-        atexit.register(lambda: os.unlink(bin_filename))
-        return bin_filename
 
     for action in args.action:
         if action == "gateware":
             gateware_bin = convert_gateware(
-                artifact_path(variant_dir, "gateware", "top.bit"))
+                artifact_path(args, bin_dir, variant_dir, "gateware", "top.bit"))
             programmer.write_binary(*config["gateware"], gateware_bin)
         elif action == "rtm_gateware":
             rtm_gateware_bin = convert_gateware(
-                artifact_path(rtm_variant_dir, "gateware", "top.bit"), header=True)
+                artifact_path(args, bin_dir, rtm_variant_dir, "gateware", "top.bit"), header=True)
             programmer.write_binary(*config["rtm_gateware"],
                                     rtm_gateware_bin)
         elif action == "bootloader":
-            bootloader_bin = artifact_path(variant_dir, "software", "bootloader", "bootloader.bin")
+            bootloader_bin = artifact_path(args, bin_dir, variant_dir, "software", "bootloader", "bootloader.bin")
             programmer.write_binary(*config["bootloader"], bootloader_bin)
         elif action == "storage":
             storage_img = args.storage
@@ -451,17 +457,17 @@ def main():
             else:
                 firmware = "runtime"
 
-            firmware_fbi = artifact_path(variant_dir, "software", firmware, firmware + ".fbi")
+            firmware_fbi = artifact_path(args, bin_dir, variant_dir, "software", firmware, firmware + ".fbi")
             programmer.write_binary(*config["firmware"], firmware_fbi)
         elif action == "load":
             if args.target == "sayma":
-                gateware_bit = artifact_path(variant_dir, "gateware", "top.bit")
+                gateware_bit = artifact_path(args, bin_dir, variant_dir, "gateware", "top.bit")
                 programmer.load(gateware_bit, 1)
             else:
-                gateware_bit = artifact_path(variant_dir, "gateware", "top.bit")
+                gateware_bit = artifact_path(args, bin_dir, variant_dir, "gateware", "top.bit")
                 programmer.load(gateware_bit, 0)
         elif action == "rtm_load":
-            rtm_gateware_bit = artifact_path(rtm_variant_dir, "gateware", "top.bit")
+            rtm_gateware_bit = artifact_path(args, bin_dir, rtm_variant_dir, "gateware", "top.bit")
             programmer.load(rtm_gateware_bit, 0)
         elif action == "start":
             programmer.start()


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
Now the users of Kasli can flash the gateware/bootloader/firmware and reload the whole system using core device management tool. Commands are very similar to artiq_flash, besides adding the flash keyword after aritq_coremgmt. If no action is specified, the default is `gateware bootloader firmware start`.
Example: `artiq_coremgmt flash --srcbuild -d artiq_kasli -V <your_variant>`
Only front-end API is committed in this PR.
### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |


## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.


### Documentation Changes

- [x] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
