### PR TITLE
Landingpad

### DIFF
--- a/artiq/compiler/ir.py
+++ b/artiq/compiler/ir.py
@@ -1360,6 +1360,14 @@ class LandingPad(Terminator):
     def cleanup(self):
         return self.operands[0]
 
+    def erase(self):
+        self.remove_from_parent()
+        # we should erase all clauses as well
+        for block in set(self.operands):
+            block.uses.remove(self)
+            block.erase()
+        assert not any(self.uses)
+
     def clauses(self):
         return zip(self.operands[1:], self.types)
 

--- a/artiq/compiler/ir.py
+++ b/artiq/compiler/ir.py
@@ -1347,6 +1347,7 @@ class LandingPad(Terminator):
     def __init__(self, cleanup, name=""):
         super().__init__([cleanup], builtins.TException(), name)
         self.types = []
+        self.has_cleanup = True
 
     def copy(self, mapper):
         self_copy = super().copy(mapper)

--- a/artiq/compiler/transforms/artiq_ir_generator.py
+++ b/artiq/compiler/transforms/artiq_ir_generator.py
@@ -718,6 +718,8 @@ class ARTIQIRGenerator(algorithm.Visitor):
 
         cleanup = self.add_block('handler.cleanup')
         landingpad = dispatcher.append(ir.LandingPad(cleanup))
+        if not any(node.finalbody):
+            landingpad.has_cleanup = False
 
         handlers = []
         for handler_node in node.handlers:

--- a/artiq/compiler/transforms/llvm_ir_generator.py
+++ b/artiq/compiler/transforms/llvm_ir_generator.py
@@ -1625,7 +1625,8 @@ class LLVMIRGenerator:
     def process_LandingPad(self, insn):
         # Layout on return from landing pad: {%_Unwind_Exception*, %Exception*}
         lllandingpadty = ll.LiteralStructType([llptr, llptr])
-        lllandingpad = self.llbuilder.landingpad(lllandingpadty, cleanup=True)
+        lllandingpad = self.llbuilder.landingpad(lllandingpadty,
+                                                 cleanup=insn.has_cleanup)
         llrawexn = self.llbuilder.extract_value(lllandingpad, 1)
         llexn = self.llbuilder.bitcast(llrawexn, self.llty_of_type(insn.type))
         llexnnameptr = self.llbuilder.gep(llexn, [self.llindex(0), self.llindex(0)],
@@ -1634,23 +1635,34 @@ class LLVMIRGenerator:
 
         for target, typ in insn.clauses():
             if typ is None:
-                exnname = "" # see the comment in ksupport/eh.rs
+                # we use a null pointer here, similar to how cpp does it
+                # https://llvm.org/docs/ExceptionHandling.html#try-catch
+                # > If @ExcType is null, any exception matches, so the
+                # landingpad should always be entered. This is used for C++
+                # catch-all blocks (“catch (...)”).
+                lllandingpad.add_clause(
+                    ll.CatchClause(
+                        ll.Constant(lli32, 0).inttoptr(llptr)
+                    )
+                )
             else:
                 exnname = "{}:{}".format(typ.id, typ.name)
 
-            llclauseexnname = self.llconst_of_const(
-                ir.Constant(exnname, builtins.TStr()))
-            llclauseexnnameptr = self.llmodule.globals.get("exn.{}".format(exnname))
-            if llclauseexnnameptr is None:
-                llclauseexnnameptr = ll.GlobalVariable(self.llmodule, llclauseexnname.type,
-                                                       name="exn.{}".format(exnname))
-                llclauseexnnameptr.global_constant = True
-                llclauseexnnameptr.initializer = llclauseexnname
-                llclauseexnnameptr.linkage = "private"
-                llclauseexnnameptr.unnamed_addr = True
-            lllandingpad.add_clause(ll.CatchClause(llclauseexnnameptr))
+                llclauseexnname = self.llconst_of_const(
+                    ir.Constant(exnname, builtins.TStr()))
+                llclauseexnnameptr = self.llmodule.globals.get("exn.{}".format(exnname))
+                if llclauseexnnameptr is None:
+                    llclauseexnnameptr = ll.GlobalVariable(self.llmodule, llclauseexnname.type,
+                                                           name="exn.{}".format(exnname))
+                    llclauseexnnameptr.global_constant = True
+                    llclauseexnnameptr.initializer = llclauseexnname
+                    llclauseexnnameptr.linkage = "private"
+                    llclauseexnnameptr.unnamed_addr = True
+                lllandingpad.add_clause(ll.CatchClause(llclauseexnnameptr))
 
             if typ is None:
+                # typ is None means that we match all exceptions, so no need to
+                # compare
                 self.llbuilder.branch(self.map(target))
             else:
                 llexnlen       = self.llbuilder.extract_value(llexnname, 1)
@@ -1667,6 +1679,9 @@ class LLVMIRGenerator:
                         self.llbuilder.branch(self.map(target))
 
         if self.llbuilder.basic_block.terminator is None:
-            self.llbuilder.branch(self.map(insn.cleanup()))
+            if insn.has_cleanup:
+                self.llbuilder.branch(self.map(insn.cleanup()))
+            else:
+                self.llbuilder.resume(lllandingpad)
 
         return llexn


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

This PR fixes exception handling issues in ARTIQ.
1. Try blocks without a final block will not be generated as a cleanup block. Together with firmware changes, we should be able to improve exception unwinding speed, as the landingpad catch clauses can be filtered in the firmware before executing the body. This change should be backward compatible with the old firmware as the old personality function does not check for catch clauses (it will execute the landingpad anyway).
2. Fixes dead code eliminator bug regarding landingpad. Landingpad clauses were not removed previously which would cause assertion errors.
3. Fixes code generation for rethrow together with final block. The code generation was correct (except that the exception has to be lazy evaluated to make sure that it is generated in the proxy), but our local access validator and LLVM cannot reason about indirect branch control flow. This patch makes the control flow explicit so our local access validator and LLVM can understand it.

Tested with zc706. Not yet tested with riscv.

### Related Issue

Closes #1815

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Close/update issues.
- [ ] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [ ] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

- [ ] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
