### PR TITLE
Draft: Add repository directory to path when importing files from repository

### DIFF
--- a/artiq/browser/experiments.py
+++ b/artiq/browser/experiments.py
@@ -486,7 +486,7 @@ class ExperimentsArea(QtWidgets.QMdiArea):
     async def examine(self, file):
         worker = Worker(self.worker_handlers)
         try:
-            return await worker.examine("examine", file)
+            return await worker.examine("examine", file, self.current_dir)
         finally:
             await worker.close()
 

--- a/artiq/master/experiments.py
+++ b/artiq/master/experiments.py
@@ -24,7 +24,7 @@ class _RepoScanner:
         logger.debug("processing file %s %s", root, filename)
         try:
             description = await self.worker.examine(
-                "scan", os.path.join(root, filename))
+                "scan", os.path.join(root, filename), root)
         except:
             log_worker_exception()
             raise
@@ -129,6 +129,7 @@ class ExperimentDB:
             exc_to_warning(self.scan_repository(new_cur_rev)))
 
     async def examine(self, filename, use_repository=True, revision=None):
+        wd = None  # todo: else: wd = os.path.base(filename) to allow relative imports even with out-of-repo exps?
         if use_repository:
             if revision is None:
                 revision = self.cur_rev
@@ -136,7 +137,7 @@ class ExperimentDB:
             filename = os.path.join(wd, filename)
         worker = Worker(self.worker_handlers)
         try:
-            description = await worker.examine("examine", filename)
+            description = await worker.examine("examine", filename, wd)
         finally:
             await worker.close()
         if use_repository:

--- a/artiq/master/worker.py
+++ b/artiq/master/worker.py
@@ -293,7 +293,7 @@ class Worker:
     async def analyze(self):
         await self._worker_action({"action": "analyze"})
 
-    async def examine(self, rid, file, timeout=20.0):
+    async def examine(self, rid, file, wd, timeout=20.0):
         self.rid = rid
         self.filename = os.path.basename(file)
 
@@ -303,7 +303,7 @@ class Worker:
         def register(class_name, name, arginfo, scheduler_defaults):
             r[class_name] = {"name": name, "arginfo": arginfo, "scheduler_defaults": scheduler_defaults}
         self.register_experiment = register
-        await self._worker_action({"action": "examine", "file": file},
+        await self._worker_action({"action": "examine", "file": file, "wd": wd},
                                   timeout)
         del self.register_experiment
         return r

--- a/artiq/master/worker_impl.py
+++ b/artiq/master/worker_impl.py
@@ -129,8 +129,8 @@ class CCB:
     issue = staticmethod(make_parent_action("ccb_issue"))
 
 
-def get_experiment(file, class_name):
-    module = tools.file_import(file, prefix="artiq_worker_")
+def get_experiment(file, class_name, repository_path=None):
+    module = tools.file_import(file, prefix="artiq_worker_", repository_path=repository_path)
     return tools.get_experiment(module, class_name)
 
 
@@ -155,10 +155,10 @@ class ExamineDatasetMgr:
         pass
 
 
-def examine(device_mgr, dataset_mgr, file):
+def examine(device_mgr, dataset_mgr, file, wd):
     previous_keys = set(sys.modules.keys())
     try:
-        module = tools.file_import(file)
+        module = tools.file_import(file, repository_path=wd)
         for class_name, exp_class in inspect.getmembers(module, is_public_experiment):
             if exp_class.__doc__ is None:
                 name = class_name
@@ -279,7 +279,7 @@ def main():
                     experiment_file = expid["file"]
                     repository_path = None
                 setup_diagnostics(experiment_file, repository_path)
-                exp = get_experiment(experiment_file, expid["class_name"])
+                exp = get_experiment(experiment_file, expid["class_name"], repository_path)
                 device_mgr.virtual_devices["scheduler"].set_run_info(
                     rid, obj["pipeline_name"], expid, obj["priority"])
                 start_local_time = time.localtime(start_time)
@@ -311,7 +311,7 @@ def main():
                 finally:
                     write_results()
             elif action == "examine":
-                examine(ExamineDeviceMgr, ExamineDatasetMgr, obj["file"])
+                examine(ExamineDeviceMgr, ExamineDatasetMgr, obj["file"], obj["wd"])
                 put_completed()
             elif action == "terminate":
                 break

--- a/artiq/tools.py
+++ b/artiq/tools.py
@@ -70,9 +70,12 @@ def short_format(v):
         return r
 
 
-def file_import(filename, prefix="file_import_"):
+def file_import(filename, prefix="file_import_", repository_path=None):
     filename = pathlib.Path(filename)
     modname = prefix + filename.stem
+
+    if repository_path and (pathlib.Path(repository_path) / "__init__.py").exists():
+        sys.path.insert(0, repository_path)
 
     path = str(filename.resolve().parent)
     sys.path.insert(0, path)


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

When importing experiments from the repository, add the repository path to `sys.path` if it contains an `__init__.py`. Very much a draft at this point, quickly thrown together as a proof-of-concept in order to get feedback.

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
Closes #1543 

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [ ] Close/update issues.
- [ ] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [ ] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [ ] Test your changes or have someone test them. Mention what was tested and how.
- [ ] Add and check docstrings and comments
- [ ] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

Existing tests pass, but this probably warrants the addition of a few tests. I've done some local testing and imports seem to work for in-repo experiments (with git and file system repos).

### Documentation Changes

- [ ] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [ ] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [ ] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
