### PR TITLE
Phaser: add helpers to align updates with RTIO timeline

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -18,7 +18,7 @@ Highlights:
    - Improved documentation
    - Expose the DAC coarse mixer and ``sif_sync``
    - Exposes upconverter calibration and enabling/disabling of upconverter LO & RF outputs.
-   - Add helpers to align Phaser updates to the RTIO timeline (``get_next_frame_timestamp()``)
+   - Add helpers to align Phaser updates to the RTIO timeline (``get_next_frame_mu()``)
 * ``get()``, ``get_mu()``, ``get_att()``, and ``get_att_mu()`` functions added for AD9910 and AD9912
 * New hardware support:
    - HVAMP_8CH 8 channel HV amplifier for Fastino / Zotino

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -18,6 +18,7 @@ Highlights:
    - Improved documentation
    - Expose the DAC coarse mixer and ``sif_sync``
    - Exposes upconverter calibration and enabling/disabling of upconverter LO & RF outputs.
+   - Add helpers to align Phaser updates to the RTIO timeline (``get_next_frame_timestamp()``)
 * ``get()``, ``get_mu()``, ``get_att()``, and ``get_att_mu()`` functions added for AD9910 and AD9912
 * New hardware support:
    - HVAMP_8CH 8 channel HV amplifier for Fastino / Zotino

--- a/artiq/coredevice/phaser.py
+++ b/artiq/coredevice/phaser.py
@@ -190,7 +190,7 @@ class Phaser:
 
         gw_rev = self.read8(PHASER_ADDR_GW_REV)
         if debug:
-            print(gw_rev)
+            print("gw_rev:", gw_rev)
             self.core.break_realtime()
         delay(.1*ms)  # slack
 
@@ -267,7 +267,7 @@ class Phaser:
         if self.tune_fifo_offset:
             fifo_offset = self.dac_tune_fifo_offset()
             if debug:
-                print(fifo_offset)
+                print("fifo_offset:", fifo_offset)
                 self.core.break_realtime()
 
         # self.dac_write(0x20, 0x0000)  # stop fifo sync
@@ -279,7 +279,7 @@ class Phaser:
         delay(.1*ms)  # slack
         if alarms & ~0x0040:  # ignore PLL alarms (see DS)
             if debug:
-                print(alarms)
+                print("alarms:", alarms)
                 self.core.break_realtime()
                 # ignore alarms
             else:

--- a/artiq/coredevice/phaser.py
+++ b/artiq/coredevice/phaser.py
@@ -93,7 +93,8 @@ class Phaser:
     The latency/group delay from the RTIO events setting
     :class:`PhaserOscillator` or :class:`PhaserChannel` DUC parameters all the
     way to the DAC outputs is deterministic. This enables deterministic
-    absolute phase with respect to other RTIO input and output events.
+    absolute phase with respect to other RTIO input and output events
+    (see `get_next_frame_timestamp()`).
 
     The four analog DAC outputs are passed through anti-aliasing filters.
 
@@ -891,7 +892,7 @@ class PhaserChannel:
 
         By default, the new NCO phase applies on completion of the SPI
         transfer. This also causes a staged NCO frequency to be applied.
-        Different triggers for applying nco settings may be configured through
+        Different triggers for applying NCO settings may be configured through
         the `syncsel_mixerxx` fields in the `dac` configuration dictionary (see
         `__init__()`).
 
@@ -909,7 +910,7 @@ class PhaserChannel:
 
         By default, the new NCO phase applies on completion of the SPI
         transfer. This also causes a staged NCO frequency to be applied.
-        Different triggers for applying nco settings may be configured through
+        Different triggers for applying NCO settings may be configured through
         the `syncsel_mixerxx` fields in the `dac` configuration dictionary (see
         `__init__()`).
 
@@ -1046,7 +1047,7 @@ class PhaserOscillator:
     """Phaser IQ channel oscillator (NCO/DDS).
 
     .. note:: Latencies between oscillators within a channel and between
-        oscillator paramters (amplitude and phase/frequency) are deterministic
+        oscillator parameters (amplitude and phase/frequency) are deterministic
         (with respect to the 25 MS/s sample clock) but not matched.
     """
     kernel_invariants = {"channel", "base_addr"}


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

When starting with Phaser, it is not totally obvious how to align updates to the RTIO timeline. This patch introduces `get_next_frame_timestamp()` for the following usage (`phaser0.channel[0]` DUC-only single-tone output phase is stable with respect to the output trigger on `ttl4`):

```python
from artiq.experiment import *


class PhaserDeterministicLatency(EnvExperiment):
    def build(self):
        self.setattr_device("core")
        self.phaser = self.get_device("phaser0")
        self.trg = self.get_device("ttl4")

    @kernel
    def run(self):
        self.core.reset()
        self.phaser.init(debug=True)
        self.trg.output()

        self.phaser.channel[0].set_duc_frequency(102 * MHz)
        self.phaser.channel[0].set_duc_cfg(clr_once=1)
        self.phaser.channel[0].set_att(0 * dB)
        self.phaser.channel[0].oscillator[0].set_amplitude_phase_mu(
            asf=0x7FFF >> 2, clr=1
        )

        at_mu(self.phaser.get_next_frame_timestamp())
        with parallel:
            self.phaser.duc_stb()
            self.trg.pulse_mu(500)

        delay(10 * us)
        self.phaser.channel[0].set_duc_cfg(clr=1)
        self.phaser.duc_stb()
```

The frame timestamp measurement is a backport of `get_frame_timestamp()` from the [`stft_pulsegen`](https://github.com/quartiq/artiq/blob/8494001ee74af52defb56e05f2cccdf23306eb7d/artiq/coredevice/phaser.py#L1044-L1052) branch in `quartiq/artiq`. @SingularitySurfer is it the intended use case?

Further commits fix typos and add labels to the debug prints in `init()`.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
|   | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Steps 

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
