### PR TITLE
Remove xbuild and use build-std feature

### DIFF
--- a/artiq/firmware/Cargo.lock
+++ b/artiq/firmware/Cargo.lock
@@ -109,12 +109,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "compiler_builtins"
-version = "0.1.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3748f82c7d366a0b4950257d19db685d4958d2fa27c6d164a3f069fec42b748b"
-
-[[package]]
 name = "crc"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,7 +131,6 @@ version = "0.0.0"
 name = "eh"
 version = "0.0.0"
 dependencies = [
- "compiler_builtins",
  "cslice",
  "libc 0.1.0",
  "unwind",

--- a/artiq/firmware/bootloader/Makefile
+++ b/artiq/firmware/bootloader/Makefile
@@ -7,6 +7,8 @@ export XBUILD_SYSROOT_PATH=$(BUILDINC_DIRECTORY)/../sysroot
 
 all:: bootloader.bin
 
+cargo = cargo build -Z build-std=core
+
 .PHONY: $(RUSTOUT)/libbootloader.a
 $(RUSTOUT)/libbootloader.a:
 	$(cargo) --target-dir ./cargo \

--- a/artiq/firmware/bootloader/Makefile
+++ b/artiq/firmware/bootloader/Makefile
@@ -3,8 +3,6 @@ include $(MISOC_DIRECTORY)/software/common.mak
 
 RUSTFLAGS += -Cpanic=abort
 
-export XBUILD_SYSROOT_PATH=$(BUILDINC_DIRECTORY)/../sysroot
-
 all:: bootloader.bin
 
 cargo = cargo build -Z build-std=core

--- a/artiq/firmware/ksupport/Makefile
+++ b/artiq/firmware/ksupport/Makefile
@@ -18,6 +18,8 @@ export XBUILD_SYSROOT_PATH=$(BUILDINC_DIRECTORY)/../sysroot
 
 all:: ksupport.elf
 
+cargo = cargo build -Z build-std=core,alloc
+
 .PHONY: $(RUSTOUT)/libksupport.a
 $(RUSTOUT)/libksupport.a:
 	$(cargo) --target-dir ./cargo \

--- a/artiq/firmware/ksupport/Makefile
+++ b/artiq/firmware/ksupport/Makefile
@@ -14,8 +14,6 @@ LDFLAGS += --eh-frame-hdr \
 
 RUSTFLAGS += -Cpanic=unwind
 
-export XBUILD_SYSROOT_PATH=$(BUILDINC_DIRECTORY)/../sysroot
-
 all:: ksupport.elf
 
 cargo = cargo build -Z build-std=core,alloc

--- a/artiq/firmware/libeh/Cargo.toml
+++ b/artiq/firmware/libeh/Cargo.toml
@@ -11,4 +11,3 @@ path = "lib.rs"
 cslice = { version = "0.3" }
 libc = { path = "../libc" }
 unwind = { path = "../libunwind" }
-compiler_builtins = "=0.1.39"    # A dependency of alloc, libeh doesn't need it

--- a/artiq/firmware/runtime/Makefile
+++ b/artiq/firmware/runtime/Makefile
@@ -10,8 +10,6 @@ LDFLAGS += \
 
 RUSTFLAGS += -Cpanic=unwind
 
-export XBUILD_SYSROOT_PATH=$(BUILDINC_DIRECTORY)/../sysroot
-
 all:: runtime.bin runtime.fbi
 
 cargo = cargo build -Z build-std=core,alloc

--- a/artiq/firmware/runtime/Makefile
+++ b/artiq/firmware/runtime/Makefile
@@ -14,6 +14,8 @@ export XBUILD_SYSROOT_PATH=$(BUILDINC_DIRECTORY)/../sysroot
 
 all:: runtime.bin runtime.fbi
 
+cargo = cargo build -Z build-std=core,alloc
+
 .PHONY: $(RUSTOUT)/libruntime.a
 $(RUSTOUT)/libruntime.a:
 	$(cargo) --target-dir ./cargo \

--- a/artiq/firmware/satman/Makefile
+++ b/artiq/firmware/satman/Makefile
@@ -9,6 +9,8 @@ export XBUILD_SYSROOT_PATH=$(BUILDINC_DIRECTORY)/../sysroot
 
 all:: satman.bin satman.fbi
 
+cargo = cargo build -Z build-std=core
+
 .PHONY: $(RUSTOUT)/libsatman.a
 $(RUSTOUT)/libsatman.a:
 	$(cargo) --target-dir ./cargo \

--- a/artiq/firmware/satman/Makefile
+++ b/artiq/firmware/satman/Makefile
@@ -5,8 +5,6 @@ LDFLAGS += -L../libbase
 
 RUSTFLAGS += -Cpanic=abort
 
-export XBUILD_SYSROOT_PATH=$(BUILDINC_DIRECTORY)/../sysroot
-
 all:: satman.bin satman.fbi
 
 cargo = cargo build -Z build-std=core

--- a/flake.nix
+++ b/flake.nix
@@ -218,20 +218,6 @@
         propagatedBuildInputs = with pkgs.python3Packages; [ pyserial prettytable msgpack migen ];
       };
 
-      cargo-xbuild = rustPlatform.buildRustPackage rec {
-        pname = "cargo-xbuild";
-        version = "0.6.5";
-
-        src = pkgs.fetchFromGitHub {
-          owner = "rust-osdev";
-          repo = pname;
-          rev = "v${version}";
-          sha256 = "18djvygq9v8rmfchvi2hfj0i6fhn36m716vqndqnj56fiqviwxvf";
-        };
-
-        cargoSha256 = "13sj9j9kl6js75h9xq0yidxy63vixxm9q3f8jil6ymarml5wkhx8";
-      };
-
       vivadoEnv = pkgs.buildFHSUserEnv {
         name = "vivado-env";
         targetPkgs = vivadoDeps;
@@ -262,7 +248,6 @@
             pkgs.lld_11
             vivado
             rustPlatform.cargoSetupHook
-            cargo-xbuild
           ];
           buildPhase = 
             ''
@@ -375,7 +360,6 @@
           (pkgs.python3.withPackages(ps: with packages.x86_64-linux; [ migen misoc jesd204b artiq ps.paramiko ps.jsonschema microscope ]))
           rustPlatform.rust.rustc
           rustPlatform.rust.cargo
-          cargo-xbuild
           pkgs.llvmPackages_11.clang-unwrapped
           pkgs.llvm_11
           pkgs.lld_11


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

This is a simple PR that removes the need for cargo xbuild, and introduces to use `build-std` that existed since nightly 2020–07–15. In fact, the developer of xbuild also suggested [using the build-std feature instead](https://github.com/rust-osdev/cargo-xbuild#alternative-the-build-std-feature-of-cargo). The only downside of this is a nightly version of Rust is required.

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

It also logically reverts some of the series of changes in https://github.com/m-labs/artiq/commit/dcbd9f905c3ea9b221eb94fe6c838c375a71ca4b