### PR TITLE
flake: Fix missing deps for devShell for Metlino/Sayma - jesd204b, microscope

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -193,6 +193,18 @@
         propagatedBuildInputs = with pkgs.python3Packages; [ migen misoc ];
       };
 
+      microscope = pkgs.python3Packages.buildPythonPackage rec {
+        pname = "microscope";
+        version = "unstable-2020-12-28";
+        src = pkgs.fetchFromGitHub {
+          owner = "m-labs";
+          repo = "microscope";
+          rev = "c21afe7a53258f05bde57e5ebf2e2761f3d495e4";
+          sha256 = "sha256-jzyiLRuEf7p8LdhmZvOQj/dyQx8eUE8p6uRlwoiT8vg=";
+        };
+        propagatedBuildInputs = with pkgs.python3Packages; [ pyserial prettytable msgpack migen ];
+      };
+
       cargo-xbuild = rustPlatform.buildRustPackage rec {
         pname = "cargo-xbuild";
         version = "0.6.5";
@@ -345,7 +357,7 @@
       devShell.x86_64-linux = pkgs.mkShell {
         name = "artiq-dev-shell";
         buildInputs = [
-          (pkgs.python3.withPackages(ps: with packages.x86_64-linux; [ migen misoc jesd204b artiq ps.paramiko ps.jsonschema ]))
+          (pkgs.python3.withPackages(ps: with packages.x86_64-linux; [ migen misoc jesd204b artiq ps.paramiko ps.jsonschema microscope ]))
           rustPlatform.rust.rustc
           rustPlatform.rust.cargo
           cargo-xbuild


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Add the following dependencies to Nix Flake for development purposes on Metlino and Sayma:
* https://github.com/m-labs/jesd204b/commit/bf1cd9014c8b7a9db67609f653634daaf3bcd39b (same as [git.m-labs.hk:M-Labs/nix-scripts](https://git.m-labs.hk/M-Labs/nix-scripts/src/commit/cf0d3d70e62d1934dbf7a1f71b1b45b2db8810d1/artiq-fast/pkgs/python-deps.nix#L147)) 
* https://github.com/m-labs/microscope/commit/c21afe7a53258f05bde57e5ebf2e2761f3d495e4 (current [git.m-labs.hk:M-Labs/nix-scripts](https://git.m-labs.hk/M-Labs/nix-scripts/src/commit/cf0d3d70e62d1934dbf7a1f71b1b45b2db8810d1/artiq-fast/pkgs/python-deps.nix#L126) uses the older commit, but that should be fixed since msgpack has been pumped as in latest nixpkgs-stable)

### Related Issue

Closes #1762.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

