### PR TITLE
Fix DRTIO message alignment

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -38,6 +38,7 @@ Breaking changes:
 * Phaser: fixed coarse mixer frequency configuration
 * Mirny: Added extra delays in ``ADF5356.sync()``. This avoids the need of an extra delay before
   calling `ADF5356.init()`.
+* DRTIO: Changed message alignment from 32-bits to 64-bits.
 
 
 ARTIQ-6

--- a/artiq/firmware/libboard_artiq/drtioaux.rs
+++ b/artiq/firmware/libboard_artiq/drtioaux.rs
@@ -137,11 +137,10 @@ pub fn send(linkno: u8, packet: &Packet) -> Result<(), Error<!>> {
 
         packet.write_to(&mut writer)?;
 
-        let padding = 4 - (writer.position() % 4);
-        if padding != 4 {
-            for _ in 0..padding {
-                writer.write_u8(0)?;
-            }
+        // Pad till offset 4, insert checksum there
+        let padding = (12 - (writer.position() % 8)) % 8;
+        for _ in 0..padding {
+            writer.write_u8(0)?;
         }
 
         let checksum = crc::crc32::checksum_ieee(&writer.get_ref()[0..writer.position()]);


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
DRTIO messages are now 64-bits aligned. See discussion in #1779.

## Tests
Tested with Kasli v1.1 and Kasli v2.0 using DRTIO.

### Related Issue
Closes #1779

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Close/update issues.
- [ ] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
