### PR TITLE
llvm_ir: move stacksave before lltag alloca in build_rpc

### DIFF
--- a/artiq/compiler/transforms/llvm_ir_generator.py
+++ b/artiq/compiler/transforms/llvm_ir_generator.py
@@ -1249,12 +1249,12 @@ class LLVMIRGenerator:
             self.engine.process(diag)
         tag += ir.rpc_tag(fun_type.ret, ret_error_handler)
 
+        llstackptr = self.llbuilder.call(self.llbuiltin("llvm.stacksave"), [],
+                                         name="rpc.stack")
+
         lltag = self.llconst_of_const(ir.Constant(tag, builtins.TStr()))
         lltagptr = self.llbuilder.alloca(lltag.type)
         self.llbuilder.store(lltag, lltagptr)
-
-        llstackptr = self.llbuilder.call(self.llbuiltin("llvm.stacksave"), [],
-                                         name="rpc.stack")
 
         llargs = self.llbuilder.alloca(llptr, ll.Constant(lli32, len(args)),
                                        name="rpc.args")


### PR DESCRIPTION
Signed-off-by: Steve Fan <sf@m-labs.hk>

# ARTIQ Pull Request

## Description of Changes

There is a minor stack errata that made some pointers dangling after restoring the stack.

https://github.com/m-labs/artiq/blob/9e5e234af31a82d053bc6c1add9eedc8bcf1d99b/artiq/compiler/transforms/llvm_ir_generator.py#L1252-L1257

This creates a potential "use-after-free" scenario (there is no `free` since this is all on stack, however, so it is more like invalid stack pointer), but this is still protected by PMP supposedly.

### Related Issue

Closes #1798

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


### Code Changes

- [ ] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [ ] Test your changes or have someone test them. Mention what was tested and how.
- [ ] Add and check docstrings and comments
- [ ] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
