### PR TITLE
applets: add warning message on plot for `plot_xy` and `plot_xy_hist`

### DIFF
--- a/artiq/applets/plot_xy.py
+++ b/artiq/applets/plot_xy.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import PyQt5  # make sure pyqtgraph imports Qt5
+from PyQt5.QtCore import QTimer
 import pyqtgraph
 
 from artiq.applets.simple import TitleApplet
@@ -11,6 +12,12 @@ class XYPlot(pyqtgraph.PlotWidget):
     def __init__(self, args):
         pyqtgraph.PlotWidget.__init__(self)
         self.args = args
+        self.timer = QTimer()
+        self.timer.setSingleShot(True)
+        self.timer.timeout.connect(self.length_warning)
+        self.mismatch = {'X values': False,
+                         'Error bars': False,
+                         'Fit values': False}
 
     def data_changed(self, data, mods, title):
         try:
@@ -24,31 +31,56 @@ class XYPlot(pyqtgraph.PlotWidget):
         fit = data.get(self.args.fit, (False, None))[1]
 
         if not len(y) or len(y) != len(x):
-            return
+            self.mismatch['X values'] = True
+            self.timer.start(1000)
+        else:
+            self.mismatch['X values'] = False
+            if not sum(self.mismatch.values()):
+                self.timer.stop()
         if error is not None and hasattr(error, "__len__"):
             if not len(error):
                 error = None
             elif len(error) != len(y):
-                return
+                self.mismatch['Error bars'] = True
+                self.timer.start(1000)
+            else:
+                self.mismatch['Error bars'] = False
+                if not sum(self.mismatch.values()):
+                    self.timer.stop()
         if fit is not None:
             if not len(fit):
                 fit = None
             elif len(fit) != len(y):
-                return
+                self.mismatch['Fit values'] = True
+                self.timer.start(1000)
+            else:
+                self.mismatch['Fit values'] = False
+                if not sum(self.mismatch.values()):
+                    self.timer.stop()
 
         self.clear()
+        if self.mismatch['X values']:
+            return
         self.plot(x, y, pen=None, symbol="x")
         self.setTitle(title)
-        if error is not None:
+        if error is not None and not self.mismatch['Error bars']:
             # See https://github.com/pyqtgraph/pyqtgraph/issues/211
             if hasattr(error, "__len__") and not isinstance(error, np.ndarray):
                 error = np.array(error)
             errbars = pyqtgraph.ErrorBarItem(
                 x=np.array(x), y=np.array(y), height=error)
             self.addItem(errbars)
-        if fit is not None:
+        if fit is not None and not self.mismatch['Fit values']:
             xi = np.argsort(x)
             self.plot(x[xi], fit[xi])
+
+    def length_warning(self):
+        text = "⚠️ dataset lengths mismatch:\n"
+        for key in self.mismatch:
+            if self.mismatch[key]:
+                text += key + ', '
+        text += "should have the same length as Y values"
+        self.addItem(pyqtgraph.TextItem(text))
 
 
 def main():


### PR DESCRIPTION

# ARTIQ Pull Request

## Description of Changes
Display a warning message on the plot window if the datasets do not satisfy some conditions after a timeout of 1s. 
For the `plot_xy` applet, the length of X values, error bars, fit values should have the same length as Y values. Because error bars and fit values are optional, the xy plot will still be displayed if they are wrong. The display is as shown below:
![image](https://user-images.githubusercontent.com/43180603/125899980-f882620f-1713-4791-b237-e783353e9348.png)
For the `plot_xy_hist` applet, the length of bin boundaries should be the same as the first dimension of histogram counts, and the length of point abscissas should be the same as the second dimension of histogram counts. Either failure will cause the xy plot to fail to display. The display is as shown below:
![image](https://user-images.githubusercontent.com/43180603/125900417-318a068f-262d-4644-9ceb-9f4dd9465852.png)
Potential bug fix: previously the histogram plot will crash in all my testing cases. Now, it will show `click on the data point at left to see histogram` if the xy plot is shown.

### Related Issue
Closes #1702


## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Close/update issues.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [ ] Test your changes or have someone test them. Mention what was tested and how.

### Git Logistics

- [ ] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
