### PR TITLE
Remove worker_db warning for writing a dataset that is also in the archive

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -34,6 +34,7 @@ Highlights:
 * HDF5 options can now be passed when creating datasets with ``set_dataset``. This allows
   in particular to use transparent compression filters as follows:
   ``set_dataset(name, value, hdf5_options={"compression": "gzip"})``.
+* Removed worker DB warning for writing a dataset that is also in the archive
 
 Breaking changes:
 

--- a/artiq/master/worker_db.py
+++ b/artiq/master/worker_db.py
@@ -120,11 +120,6 @@ class DatasetManager:
 
     def set(self, key, value, broadcast=False, persist=False, archive=True,
             hdf5_options=None):
-        if key in self.archive:
-            logger.warning("Modifying dataset '%s' which is in archive, "
-                           "archive will remain untouched",
-                           key, stack_info=True)
-
         if persist:
             broadcast = True
 


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

When using `get_dataset()` to obtain a key that was stored persistent, the value is added to the archive of the dataset manager.
When using `set_dataset()` with a key that was archived earlier, you get the following warning:

```
WARNING:worker(219,artiq_test.py):artiq.master.worker_db:Modifying dataset 'foo' which is in archive, archive will remain untouched
```

I think this warning is overkill as this is the expected behavior of the archive. Nevertheless, the log can have many of these warnings. The warning especially appears when we load calibrated values from the persistent datasets and update some of these calibration values at the end of the experiment.

If others agree, I propose to remove this warning.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature? |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
