### PR TITLE
comm_kernel: check if elements are within bounds for RPC list

### DIFF
--- a/artiq/coredevice/comm_kernel.py
+++ b/artiq/coredevice/comm_kernel.py
@@ -476,11 +476,23 @@ class CommKernel:
             if tag_element == "b":
                 self._write(bytes(value))
             elif tag_element == "i":
-                self._write(struct.pack(self.endian + "%sl" %
-                                        len(value), *value))
+                try:
+                    data = struct.pack(self.endian + "%sl" % len(value), *value)
+                except struct.error:
+                    raise RPCReturnValueError(
+                        "type mismatch: cannot serialize {value} as {type}".format(
+                            value=repr(value), type="32-bit integer list"))
+                else:
+                    self._write(data)
             elif tag_element == "I":
-                self._write(struct.pack(self.endian + "%sq" %
-                                        len(value), *value))
+                try:
+                    data = struct.pack(self.endian + "%sq" % len(value), *value)
+                except struct.error:
+                    raise RPCReturnValueError(
+                        "type mismatch: cannot serialize {value} as {type}".format(
+                            value=repr(value), type="64-bit integer list"))
+                else:
+                    self._write(data)
             elif tag_element == "f":
                 self._write(struct.pack(self.endian + "%sd" %
                                         len(value), *value))

--- a/artiq/coredevice/comm_kernel.py
+++ b/artiq/coredevice/comm_kernel.py
@@ -477,22 +477,18 @@ class CommKernel:
                 self._write(bytes(value))
             elif tag_element == "i":
                 try:
-                    data = struct.pack(self.endian + "%sl" % len(value), *value)
+                    self._write(struct.pack(self.endian + "%sl" % len(value), *value))
                 except struct.error:
                     raise RPCReturnValueError(
                         "type mismatch: cannot serialize {value} as {type}".format(
                             value=repr(value), type="32-bit integer list"))
-                else:
-                    self._write(data)
             elif tag_element == "I":
                 try:
-                    data = struct.pack(self.endian + "%sq" % len(value), *value)
+                    self._write(struct.pack(self.endian + "%sq" % len(value), *value))
                 except struct.error:
                     raise RPCReturnValueError(
                         "type mismatch: cannot serialize {value} as {type}".format(
                             value=repr(value), type="64-bit integer list"))
-                else:
-                    self._write(data)
             elif tag_element == "f":
                 self._write(struct.pack(self.endian + "%sd" %
                                         len(value), *value))


### PR DESCRIPTION
Signed-off-by: Steve Fan <sf@m-labs.hk>

# ARTIQ Pull Request

## Description of Changes

Adds missing type validator in `_send_rpc_value` when handling list of i32 and i64 types by checking `struct.error` and throw a RPCReturnValueError.  

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
