### PR TITLE
Urukul/SU-Servo: Use constants for default profiles

### DIFF
--- a/artiq/coredevice/ad9910.py
+++ b/artiq/coredevice/ad9910.py
@@ -7,6 +7,7 @@ from artiq.language.types import TBool, TInt32, TInt64, TFloat, TList, TTuple
 
 from artiq.coredevice import spi2 as spi
 from artiq.coredevice import urukul
+from artiq.coredevice.urukul import DEFAULT_PROFILE
 
 # Work around ARTIQ-Python import machinery
 urukul_sta_pll_lock = urukul.urukul_sta_pll_lock
@@ -59,6 +60,9 @@ RAM_MODE_RAMPUP = 1
 RAM_MODE_BIDIR_RAMP = 2
 RAM_MODE_CONT_BIDIR_RAMP = 3
 RAM_MODE_CONT_RAMPUP = 4
+
+# Default profile for RAM mode
+_DEFAULT_PROFILE_RAM = 0
 
 
 class SyncDataUser:
@@ -518,7 +522,8 @@ class AD9910:
     @kernel
     def set_mu(self, ftw: TInt32 = 0, pow_: TInt32 = 0, asf: TInt32 = 0x3fff,
                phase_mode: TInt32 = _PHASE_MODE_DEFAULT,
-               ref_time_mu: TInt64 = int64(-1), profile: TInt32 = 7,
+               ref_time_mu: TInt64 = int64(-1),
+               profile: TInt32 = DEFAULT_PROFILE,
                ram_destination: TInt32 = -1) -> TInt32:
         """Set DDS data in machine units.
 
@@ -588,13 +593,14 @@ class AD9910:
         return pow_
 
     @kernel
-    def get_mu(self, profile: TInt32 = 0) -> TTuple([TInt32, TInt32, TInt32]):
+    def get_mu(self, profile: TInt32 = DEFAULT_PROFILE
+               ) -> TTuple([TInt32, TInt32, TInt32]):
         """Get the frequency tuning word, phase offset word,
         and amplitude scale factor.
 
         .. seealso:: :meth:`get`
 
-        :param profile: Profile number to get (0-7, default: 0)
+        :param profile: Profile number to get (0-7, default: 7)
         :return: A tuple ``(ftw, pow, asf)``
         """
 
@@ -608,8 +614,9 @@ class AD9910:
 
     @kernel
     def set_profile_ram(self, start: TInt32, end: TInt32, step: TInt32 = 1,
-                        profile: TInt32 = 0, nodwell_high: TInt32 = 0,
-                        zero_crossing: TInt32 = 0, mode: TInt32 = 1):
+                        profile: TInt32 = _DEFAULT_PROFILE_RAM,
+                        nodwell_high: TInt32 = 0, zero_crossing: TInt32 = 0,
+                        mode: TInt32 = 1):
         """Set the RAM profile settings.
 
         :param start: Profile start address in RAM.
@@ -839,7 +846,7 @@ class AD9910:
     @kernel
     def set(self, frequency: TFloat = 0.0, phase: TFloat = 0.0,
             amplitude: TFloat = 1.0, phase_mode: TInt32 = _PHASE_MODE_DEFAULT,
-            ref_time_mu: TInt64 = int64(-1), profile: TInt32 = 7,
+            ref_time_mu: TInt64 = int64(-1), profile: TInt32 = DEFAULT_PROFILE,
             ram_destination: TInt32 = -1) -> TFloat:
         """Set DDS data in SI units.
 
@@ -860,12 +867,13 @@ class AD9910:
             profile, ram_destination))
 
     @kernel
-    def get(self, profile: TInt32 = 0) -> TTuple([TFloat, TFloat, TFloat]):
+    def get(self, profile: TInt32 = DEFAULT_PROFILE
+            ) -> TTuple([TFloat, TFloat, TFloat]):
         """Get the frequency, phase, and amplitude.
 
         .. seealso:: :meth:`get_mu`
 
-        :param profile: Profile number to get (0-7, default: 0)
+        :param profile: Profile number to get (0-7, default: 7)
         :return: A tuple ``(frequency, phase, amplitude)``
         """
 

--- a/artiq/coredevice/urukul.py
+++ b/artiq/coredevice/urukul.py
@@ -52,6 +52,9 @@ CS_DDS_CH1 = 5
 CS_DDS_CH2 = 6
 CS_DDS_CH3 = 7
 
+# Default profile
+DEFAULT_PROFILE = 7
+
 
 @portable
 def urukul_cfg(rf_sw, led, profile, io_update, mask_nu,
@@ -188,7 +191,7 @@ class CPLD:
             assert sync_div is None
             sync_div = 0
 
-        self.cfg_reg = urukul_cfg(rf_sw=rf_sw, led=0, profile=7,
+        self.cfg_reg = urukul_cfg(rf_sw=rf_sw, led=0, profile=DEFAULT_PROFILE,
                                   io_update=0, mask_nu=0, clk_sel=clk_sel,
                                   sync_sel=sync_sel,
                                   rst=0, io_rst=0, clk_div=clk_div)

--- a/artiq/gateware/suservo/dds_ser.py
+++ b/artiq/gateware/suservo/dds_ser.py
@@ -2,6 +2,8 @@ import logging
 
 from migen import *
 
+from artiq.coredevice.urukul import DEFAULT_PROFILE
+
 from . import spi
 
 
@@ -26,7 +28,8 @@ class DDS(spi.SPISimple):
 
         self.profile = [Signal(32 + 16 + 16, reset_less=True)
                 for i in range(params.channels)]
-        cmd = Signal(8, reset=0x15)  # write to single tone profile 7
+        # write to single tone default profile
+        cmd = Signal(8, reset=0x0e + DEFAULT_PROFILE)
         assert params.width == len(cmd) + len(self.profile[0])
 
         self.sync += [


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

This PR patches the issues originated from the change of default profiles in #1584.
- AD9910 & Urukul drivers now uses the default single tone profile `DEFAULT_PROFILE` (7) as the default value of both `set`/set_mu` & `get`/`get_mu` (#1809).
- RAM profile setter uses `DEFAULT_PROFILE_RAM` (0) as default.
- SU-Servo gateware now sends to the default single tone profile.

`DEFAULT_PROFILE` concerns the default value of CPLD shift register and AD9910 itself, so it is in `urukul.py`.
`_DEFAULT_PROFILE_RAM` is only referenced in AD9910, and only AD9910 has RAM mode, so it is in `ad9910.py`.
I need some feedback about the constants.

## Tests
Ran the code in the example of #1817 and getting RF signal from Urukul, controllable by Sampler.

### Related Issue
#1809 (RAM FTW/ASF/POW getter is not ported to `get`/`get_mu`)
Closes #1817

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Close/update issues.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments

### Documentation Changes

- [x] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
