### PR TITLE
comm_kernel: only send replies when no user-defined RPC function throws in service

### DIFF
--- a/artiq/coredevice/comm_kernel.py
+++ b/artiq/coredevice/comm_kernel.py
@@ -557,12 +557,6 @@ class CommKernel:
             result = service(*args, **kwargs)
             logger.debug("rpc service: %d %r %r = %r",
                          service_id, args, kwargs, result)
-
-            self._write_header(Request.RPCReply)
-            self._write_bytes(return_tags)
-            self._send_rpc_value(bytearray(return_tags),
-                                 result, result, service)
-            self._flush()
         except RPCReturnValueError as exn:
             raise
         except Exception as exn:
@@ -608,6 +602,12 @@ class CommKernel:
                 self._write_int32(line)
                 self._write_int32(-1)  # column not known
                 self._write_string(function)
+            self._flush()
+        else:
+            self._write_header(Request.RPCReply)
+            self._write_bytes(return_tags)
+            self._send_rpc_value(bytearray(return_tags),
+                                 result, result, service)
             self._flush()
 
     def _serve_exception(self, embedding_map, symbolizer, demangler):

--- a/artiq/coredevice/comm_kernel.py
+++ b/artiq/coredevice/comm_kernel.py
@@ -555,8 +555,6 @@ class CommKernel:
 
         try:
             result = service(*args, **kwargs)
-            logger.debug("rpc service: %d %r %r = %r",
-                         service_id, args, kwargs, result)
         except RPCReturnValueError as exn:
             raise
         except Exception as exn:
@@ -604,6 +602,8 @@ class CommKernel:
                 self._write_string(function)
             self._flush()
         else:
+            logger.debug("rpc service: %d %r %r = %r",
+                         service_id, args, kwargs, result)
             self._write_header(Request.RPCReply)
             self._write_bytes(return_tags)
             self._send_rpc_value(bytearray(return_tags),


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

This PR fixes an issue when an exception happens after running the service function in RPC service routine. Previously I tried to catch `struct.error` as a quick fix, but it seems like the fundamental issue is not just because of that. 

The problem started with this part, after running the service routine:
https://github.com/m-labs/artiq/blob/bbac4770926048b3c0b434aede371a63d198ecd5/artiq/coredevice/comm_kernel.py#L561-L564

And when an exception happened around that part:

https://github.com/m-labs/artiq/blob/bbac4770926048b3c0b434aede371a63d198ecd5/artiq/coredevice/comm_kernel.py#L568-L572

It is possible that the `RPCException` is being mistaken as part of the `RPCReply`, which is going to confuse the host kernel.

One possible way of fixing this is to discard the write buffer when an exception happens. Another solution is to move the RPC reply after service call was handled and checked without error, and if something is wrong in the RPC reply process, let it propagate properly
 
Check out https://github.com/m-labs/artiq/issues/1655#issuecomment-995455469 as well for extra context.

### Related Issue

Closes #1655

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

### Code Changes

- [ ] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [ ] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
