### PR TITLE
Add KEEPALIVE to socket connections

### DIFF
--- a/artiq/coredevice/comm_moninj.py
+++ b/artiq/coredevice/comm_moninj.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import struct
 from enum import Enum
+from sipyco import keepalive
 
 
 __all__ = ["TTLProbe", "TTLOverride", "CommMonInj"]
@@ -28,7 +29,8 @@ class CommMonInj:
         self.disconnect_cb = disconnect_cb
 
     async def connect(self, host, port=1383):
-        self._reader, self._writer = await asyncio.open_connection(host, port)
+        self._reader, self._writer = \
+            await keepalive.open_connection(host, port)
         try:
             self._writer.write(b"ARTIQ moninj\n")
             # get device endian

--- a/artiq/frontend/aqctl_corelog.py
+++ b/artiq/frontend/aqctl_corelog.py
@@ -7,7 +7,7 @@ import logging
 import re
 
 from sipyco.pc_rpc import Server
-from sipyco import common_args
+from sipyco import common_args, keepalive
 from sipyco.logging_tools import log_with_name
 
 from artiq.coredevice.comm_mgmt import Request, Reply
@@ -37,7 +37,7 @@ async def get_logs_sim(host):
 
 
 async def get_logs(host):
-    reader, writer = await asyncio.open_connection(host, 1380)
+    reader, writer = await keepalive.open_connection(host, 1380)
     writer.write(b"ARTIQ management\n")
     writer.write(struct.pack("B", Request.PullLog.value))
     await writer.drain()


### PR DESCRIPTION
### Symptom
When running `artiq_dashboard` we see connection errors to the master and Kasli when left unattended.
We are running a Linux dashboard inside a Docker container running on WSL2 (Windows 10).

### Diagnosis
Inside a Docker container (Ubuntu running on WSL2) idle TCP socket connections drop out after 5 minutes.

This can be reproduced with a simple socket connection outside of SiPyCo.
On a server (Linux): `nc -l 0.0.0.0 1234`
In a container (Ubuntu/WSL2): `telnet <server ip> 1234`

### Solution
Sending KEEPALIVE packets before the connection dies prevents this.

Fix requires:
1) KEEPALIVE flag added to TCP socket connections
2) Reduce the keepalive time (default is 12 minutes)

A SiPyCo fix for (1) is open for review: https://github.com/m-labs/sipyco/pull/21

For (2) we run docker with following option: `docker run --sysctl net.ipv4.tcp_keepalive_time=200 ...`

### Implementation
https://github.com/m-labs/sipyco/pull/21 creates a `keepalive` module that sets up the flags (taking into account the operating system). This is then used to wrap calls to `asyncio.open_connection`.

By importing this module we can add KEEPALIVE to moninj/corelog connections.
(Other dashboard to master connections are created through SiPyCo so no Artiq change required.)

### Testing
We have been running a local version of this change for the past 6 months with no issues.

### PR Dependency
This PR is dependent on https://github.com/m-labs/sipyco/pull/21
