### PR TITLE
artiq_flash: Allow flashing Sayma RTM even if AMC artifacts are missing

### DIFF
--- a/artiq/frontend/artiq_flash.py
+++ b/artiq/frontend/artiq_flash.py
@@ -362,7 +362,10 @@ def main():
                 variants.remove("rtm")
             except ValueError:
                 pass
-        if len(variants) == 0:
+        if all(action in ["rtm_gateware", "storage", "rtm_load", "erase", "start"]
+            for action in args.action) and args.action:
+            pass
+        elif len(variants) == 0:
             raise FileNotFoundError("no variants found, did you install a board binary package?")
         elif len(variants) == 1:
             variant = variants[0]


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

This allows the user to flash (i.e. with `rtm_gateware` as an action) or load (`rtm_load`) bistreams for Sayma RTM in the absence of the Sayma AMC binaries and bitstreams.

Prior to this fix, the user must create a dummy directory (e.g. named `satellite`) inside the `--dir` path, in order to perform any of the above non-AMC specific actions. Otherwise, `artiq_flash` will raise `FileNotFoundError: no variants found, did you install a board binary package?`.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

