### PR TITLE
Adding sampler write and read functions to sampler.py 

### DIFF
--- a/artiq/coredevice/sampler.py
+++ b/artiq/coredevice/sampler.py
@@ -129,6 +129,60 @@ class Sampler:
             data[i] = val >> 16
             val &= 0xffff
             data[i - 1] = -(val & mask) + (val & ~mask)
+            
+    
+    @kernel
+    def sample_mu_write(self, data):
+        """prepare ADC.
+
+        Perform a conversion and transfer the samples.
+
+        This assumes that the input FIFO of the ADC SPI RTIO channel is deep
+        enough to buffer the samples (half the length of `data` deep).
+        If it is not, there will be RTIO input overflows.
+
+        :param data: List of data samples to fill. Must have even length.
+            Samples are always read from the last channel (channel 7) down.
+            The `data` list will always be filled with the last item
+            holding to the sample from channel 7.
+        """
+        self.cnv.pulse(30*ns)  # t_CNVH
+        delay(450*ns)  # t_CONV
+        mask = 1 << 15
+        for i in range(len(data)//2):
+            self.bus_adc.write(0)
+        # for i in range(len(data) - 1, -1, -2):
+        #     val = self.bus_adc.read()
+        #     data[i] = val >> 16
+        #     val &= 0xffff
+        #     data[i - 1] = -(val & mask) + (val & ~mask)
+            
+        
+    @kernel
+    def sample_mu_read(self, data):
+        """read in the values.
+
+        Perform a conversion and transfer the samples.
+
+        This assumes that the input FIFO of the ADC SPI RTIO channel is deep
+        enough to buffer the samples (half the length of `data` deep).
+        If it is not, there will be RTIO input overflows.
+
+        :param data: List of data samples to fill. Must have even length.
+            Samples are always read from the last channel (channel 7) down.
+            The `data` list will always be filled with the last item
+            holding to the sample from channel 7.
+        """
+        # self.cnv.pulse(30*ns)  # t_CNVH
+        delay(450*ns)  # t_CONV
+        mask = 1 << 15
+        # for i in range(len(data)//2):
+        #     self.bus_adc.write(0)
+        for i in range(len(data) - 1, -1, -2):
+            val = self.bus_adc.read()
+            data[i] = val >> 16
+            val &= 0xffff
+            data[i - 1] = -(val & mask) + (val & ~mask)
 
     @kernel
     def sample(self, data):

--- a/artiq/coredevice/sampler.py
+++ b/artiq/coredevice/sampler.py
@@ -135,49 +135,21 @@ class Sampler:
     def sample_mu_write(self, data):
         """prepare ADC.
 
-        Perform a conversion and transfer the samples.
-
-        This assumes that the input FIFO of the ADC SPI RTIO channel is deep
-        enough to buffer the samples (half the length of `data` deep).
-        If it is not, there will be RTIO input overflows.
-
-        :param data: List of data samples to fill. Must have even length.
-            Samples are always read from the last channel (channel 7) down.
-            The `data` list will always be filled with the last item
-            holding to the sample from channel 7.
+        Writing appropriate data to shift register and start transfer
         """
         self.cnv.pulse(30*ns)  # t_CNVH
         delay(450*ns)  # t_CONV
         mask = 1 << 15
         for i in range(len(data)//2):
             self.bus_adc.write(0)
-        # for i in range(len(data) - 1, -1, -2):
-        #     val = self.bus_adc.read()
-        #     data[i] = val >> 16
-        #     val &= 0xffff
-        #     data[i - 1] = -(val & mask) + (val & ~mask)
+
             
         
     @kernel
     def sample_mu_read(self, data):
-        """read in the values.
-
-        Perform a conversion and transfer the samples.
-
-        This assumes that the input FIFO of the ADC SPI RTIO channel is deep
-        enough to buffer the samples (half the length of `data` deep).
-        If it is not, there will be RTIO input overflows.
-
-        :param data: List of data samples to fill. Must have even length.
-            Samples are always read from the last channel (channel 7) down.
-            The `data` list will always be filled with the last item
-            holding to the sample from channel 7.
+        """read in the values submitted to the SPI core.
         """
-        # self.cnv.pulse(30*ns)  # t_CNVH
-        delay(450*ns)  # t_CONV
         mask = 1 << 15
-        # for i in range(len(data)//2):
-        #     self.bus_adc.write(0)
         for i in range(len(data) - 1, -1, -2):
             val = self.bus_adc.read()
             data[i] = val >> 16


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
Adds sampler_mu_write and sampler_mu_read functions to the sampler core device driver. The purpose is to allow for control of the buffering of samples e.g sampling on a timestamp and then recovering the results at a later time. 
Addresses issue #1738.

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |



## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Close/update issues.
- [ ] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [ ] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [ ] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

- [x] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [ ] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
