### PR TITLE
Host report for async error upon kernel termination

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -39,7 +39,8 @@ Breaking changes:
 * Mirny: Added extra delays in ``ADF5356.sync()``. This avoids the need of an extra delay before
   calling `ADF5356.init()`.
 * DRTIO: Changed message alignment from 32-bits to 64-bits.
-
+* When an RTIO async error was spotted by the kernel, it will now report back to the host
+  and prints a warning message
 
 ARTIQ-6
 -------

--- a/artiq/coredevice/comm_kernel.py
+++ b/artiq/coredevice/comm_kernel.py
@@ -636,18 +636,15 @@ class CommKernel:
         python_exn.artiq_core_exception = core_exn
         raise python_exn
 
-    def _warn_async_errors(self, collision, busy_error, sequence_error):
-        map_name = lambda y, z: [f"{y}(s)"] if z else []
-        errors = map_name("collision", collision) + \
-                 map_name("busy error", busy_error) + \
-                 map_name("sequence error", sequence_error)
-        logger.warning(f"{(', '.join(errors[:-1]) + ' and ') if len(errors) > 1 else ''}{errors[-1]} "
-                       f"reported during kernel execution")
-
     def _process_async_error(self):
         errors = self._read_int8()
         if errors > 0:
-            self._warn_async_errors(errors & 2**0, errors & 2**1, errors & 2**2)
+            map_name = lambda y, z: [f"{y}(s)"] if z else []
+            errors = map_name("collision",      errors & 2 ** 0) + \
+                     map_name("busy error",     errors & 2 ** 1) + \
+                     map_name("sequence error", errors & 2 ** 2)
+            logger.warning(f"{(', '.join(errors[:-1]) + ' and ') if len(errors) > 1 else ''}{errors[-1]} "
+                           f"reported during kernel execution")
 
     def serve(self, embedding_map, symbolizer, demangler):
         while True:

--- a/artiq/coredevice/comm_kernel.py
+++ b/artiq/coredevice/comm_kernel.py
@@ -621,6 +621,7 @@ class CommKernel:
         function = self._read_string()
 
         backtrace = [self._read_int32() for _ in range(self._read_int32())]
+        self._process_async_error()
 
         traceback = list(reversed(symbolizer(backtrace))) + \
             [(filename, line, column, *demangler([function]), None)]
@@ -635,6 +636,19 @@ class CommKernel:
         python_exn.artiq_core_exception = core_exn
         raise python_exn
 
+    def _warn_async_errors(self, collision, busy_error, sequence_error):
+        map_name = lambda y, z: [f"{y}(s)"] if z else []
+        errors = map_name("collision", collision) + \
+                 map_name("busy error", busy_error) + \
+                 map_name("sequence error", sequence_error)
+        logger.warning(f"{(', '.join(errors[:-1]) + ' and ') if len(errors) > 1 else ''}{errors[-1]} "
+                       f"reported during kernel execution")
+
+    def _process_async_error(self):
+        errors = self._read_int8()
+        if errors > 0:
+            self._warn_async_errors(errors & 2**0, errors & 2**1, errors & 2**2)
+
     def serve(self, embedding_map, symbolizer, demangler):
         while True:
             self._read_header()
@@ -646,4 +660,5 @@ class CommKernel:
                 raise exceptions.ClockFailure
             else:
                 self._read_expect(Reply.KernelFinished)
+                self._process_async_error()
                 return

--- a/artiq/firmware/runtime/rtio_mgt.rs
+++ b/artiq/firmware/runtime/rtio_mgt.rs
@@ -326,6 +326,14 @@ pub mod drtio {
     pub fn reset(_io: &Io, _aux_mutex: &Mutex) {}
 }
 
+static mut SEEN_ASYNC_ERRORS: u8 = 0;
+
+pub unsafe fn get_async_errors() -> u8 {
+    let mut errors = SEEN_ASYNC_ERRORS;
+    SEEN_ASYNC_ERRORS = 0;
+    errors
+}
+
 fn async_error_thread(io: Io) {
     loop {
         unsafe {
@@ -343,6 +351,7 @@ fn async_error_thread(io: Io) {
                 error!("RTIO sequence error involving channel {}",
                        csr::rtio_core::sequence_error_channel_read());
             }
+            SEEN_ASYNC_ERRORS = errors;
             csr::rtio_core::async_error_write(errors);
         }
     }


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

When an asynchronous error such as RTIO channel collision, there no indications nor hints to tell the host something wrong happened. This PR tries to inform the host as best as possible. High latency DRTIO are yet to be tested, plus the use of network in DRTIO will be very tricky to handle (per https://github.com/m-labs/artiq/issues/1644#issuecomment-806897336).
 
### Related Issue

Closes #1644

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [ ] Close/update issues.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [ ] Test your changes or have someone test them. Mention what was tested and how.
- [ ] Add and check docstrings and comments
- [ ] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

- [ ] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
