### PR TITLE
comm_kernel: fix off-by-one error for numeric value range check

### DIFF
--- a/artiq/coredevice/comm_kernel.py
+++ b/artiq/coredevice/comm_kernel.py
@@ -476,11 +476,27 @@ class CommKernel:
             if tag_element == "b":
                 self._write(bytes(value))
             elif tag_element == "i":
-                self._write(struct.pack(self.endian + "%sl" %
-                                        len(value), *value))
+                try:
+                    data = struct.pack(self.endian + "%sl" % len(value), *value)
+                except struct.error:
+                    raise RPCReturnValueError(
+                        "type mismatch: cannot serialize {value} as {type}"
+                        " ({function} has returned {root})".format(
+                            value=repr(value), type="32-bit integer list",
+                            function=function, root=root))
+                else:
+                    self._write(data)
             elif tag_element == "I":
-                self._write(struct.pack(self.endian + "%sq" %
-                                        len(value), *value))
+                try:
+                    data = struct.pack(self.endian + "%sq" % len(value), *value)
+                except struct.error:
+                    raise RPCReturnValueError(
+                        "type mismatch: cannot serialize {value} as {type}"
+                        " ({function} has returned {root})".format(
+                            value=repr(value), type="64-bit integer list",
+                            function=function, root=root))
+                else:
+                    self._write(data)
             elif tag_element == "f":
                 self._write(struct.pack(self.endian + "%sd" %
                                         len(value), *value))

--- a/artiq/coredevice/comm_kernel.py
+++ b/artiq/coredevice/comm_kernel.py
@@ -476,27 +476,11 @@ class CommKernel:
             if tag_element == "b":
                 self._write(bytes(value))
             elif tag_element == "i":
-                try:
-                    data = struct.pack(self.endian + "%sl" % len(value), *value)
-                except struct.error:
-                    raise RPCReturnValueError(
-                        "type mismatch: cannot serialize {value} as {type}"
-                        " ({function} has returned {root})".format(
-                            value=repr(value), type="32-bit integer list",
-                            function=function, root=root))
-                else:
-                    self._write(data)
+                self._write(struct.pack(self.endian + "%sl" %
+                                        len(value), *value))
             elif tag_element == "I":
-                try:
-                    data = struct.pack(self.endian + "%sq" % len(value), *value)
-                except struct.error:
-                    raise RPCReturnValueError(
-                        "type mismatch: cannot serialize {value} as {type}"
-                        " ({function} has returned {root})".format(
-                            value=repr(value), type="64-bit integer list",
-                            function=function, root=root))
-                else:
-                    self._write(data)
+                self._write(struct.pack(self.endian + "%sq" %
+                                        len(value), *value))
             elif tag_element == "f":
                 self._write(struct.pack(self.endian + "%sd" %
                                         len(value), *value))

--- a/artiq/test/coredevice/test_embedding.py
+++ b/artiq/test/coredevice/test_embedding.py
@@ -168,7 +168,6 @@ class RPCHostRoundtripTypeTest(ExperimentCase):
         self.assert_roundtrip_value_equal(i64_maxmin)
 
     def test_i32_bad(self):
-        # Notice: the constant itself is valid if casted as u32
         def invalid_as_i32() -> TInt32:
             return 2 ** 31
 
@@ -176,7 +175,6 @@ class RPCHostRoundtripTypeTest(ExperimentCase):
             self.assert_roundtrip_value_equal(invalid_as_i32)
 
     def test_i64_bad(self):
-        # Notice: the constant itself is valid if casted as u64
         def invalid_as_i64() -> TInt64:
             return 2 ** 63
 


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
This is the spun-off of #1801, where there are several off-by-one minor mistakes in `_send_rpc_value`. 

Unit tests included.

## Explanation

Let w be the number of bits and a w-bit signed integer i in two's complement, we should check if i is in [-2^(w-1), 2^(w-1)). However in the kernel communicator code, it is mistaken as (-2^(w-1), 2^(w-1)-1), which means (-2^(w-1), 2^(w-1)-2]. 

Equivalently, if you have an unsigned w-bit integer, check [0, 2^w) 

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

### Code Changes

- [ ] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [ ] Test your changes or have someone test them. Mention what was tested and how.
- [ ] Add and check docstrings and comments
- [ ] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
