### PR TITLE
flake: Fix missing dependencies for Vivado GUI mode

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,8 @@
         xorg.libXext
         xorg.libXtst
         xorg.libXi
+        freetype
+        fontconfig
       ];
 
       sipyco = pkgs.python3Packages.buildPythonPackage {


### PR DESCRIPTION
# ARTIQ Pull Request

## Issue

Prior to this fix, after entering the Nix shell with `nix develop`, the user could not launch Vivado in GUI mode (`vivado -mode gui`). The error log suggests that `libfreetype` could not be found, and `java.lang.NullPointerException` was emitted from `java.desktop/sun.awt.FontConfiguration`.

## Description of Changes

Fix the following missing dependencies for properly launching Vivado in GUI mode:
* `freetype` library: https://freetype.org/index.html
* `fontconfig` library: https://www.freedesktop.org/wiki/Software/fontconfig/

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

