### PR TITLE
zotino: Unify default SPI read clock divisor at 16

### DIFF
--- a/artiq/coredevice/ad53xx.py
+++ b/artiq/coredevice/ad53xx.py
@@ -127,9 +127,9 @@ class AD53xx:
       transactions (default: 1)
     :param div_write: SPI clock divider for write operations (default: 4,
       50MHz max SPI clock with {t_high, t_low} >=8ns)
-    :param div_read: SPI clock divider for read operations (default: 8, not
-      optimized for speed, but cf data sheet t22: 25ns min SCLK edge to SDO
-      valid)
+    :param div_read: SPI clock divider for read operations (default: 16, not
+      optimized for speed; datasheet says t22: 25ns min SCLK edge to SDO
+      valid, and suggests the SPI speed for reads should be <=20 MHz)
     :param vref: DAC reference voltage (default: 5.)
     :param offset_dacs: Initial register value for the two offset DACs, device
       dependent and must be set correctly for correct voltage to mu

--- a/artiq/coredevice/zotino.py
+++ b/artiq/coredevice/zotino.py
@@ -27,15 +27,15 @@ class Zotino(AD53xx):
     :param clr_device: CLR RTIO TTLOut channel name.
     :param div_write: SPI clock divider for write operations (default: 4,
       50MHz max SPI clock)
-    :param div_read: SPI clock divider for read operations (default: 8, not
-      optimized for speed, but cf data sheet t22: 25ns min SCLK edge to SDO
-      valid)
+    :param div_read: SPI clock divider for read operations (default: 16, not
+      optimized for speed; datasheet says t22: 25ns min SCLK edge to SDO
+      valid, and suggests the SPI speed for reads should be <=20 MHz)
     :param vref: DAC reference voltage (default: 5.)
     :param core_device: Core device name (default: "core")
     """
 
     def __init__(self, dmgr, spi_device, ldac_device=None, clr_device=None,
-                 div_write=4, div_read=8, vref=5., core="core"):
+                 div_write=4, div_read=16, vref=5., core="core"):
         AD53xx.__init__(self, dmgr=dmgr, spi_device=spi_device,
                         ldac_device=ldac_device, clr_device=clr_device,
                         chip_select=_SPI_CS_DAC, div_write=div_write,


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Unify the default SPI read clock divisor (`div_read`) for both `Zotino` and `AD53xx` at 16. Plus minor update to the documentation.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Importance

Currently, `AD53xx` and `Zotino` have different default SPI clock speeds for readbacks. According to 99f7672c79b4fd9e3fa400caeea16d33155b62ff, `AD53xx` has switched the divisor value from 8 to 16 but `Zotino` has never been changed.

The motivation is that reads should take longer duration than writes because of variable round-trip delays in various types of device connection (e.g. DRTIO vs VHDCI).

Now, using default Zotino settings, the SPI clock for reading AD53xx registers will be halved. This will make Zotino, Urukul and Mirny the same readback speed (i.e. at 7.8125 MHz for RTIO @ 125 MHz). This should be deemed acceptable as SPI register readbacks for these cards are generally not performance-critical.

