### PR TITLE
Support for DRTIO 100MHz

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -28,6 +28,7 @@ Highlights:
   repository when building the list of experiments.
 * The configuration entry ``rtio_clock`` supports multiple clocking settings, deprecating the usage
   of compile-time options.
+* DRTIO: added support for 100MHz clock.
 
 Breaking changes:
 

--- a/artiq/firmware/satman/main.rs
+++ b/artiq/firmware/satman/main.rs
@@ -447,6 +447,19 @@ const SI5324_SETTINGS: si5324::FrequencySettings
     crystal_ref: true
 };
 
+#[cfg(all(has_si5324, rtio_frequency = "100.0"))]
+const SI5324_SETTINGS: si5324::FrequencySettings
+    = si5324::FrequencySettings {
+    n1_hs  : 5,
+    nc1_ls : 10,
+    n2_hs  : 10,
+    n2_ls  : 250,
+    n31    : 50,
+    n32    : 50,
+    bwsel  : 4,
+    crystal_ref: true
+};
+
 #[no_mangle]
 pub extern fn main() -> i32 {
     extern {

--- a/artiq/gateware/drtio/siphaser.py
+++ b/artiq/gateware/drtio/siphaser.py
@@ -4,7 +4,7 @@ from migen.genlib.cdc import MultiReg, PulseSynchronizer
 from misoc.interconnect.csr import *
 
 
-# This code assumes 125/62.5MHz reference clock and 125MHz or 150MHz RTIO
+# This code assumes 125/62.5MHz reference clock and 100MHz, 125MHz or 150MHz RTIO
 # frequency.
 
 class SiPhaser7Series(Module, AutoCSR):
@@ -15,9 +15,9 @@ class SiPhaser7Series(Module, AutoCSR):
         self.phase_shift_done = CSRStatus(reset=1)
         self.error = CSR()
 
-        assert rtio_clk_freq in (125e6, 150e6)
+        assert rtio_clk_freq in (100e6, 125e6, 150e6)
 
-        # 125MHz/62.5MHz reference clock to 125MHz/150MHz. VCO @ 750MHz.
+        # 125MHz/62.5MHz reference clock to 100MHz/125MHz/150MHz. VCO @ 750MHz.
         # Used to provide a startup clock to the transceiver through the Si,
         # we do not use the crystal reference so that the PFD (f3) frequency
         # can be high.
@@ -43,7 +43,7 @@ class SiPhaser7Series(Module, AutoCSR):
         else:
             mmcm_freerun_output = mmcm_freerun_output_raw
 
-        # 125MHz/150MHz to 125MHz/150MHz with controllable phase shift,
+        # 100MHz/125MHz/150MHz to 100MHz/125MHz/150MHz with controllable phase shift,
         # VCO @ 1000MHz/1200MHz.
         # Inserted between CDR and output to Si, used to correct
         # non-determinstic skew of Si5324.

--- a/artiq/gateware/drtio/siphaser.py
+++ b/artiq/gateware/drtio/siphaser.py
@@ -44,7 +44,7 @@ class SiPhaser7Series(Module, AutoCSR):
             mmcm_freerun_output = mmcm_freerun_output_raw
 
         # 100MHz/125MHz/150MHz to 100MHz/125MHz/150MHz with controllable phase shift,
-        # VCO @ 1000MHz/1200MHz.
+        # VCO @ 800MHz/1000MHz/1200MHz.
         # Inserted between CDR and output to Si, used to correct
         # non-determinstic skew of Si5324.
         mmcm_ps_fb = Signal()


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

This pull request adds support for 100MHz DRTIO clock for KC705 and Kasli. The PLL and VCO frequency parameters have been checked with the datasheets for these boards and it's well within specs.

For Kasli, frequency is chosen within the JSON file ("rtio_frequency" key); for KC705 it's an additional argument for building.

Additionally, this PR includes changes in the siphaser, meaning it must be merged before the corresponding PR in artiq-zynq repo.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Close/update issues.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
