### PR TITLE
Gateware refactor: RTIOClockMultiplier, fix_serdes_timing_path

### DIFF
--- a/artiq/gateware/rtio/__init__.py
+++ b/artiq/gateware/rtio/__init__.py
@@ -5,3 +5,4 @@ from artiq.gateware.rtio.core import Core
 from artiq.gateware.rtio.analyzer import Analyzer
 from artiq.gateware.rtio.moninj import MonInj
 from artiq.gateware.rtio.dma import DMA
+from artiq.gateware.rtio.xilinx_clocking import RTIOClockMultiplier, fix_serdes_timing_path

--- a/artiq/gateware/rtio/xilinx_clocking.py
+++ b/artiq/gateware/rtio/xilinx_clocking.py
@@ -2,6 +2,7 @@ from migen import *
 from migen.genlib.cdc import MultiReg
 from misoc.interconnect.csr import *
 
+
 class RTIOClockMultiplier(Module, AutoCSR):
     def __init__(self, rtio_clk_freq):
         self.pll_reset = CSRStorage(reset=1)
@@ -15,17 +16,17 @@ class RTIOClockMultiplier(Module, AutoCSR):
         pll_locked = Signal()
         self.specials += [
             Instance("MMCME2_BASE",
-                p_CLKIN1_PERIOD=1e9/rtio_clk_freq,
-                i_CLKIN1=ClockSignal("rtio"),
-                i_RST=self.pll_reset.storage,
-                o_LOCKED=pll_locked,
+                     p_CLKIN1_PERIOD=1e9/rtio_clk_freq,
+                     i_CLKIN1=ClockSignal("rtio"),
+                     i_RST=self.pll_reset.storage,
+                     o_LOCKED=pll_locked,
 
-                p_CLKFBOUT_MULT_F=8.0, p_DIVCLK_DIVIDE=1,
+                     p_CLKFBOUT_MULT_F=8.0, p_DIVCLK_DIVIDE=1,
 
-                o_CLKFBOUT=clkfbout, i_CLKFBIN=clkfbin,
+                     o_CLKFBOUT=clkfbout, i_CLKFBIN=clkfbin,
 
-                p_CLKOUT0_DIVIDE_F=2.0, o_CLKOUT0=rtiox4_clk,
-            ),
+                     p_CLKOUT0_DIVIDE_F=2.0, o_CLKOUT0=rtiox4_clk,
+                     ),
             Instance("BUFG", i_I=clkfbout, o_O=clkfbin),
             Instance("BUFG", i_I=rtiox4_clk, o_O=self.cd_rtiox4.clk),
 

--- a/artiq/gateware/rtio/xilinx_clocking.py
+++ b/artiq/gateware/rtio/xilinx_clocking.py
@@ -1,0 +1,44 @@
+from migen import *
+from migen.genlib.cdc import MultiReg
+from misoc.interconnect.csr import *
+
+class RTIOClockMultiplier(Module, AutoCSR):
+    def __init__(self, rtio_clk_freq):
+        self.pll_reset = CSRStorage(reset=1)
+        self.pll_locked = CSRStatus()
+        self.clock_domains.cd_rtiox4 = ClockDomain(reset_less=True)
+
+        # See "Global Clock Network Deskew Using Two BUFGs" in ug472.
+        clkfbout = Signal()
+        clkfbin = Signal()
+        rtiox4_clk = Signal()
+        pll_locked = Signal()
+        self.specials += [
+            Instance("MMCME2_BASE",
+                p_CLKIN1_PERIOD=1e9/rtio_clk_freq,
+                i_CLKIN1=ClockSignal("rtio"),
+                i_RST=self.pll_reset.storage,
+                o_LOCKED=pll_locked,
+
+                p_CLKFBOUT_MULT_F=8.0, p_DIVCLK_DIVIDE=1,
+
+                o_CLKFBOUT=clkfbout, i_CLKFBIN=clkfbin,
+
+                p_CLKOUT0_DIVIDE_F=2.0, o_CLKOUT0=rtiox4_clk,
+            ),
+            Instance("BUFG", i_I=clkfbout, o_O=clkfbin),
+            Instance("BUFG", i_I=rtiox4_clk, o_O=self.cd_rtiox4.clk),
+
+            MultiReg(pll_locked, self.pll_locked.status)
+        ]
+
+
+def fix_serdes_timing_path(platform):
+    # ignore timing of path from OSERDESE2 through the pad to ISERDESE2
+    platform.add_platform_command(
+        "set_false_path -quiet "
+        "-through [get_pins -filter {{REF_PIN_NAME == OQ || REF_PIN_NAME == TQ}} "
+            "-of [get_cells -filter {{REF_NAME == OSERDESE2}}]] "
+        "-to [get_pins -filter {{REF_PIN_NAME == D}} "
+            "-of [get_cells -filter {{REF_NAME == ISERDESE2}}]]"
+    )

--- a/artiq/gateware/targets/kasli.py
+++ b/artiq/gateware/targets/kasli.py
@@ -24,6 +24,7 @@ from artiq.gateware.drtio.wrpll import WRPLL, DDMTDSamplerGTP
 from artiq.gateware.drtio.rx_synchronizer import XilinxRXSynchronizer
 from artiq.gateware.drtio import *
 from artiq.build_soc import *
+from artiq.gateware.rtio.xilinx_clocking import RTIOClockMultiplier, fix_serdes_timing_path
 
 
 class _RTIOCRG(Module, AutoCSR):
@@ -92,17 +93,6 @@ class SMAClkinForward(Module):
             Instance("ODDR", i_C=sma_clkin_buffered, i_CE=1, i_D1=0, i_D2=1, o_Q=cdr_clk_se),
             Instance("OBUFDS", i_I=cdr_clk_se, o_O=cdr_clk.p, o_OB=cdr_clk.n)
         ]
-
-
-def fix_serdes_timing_path(platform):
-    # ignore timing of path from OSERDESE2 through the pad to ISERDESE2
-    platform.add_platform_command(
-        "set_false_path -quiet "
-        "-through [get_pins -filter {{REF_PIN_NAME == OQ || REF_PIN_NAME == TQ}} "
-            "-of [get_cells -filter {{REF_NAME == OSERDESE2}}]] "
-        "-to [get_pins -filter {{REF_PIN_NAME == D}} "
-            "-of [get_cells -filter {{REF_NAME == ISERDESE2}}]]"
-    )
 
 
 class StandaloneBase(MiniSoC, AMPSoC):
@@ -255,37 +245,6 @@ class SUServo(StandaloneBase):
             pads.clkout, self.crg.cd_sys.clk)
 
 
-class _RTIOClockMultiplier(Module, AutoCSR):
-    def __init__(self, rtio_clk_freq):
-        self.pll_reset = CSRStorage(reset=1)
-        self.pll_locked = CSRStatus()
-        self.clock_domains.cd_rtiox4 = ClockDomain(reset_less=True)
-
-        # See "Global Clock Network Deskew Using Two BUFGs" in ug472.
-        clkfbout = Signal()
-        clkfbin = Signal()
-        rtiox4_clk = Signal()
-        pll_locked = Signal()
-        self.specials += [
-            Instance("MMCME2_BASE",
-                p_CLKIN1_PERIOD=1e9/rtio_clk_freq,
-                i_CLKIN1=ClockSignal("rtio"),
-                i_RST=self.pll_reset.storage,
-                o_LOCKED=pll_locked,
-
-                p_CLKFBOUT_MULT_F=8.0, p_DIVCLK_DIVIDE=1,
-
-                o_CLKFBOUT=clkfbout, i_CLKFBIN=clkfbin,
-
-                p_CLKOUT0_DIVIDE_F=2.0, o_CLKOUT0=rtiox4_clk,
-            ),
-            Instance("BUFG", i_I=clkfbout, o_O=clkfbin),
-            Instance("BUFG", i_I=rtiox4_clk, o_O=self.cd_rtiox4.clk),
-
-            MultiReg(pll_locked, self.pll_locked.status)
-        ]
-
-
 class MasterBase(MiniSoC, AMPSoC):
     mem_map = {
         "cri_con":       0x10000000,
@@ -400,7 +359,7 @@ class MasterBase(MiniSoC, AMPSoC):
             platform.add_false_path_constraints(
                 self.crg.cd_sys.clk, gtp.rxoutclk)
 
-        self.submodules.rtio_crg = _RTIOClockMultiplier(rtio_clk_freq)
+        self.submodules.rtio_crg = RTIOClockMultiplier(rtio_clk_freq)
         self.csr_devices.append("rtio_crg")
         fix_serdes_timing_path(platform)
 
@@ -627,7 +586,7 @@ class SatelliteBase(BaseSoC):
             platform.add_false_path_constraints(
                 self.crg.cd_sys.clk, gtp.rxoutclk)
 
-        self.submodules.rtio_crg = _RTIOClockMultiplier(rtio_clk_freq)
+        self.submodules.rtio_crg = RTIOClockMultiplier(rtio_clk_freq)
         self.csr_devices.append("rtio_crg")
         fix_serdes_timing_path(platform)
 

--- a/artiq/gateware/targets/kasli.py
+++ b/artiq/gateware/targets/kasli.py
@@ -17,6 +17,7 @@ from misoc.integration.builder import builder_args, builder_argdict
 from artiq.gateware.amp import AMPSoC
 from artiq.gateware import rtio
 from artiq.gateware.rtio.phy import ttl_simple, ttl_serdes_7series, edge_counter
+from artiq.gateware.rtio.xilinx_clocking import RTIOClockMultiplier, fix_serdes_timing_path
 from artiq.gateware import eem
 from artiq.gateware.drtio.transceiver import gtp_7series
 from artiq.gateware.drtio.siphaser import SiPhaser7Series
@@ -24,7 +25,6 @@ from artiq.gateware.drtio.wrpll import WRPLL, DDMTDSamplerGTP
 from artiq.gateware.drtio.rx_synchronizer import XilinxRXSynchronizer
 from artiq.gateware.drtio import *
 from artiq.build_soc import *
-from artiq.gateware.rtio.xilinx_clocking import RTIOClockMultiplier, fix_serdes_timing_path
 
 
 class _RTIOCRG(Module, AutoCSR):

--- a/artiq/gateware/targets/kc705.py
+++ b/artiq/gateware/targets/kc705.py
@@ -17,12 +17,12 @@ from misoc.integration.builder import builder_args, builder_argdict
 from artiq.gateware.amp import AMPSoC
 from artiq.gateware import rtio, nist_clock, nist_qc2
 from artiq.gateware.rtio.phy import ttl_simple, ttl_serdes_7series, dds, spi2
+from artiq.gateware.rtio.xilinx_clocking import RTIOClockMultiplier, fix_serdes_timing_path
 from artiq.gateware.drtio.transceiver import gtx_7series
 from artiq.gateware.drtio.siphaser import SiPhaser7Series
 from artiq.gateware.drtio.rx_synchronizer import XilinxRXSynchronizer
 from artiq.gateware.drtio import *
 from artiq.build_soc import *
-from artiq.gateware.rtio.xilinx_clocking import RTIOClockMultiplier, fix_serdes_timing_path
 
 
 class _RTIOCRG(Module, AutoCSR):

--- a/artiq/gateware/targets/kc705.py
+++ b/artiq/gateware/targets/kc705.py
@@ -22,6 +22,7 @@ from artiq.gateware.drtio.siphaser import SiPhaser7Series
 from artiq.gateware.drtio.rx_synchronizer import XilinxRXSynchronizer
 from artiq.gateware.drtio import *
 from artiq.build_soc import *
+from artiq.gateware.rtio.xilinx_clocking import RTIOClockMultiplier, fix_serdes_timing_path
 
 
 class _RTIOCRG(Module, AutoCSR):
@@ -80,48 +81,6 @@ class _RTIOCRG(Module, AutoCSR):
             AsyncResetSynchronizer(self.cd_rtio, ~pll_locked),
             MultiReg(pll_locked, self._pll_locked.status)
         ]
-
-
-class _RTIOClockMultiplier(Module, AutoCSR):
-    def __init__(self, rtio_clk_freq):
-        self.pll_reset = CSRStorage(reset=1)
-        self.pll_locked = CSRStatus()
-        self.clock_domains.cd_rtiox4 = ClockDomain(reset_less=True)
-
-        # See "Global Clock Network Deskew Using Two BUFGs" in ug472.
-        clkfbout = Signal()
-        clkfbin = Signal()
-        rtiox4_clk = Signal()
-        pll_locked = Signal()
-        self.specials += [
-            Instance("MMCME2_BASE",
-                p_CLKIN1_PERIOD=1e9/rtio_clk_freq,
-                i_CLKIN1=ClockSignal("rtio"),
-                i_RST=self.pll_reset.storage,
-                o_LOCKED=pll_locked,
-
-                p_CLKFBOUT_MULT_F=8.0, p_DIVCLK_DIVIDE=1,
-
-                o_CLKFBOUT=clkfbout, i_CLKFBIN=clkfbin,
-
-                p_CLKOUT0_DIVIDE_F=2.0, o_CLKOUT0=rtiox4_clk,
-            ),
-            Instance("BUFG", i_I=clkfbout, o_O=clkfbin),
-            Instance("BUFG", i_I=rtiox4_clk, o_O=self.cd_rtiox4.clk),
-
-            MultiReg(pll_locked, self.pll_locked.status)
-        ]
-
-
-def fix_serdes_timing_path(platform):
-    # ignore timing of path from OSERDESE2 through the pad to ISERDESE2
-    platform.add_platform_command(
-        "set_false_path -quiet "
-        "-through [get_pins -filter {{REF_PIN_NAME == OQ || REF_PIN_NAME == TQ}} "
-            "-of [get_cells -filter {{REF_NAME == OSERDESE2}}]] "
-        "-to [get_pins -filter {{REF_PIN_NAME == D}} "
-            "-of [get_cells -filter {{REF_NAME == ISERDESE2}}]]"
-    )
 
 
 # The default voltage for these signals on KC705 is 2.5V, and the Migen platform
@@ -349,7 +308,7 @@ class _MasterBase(MiniSoC, AMPSoC):
             platform.add_false_path_constraints(
                 self.crg.cd_sys.clk, gtx0.txoutclk, gtx.rxoutclk)
 
-        self.submodules.rtio_crg = _RTIOClockMultiplier(self.drtio_transceiver.rtio_clk_freq)
+        self.submodules.rtio_crg = RTIOClockMultiplier(self.drtio_transceiver.rtio_clk_freq)
         self.csr_devices.append("rtio_crg")
         fix_serdes_timing_path(platform)
 
@@ -498,7 +457,7 @@ class _SatelliteBase(BaseSoC):
             platform.add_false_path_constraints(
                 self.crg.cd_sys.clk, gtx.rxoutclk)
 
-        self.submodules.rtio_crg = _RTIOClockMultiplier(self.drtio_transceiver.rtio_clk_freq)
+        self.submodules.rtio_crg = RTIOClockMultiplier(self.drtio_transceiver.rtio_clk_freq)
         self.csr_devices.append("rtio_crg")
         fix_serdes_timing_path(platform)
 

--- a/artiq/gateware/targets/sayma_rtm.py
+++ b/artiq/gateware/targets/sayma_rtm.py
@@ -18,6 +18,7 @@ from misoc.integration.builder import Builder, builder_args, builder_argdict
 from artiq.gateware import rtio
 from artiq.gateware import jesd204_tools
 from artiq.gateware.rtio.phy import ttl_simple, ttl_serdes_7series
+from artiq.gateware.rtio.xilinx_clocking import RTIOClockMultiplier, fix_serdes_timing_path
 from artiq.gateware.drtio.transceiver import gtp_7series
 from artiq.gateware.drtio.siphaser import SiPhaser7Series
 from artiq.gateware.drtio.wrpll import WRPLL, DDMTDSamplerGTP
@@ -25,7 +26,6 @@ from artiq.gateware.drtio.rx_synchronizer import XilinxRXSynchronizer
 from artiq.gateware.drtio import *
 from artiq.build_soc import add_identifier
 from artiq import __artiq_dir__ as artiq_dir
-from artiq.gateware.rtio.xilinx_clocking import RTIOClockMultiplier, fix_serdes_timing_path
 
 
 class _SatelliteBase(BaseSoC):

--- a/artiq/gateware/targets/sayma_rtm.py
+++ b/artiq/gateware/targets/sayma_rtm.py
@@ -25,48 +25,7 @@ from artiq.gateware.drtio.rx_synchronizer import XilinxRXSynchronizer
 from artiq.gateware.drtio import *
 from artiq.build_soc import add_identifier
 from artiq import __artiq_dir__ as artiq_dir
-
-
-def fix_serdes_timing_path(platform):
-    # ignore timing of path from OSERDESE2 through the pad to ISERDESE2
-    platform.add_platform_command(
-        "set_false_path -quiet "
-        "-through [get_pins -filter {{REF_PIN_NAME == OQ || REF_PIN_NAME == TQ}} "
-            "-of [get_cells -filter {{REF_NAME == OSERDESE2}}]] "
-        "-to [get_pins -filter {{REF_PIN_NAME == D}} "
-            "-of [get_cells -filter {{REF_NAME == ISERDESE2}}]]"
-    )
-
-
-class _RTIOClockMultiplier(Module, AutoCSR):
-    def __init__(self, rtio_clk_freq):
-        self.pll_reset = CSRStorage(reset=1)
-        self.pll_locked = CSRStatus()
-        self.clock_domains.cd_rtiox4 = ClockDomain(reset_less=True)
-
-        # See "Global Clock Network Deskew Using Two BUFGs" in ug472.
-        clkfbout = Signal()
-        clkfbin = Signal()
-        rtiox4_clk = Signal()
-        pll_locked = Signal()
-        self.specials += [
-            Instance("MMCME2_BASE",
-                p_CLKIN1_PERIOD=1e9/rtio_clk_freq,
-                i_CLKIN1=ClockSignal("rtio"),
-                i_RST=self.pll_reset.storage,
-                o_LOCKED=pll_locked,
-
-                p_CLKFBOUT_MULT_F=8.0, p_DIVCLK_DIVIDE=1,
-
-                o_CLKFBOUT=clkfbout, i_CLKFBIN=clkfbin,
-
-                p_CLKOUT0_DIVIDE_F=2.0, o_CLKOUT0=rtiox4_clk,
-            ),
-            Instance("BUFG", i_I=clkfbout, o_O=clkfbin),
-            Instance("BUFG", i_I=rtiox4_clk, o_O=self.cd_rtiox4.clk),
-
-            MultiReg(pll_locked, self.pll_locked.status)
-        ]
+from artiq.gateware.rtio.xilinx_clocking import RTIOClockMultiplier, fix_serdes_timing_path
 
 
 class _SatelliteBase(BaseSoC):
@@ -178,7 +137,7 @@ class _SatelliteBase(BaseSoC):
             self.crg.cd_sys.clk,
             gtp.txoutclk, gtp.rxoutclk)
 
-        self.submodules.rtio_crg = _RTIOClockMultiplier(rtio_clk_freq)
+        self.submodules.rtio_crg = RTIOClockMultiplier(rtio_clk_freq)
         self.csr_devices.append("rtio_crg")
         fix_serdes_timing_path(platform)
 


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

A small refactor, in which ``_RTIOClockMultiplier`` and ``fix_serdes_timing_path`` duplicate functions were moved from kasli, kc705 and sayama_rtm into one module, ``artiq.gateware.rtio.rtio.xilinx_clocking`` for better clarity, and to be used by artiq-zynq as well.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
|   | :bug: Bug fix  |
|   | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |
|   | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
