### PR TITLE
compiler: exception fixes

### DIFF
--- a/artiq/compiler/builtins.py
+++ b/artiq/compiler/builtins.py
@@ -123,18 +123,23 @@ class TException(types.TMono):
     #  * File, line and column where it was raised (str, int, int).
     #  * Message, which can contain substitutions {0}, {1} and {2} (str).
     #  * Three 64-bit integers, parameterizing the message (numpy.int64).
+    # These attributes are prefixed with `#` so that users cannot access them,
+    # and we don't have to do string allocation in the runtime.
+    # #__name__ is now a string key in the host. TStr may not be an actual
+    # CSlice in the runtime, they might be a CSlice with length = i32::MAX and
+    # ptr = string key in the host.
 
     # Keep this in sync with the function ARTIQIRGenerator.alloc_exn.
     attributes = OrderedDict([
-        ("__name__",    TStr()),
-        ("__file__",    TStr()),
-        ("__line__",    TInt32()),
-        ("__col__",     TInt32()),
-        ("__func__",    TStr()),
-        ("__message__", TStr()),
-        ("__param0__",  TInt64()),
-        ("__param1__",  TInt64()),
-        ("__param2__",  TInt64()),
+        ("#__name__",    TInt32()),
+        ("#__file__",    TStr()),
+        ("#__line__",    TInt32()),
+        ("#__col__",     TInt32()),
+        ("#__func__",    TStr()),
+        ("#__message__", TStr()),
+        ("#__param0__",  TInt64()),
+        ("#__param1__",  TInt64()),
+        ("#__param2__",  TInt64()),
     ])
 
     def __init__(self, name="Exception", id=0):

--- a/artiq/compiler/embedding.py
+++ b/artiq/compiler/embedding.py
@@ -50,9 +50,22 @@ class EmbeddingMap:
         self.str_forward_map = {}
         self.str_reverse_map = {}
 
+        self.preallocate_runtime_exception_names(["RuntimeError",
+                                                  "RTIOUnderflow",
+                                                  "RTIOOverflow",
+                                                  "RTIODestinationUnreachable",
+                                                  "DMAError",
+                                                  "I2CError",
+                                                  "CacheError",
+                                                  "SPIError",
+                                                  "0:ZeroDivisionError",
+                                                  "0:IndexError"])
+
     def preallocate_runtime_exception_names(self, names):
         for i, name in enumerate(names):
-            exn_id = self.store_str("0:artiq.coredevice.exceptions." + name)
+            if ":" not in name:
+                name = "0:artiq.coredevice.exceptions." + name
+            exn_id = self.store_str(name)
             assert exn_id == i
 
     def store_str(self, s):
@@ -754,12 +767,6 @@ class Stitcher:
         self.functions = {}
 
         self.embedding_map = EmbeddingMap()
-        self.embedding_map.preallocate_runtime_exception_names(["runtimeerror",
-                                                                "RTIOUnderflow",
-                                                                "RTIOOverflow",
-                                                                "RTIODestinationUnreachable",
-                                                                "DMAError",
-                                                                "I2CError"])
         self.value_map = defaultdict(lambda: [])
         self.definitely_changed = False
 

--- a/artiq/compiler/embedding.py
+++ b/artiq/compiler/embedding.py
@@ -47,6 +47,24 @@ class EmbeddingMap:
         self.module_map = {}
         self.type_map = {}
         self.function_map = {}
+        self.str_forward_map = {}
+        self.str_reverse_map = {}
+
+    def preallocate_runtime_exception_names(self, names):
+        for i, name in enumerate(names):
+            exn_id = self.store_str("0:artiq.coredevice.exceptions." + name)
+            assert exn_id == i
+
+    def store_str(self, s):
+        if s in self.str_forward_map:
+            return self.str_forward_map[s]
+        str_id = len(self.str_forward_map)
+        self.str_forward_map[s] = str_id
+        self.str_reverse_map[str_id] = s
+        return str_id
+
+    def retrieve_str(self, str_id):
+        return self.str_reverse_map[str_id]
 
     # Modules
     def store_module(self, module, module_type):
@@ -736,6 +754,12 @@ class Stitcher:
         self.functions = {}
 
         self.embedding_map = EmbeddingMap()
+        self.embedding_map.preallocate_runtime_exception_names(["runtimeerror",
+                                                                "RTIOUnderflow",
+                                                                "RTIOOverflow",
+                                                                "RTIODestinationUnreachable",
+                                                                "DMAError",
+                                                                "I2CError"])
         self.value_map = defaultdict(lambda: [])
         self.definitely_changed = False
 

--- a/artiq/compiler/ir.py
+++ b/artiq/compiler/ir.py
@@ -1245,9 +1245,9 @@ class Raise(Terminator):
         if len(self.operands) > 1:
             return self.operands[1]
 
-class Reraise(Terminator):
+class Resume(Terminator):
     """
-    A reraise instruction.
+    A resume instruction.
     """
 
     """
@@ -1261,7 +1261,7 @@ class Reraise(Terminator):
         super().__init__(operands, builtins.TNone(), name)
 
     def opcode(self):
-        return "reraise"
+        return "resume"
 
     def exception_target(self):
         if len(self.operands) > 0:

--- a/artiq/compiler/module.py
+++ b/artiq/compiler/module.py
@@ -57,7 +57,8 @@ class Module:
         constness_validator = validators.ConstnessValidator(engine=self.engine)
         artiq_ir_generator = transforms.ARTIQIRGenerator(engine=self.engine,
                                                          module_name=src.name,
-                                                         ref_period=ref_period)
+                                                         ref_period=ref_period,
+                                                         embedding_map=self.embedding_map)
         dead_code_eliminator = transforms.DeadCodeEliminator(engine=self.engine)
         local_access_validator = validators.LocalAccessValidator(engine=self.engine)
         local_demoter = transforms.LocalDemoter()

--- a/artiq/compiler/module.py
+++ b/artiq/compiler/module.py
@@ -10,7 +10,7 @@ string and infers types for it using a trivial :module:`prelude`.
 
 import os
 from pythonparser import source, diagnostic, parse_buffer
-from . import prelude, types, transforms, analyses, validators
+from . import prelude, types, transforms, analyses, validators, embedding
 
 class Source:
     def __init__(self, source_buffer, engine=None):
@@ -18,7 +18,7 @@ class Source:
             self.engine = diagnostic.Engine(all_errors_are_fatal=True)
         else:
             self.engine = engine
-        self.embedding_map = None
+        self.embedding_map = embedding.EmbeddingMap()
         self.name, _ = os.path.splitext(os.path.basename(source_buffer.name))
 
         asttyped_rewriter = transforms.ASTTypedRewriter(engine=engine,

--- a/artiq/compiler/transforms/artiq_ir_generator.py
+++ b/artiq/compiler/transforms/artiq_ir_generator.py
@@ -2814,14 +2814,15 @@ class ARTIQIRGenerator(algorithm.Visitor):
 
                 format_string += ")"
             elif builtins.is_exception(value.type):
+                # message may not be an actual string...
+                # so we cannot really print it
                 name    = self.append(ir.GetAttr(value, "#__name__"))
-                message = self.append(ir.GetAttr(value, "#__message__"))
                 param1  = self.append(ir.GetAttr(value, "#__param0__"))
                 param2  = self.append(ir.GetAttr(value, "#__param1__"))
                 param3  = self.append(ir.GetAttr(value, "#__param2__"))
 
-                format_string += "%.*s(%.*s, %lld, %lld, %lld)"
-                args += [name, message, param1, param2, param3]
+                format_string += "%ld(%lld, %lld, %lld)"
+                args += [name, param1, param2, param3]
             else:
                 assert False
 

--- a/artiq/compiler/transforms/llvm_ir_generator.py
+++ b/artiq/compiler/transforms/llvm_ir_generator.py
@@ -171,10 +171,16 @@ class LLVMIRGenerator:
         self.llfunction = None
         self.llmap = {}
         self.llobject_map = {}
+        self.llpred_map = {}
         self.phis = []
         self.debug_info_emitter = DebugInfoEmitter(self.llmodule)
         self.empty_metadata = self.llmodule.add_metadata([])
         self.quote_fail_msg = None
+
+    def add_pred(self, pred, block):
+        if block not in self.llpred_map:
+            self.llpred_map[block] = set()
+        self.llpred_map[block].add(pred)
 
     def needs_sret(self, lltyp, may_be_large=True):
         if isinstance(lltyp, ll.VoidType):
@@ -367,7 +373,9 @@ class LLVMIRGenerator:
             llty = ll.FunctionType(lli32, [], var_arg=True)
         elif name == "__artiq_raise":
             llty = ll.FunctionType(llvoid, [self.llty_of_type(builtins.TException())])
-        elif name == "__artiq_reraise":
+        elif name == "__artiq_resume":
+            llty = ll.FunctionType(llvoid, [])
+        elif name == "__artiq_end_catch":
             llty = ll.FunctionType(llvoid, [])
         elif name == "memcmp":
             llty = ll.FunctionType(lli32, [llptr, llptr, lli32])
@@ -653,6 +661,28 @@ class LLVMIRGenerator:
             self.llbuilder = ll.IRBuilder()
             llblock_map = {}
 
+            # this is the predecessor map, from basic block to the set of its
+            # predecessors
+            # handling for branch and cbranch is here, and the handling of
+            # indirectbr and landingpad are in their respective process_*
+            # function
+            self.llpred_map = llpred_map = {}
+            branch_fn = self.llbuilder.branch
+            cbranch_fn = self.llbuilder.cbranch
+            def override_branch(block):
+                nonlocal self, branch_fn
+                self.add_pred(self.llbuilder.basic_block, block)
+                return branch_fn(block)
+
+            def override_cbranch(pred, bbif, bbelse):
+                nonlocal self, cbranch_fn
+                self.add_pred(self.llbuilder.basic_block, bbif)
+                self.add_pred(self.llbuilder.basic_block, bbelse)
+                return cbranch_fn(pred, bbif, bbelse)
+
+            self.llbuilder.branch = override_branch
+            self.llbuilder.cbranch = override_cbranch
+
             if not func.is_generated:
                 lldisubprogram = self.debug_info_emitter.emit_subprogram(func, self.llfunction)
                 self.llfunction.set_metadata('dbg', lldisubprogram)
@@ -675,6 +705,10 @@ class LLVMIRGenerator:
             # Third, translate all instructions.
             for block in func.basic_blocks:
                 self.llbuilder.position_at_end(self.llmap[block])
+                old_block = None
+                if len(block.instructions) == 1 and \
+                    isinstance(block.instructions[0], ir.LandingPad):
+                    old_block = self.llbuilder.basic_block
                 for insn in block.instructions:
                     if insn.loc is not None and not func.is_generated:
                         self.llbuilder.debug_metadata = \
@@ -689,12 +723,28 @@ class LLVMIRGenerator:
                 # instruction so that the result spans several LLVM basic
                 # blocks. This only really matters for phis, which are thus
                 # using a different map (the following one).
-                llblock_map[block] = self.llbuilder.basic_block
+                if old_block is None:
+                    llblock_map[block] = self.llbuilder.basic_block
+                else:
+                    llblock_map[block] = old_block
 
             # Fourth, add incoming values to phis.
             for phi, llphi in self.phis:
                 for value, block in phi.incoming():
-                    llphi.add_incoming(self.map(value), llblock_map[block])
+                    if isinstance(phi.type, builtins.TException):
+                        # a hack to patch phi from landingpad
+                        # because landingpad is a single bb in artiq IR, but
+                        # generates multiple bb, we need to find out the
+                        # predecessor to figure out the actual bb
+                        landingpad = llblock_map[block]
+                        for pred in llpred_map[llphi.parent]:
+                            if pred in llpred_map and landingpad in llpred_map[pred]:
+                                llphi.add_incoming(self.map(value), pred)
+                                break
+                        else:
+                            llphi.add_incoming(self.map(value), landingpad)
+                    else:
+                        llphi.add_incoming(self.map(value), llblock_map[block])
         finally:
             self.function_flags = None
             self.llfunction = None
@@ -1247,6 +1297,8 @@ class LLVMIRGenerator:
                 return llstore_lo
             else:
                 return self.llbuilder.call(self.llbuiltin("delay_mu"), [llinterval])
+        elif insn.op == "end_catch":
+            return self.llbuilder.call(self.llbuiltin("__artiq_end_catch"), [])
         else:
             assert False
 
@@ -1678,7 +1730,12 @@ class LLVMIRGenerator:
     def process_IndirectBranch(self, insn):
         llinsn = self.llbuilder.branch_indirect(self.map(insn.target()))
         for dest in insn.destinations():
-            llinsn.add_destination(self.map(dest))
+            dest = self.map(dest)
+            self.add_pred(self.llbuilder.basic_block, dest)
+            if dest not in self.llpred_map:
+                self.llpred_map[dest] = set()
+            self.llpred_map[dest].add(self.llbuilder.basic_block)
+            llinsn.add_destination(dest)
         return llinsn
 
     def process_Return(self, insn):
@@ -1716,8 +1773,8 @@ class LLVMIRGenerator:
         llexn = self.map(insn.value())
         return self._gen_raise(insn, self.llbuiltin("__artiq_raise"), [llexn])
 
-    def process_Reraise(self, insn):
-        return self._gen_raise(insn, self.llbuiltin("__artiq_reraise"), [])
+    def process_Resume(self, insn):
+        return self._gen_raise(insn, self.llbuiltin("__artiq_resume"), [])
 
     def process_LandingPad(self, insn):
         # Layout on return from landing pad: {%_Unwind_Exception*, %Exception*}
@@ -1726,10 +1783,11 @@ class LLVMIRGenerator:
                                                  cleanup=insn.has_cleanup)
         llrawexn = self.llbuilder.extract_value(lllandingpad, 1)
         llexn = self.llbuilder.bitcast(llrawexn, self.llty_of_type(insn.type))
-        llexnnameptr = self.llbuilder.gep(llexn, [self.llindex(0), self.llindex(0)],
+        llexnidptr = self.llbuilder.gep(llexn, [self.llindex(0), self.llindex(0)],
                                           inbounds=True)
-        llexnname = self.llbuilder.load(llexnnameptr)
+        llexnid = self.llbuilder.load(llexnidptr)
 
+        landingpadbb = self.llbuilder.basic_block
         for target, typ in insn.clauses():
             if typ is None:
                 # we use a null pointer here, similar to how cpp does it
@@ -1742,42 +1800,40 @@ class LLVMIRGenerator:
                         ll.Constant(lli32, 0).inttoptr(llptr)
                     )
                 )
-            else:
-                exnname = "{}:{}".format(typ.id, typ.name)
 
-                llclauseexnname = self.llconst_of_const(
-                    ir.Constant(exnname, builtins.TStr()))
-                llclauseexnnameptr = self.llmodule.globals.get("exn.{}".format(exnname))
-                if llclauseexnnameptr is None:
-                    llclauseexnnameptr = ll.GlobalVariable(self.llmodule, llclauseexnname.type,
-                                                           name="exn.{}".format(exnname))
-                    llclauseexnnameptr.global_constant = True
-                    llclauseexnnameptr.initializer = llclauseexnname
-                    llclauseexnnameptr.linkage = "private"
-                    llclauseexnnameptr.unnamed_addr = True
-                lllandingpad.add_clause(ll.CatchClause(llclauseexnnameptr))
-
-            if typ is None:
                 # typ is None means that we match all exceptions, so no need to
                 # compare
-                self.llbuilder.branch(self.map(target))
+                target = self.map(target)
+                self.add_pred(landingpadbb, target)
+                self.add_pred(landingpadbb, self.llbuilder.basic_block)
+                self.llbuilder.branch(target)
             else:
-                llexnlen       = self.llbuilder.extract_value(llexnname, 1)
-                llclauseexnlen = self.llbuilder.extract_value(llclauseexnname, 1)
-                llmatchinglen  = self.llbuilder.icmp_unsigned('==', llexnlen, llclauseexnlen)
-                with self.llbuilder.if_then(llmatchinglen):
-                    llexnptr       = self.llbuilder.extract_value(llexnname, 0)
-                    llclauseexnptr = self.llbuilder.extract_value(llclauseexnname, 0)
-                    llcomparedata  = self.llbuilder.call(self.llbuiltin("memcmp"),
-                                                         [llexnptr, llclauseexnptr, llexnlen])
-                    llmatchingdata = self.llbuilder.icmp_unsigned('==', llcomparedata,
-                                                                  ll.Constant(lli32, 0))
-                    with self.llbuilder.if_then(llmatchingdata):
-                        self.llbuilder.branch(self.map(target))
+                exnname = "{}:{}".format(typ.id, typ.name)
+                llclauseexnidptr = self.llmodule.globals.get("exn.{}".format(exnname))
+                exnid = ll.Constant(lli32, self.embedding_map.store_str(exnname))
+                if llclauseexnidptr is None:
+                    llclauseexnidptr = ll.GlobalVariable(self.llmodule, lli32,
+                                                         name="exn.{}".format(exnname))
+                    llclauseexnidptr.global_constant = True
+                    llclauseexnidptr.initializer = exnid
+                    llclauseexnidptr.linkage = "private"
+                    llclauseexnidptr.unnamed_addr = True
+                lllandingpad.add_clause(ll.CatchClause(llclauseexnidptr))
+                llmatchingdata = self.llbuilder.icmp_unsigned("==", llexnid,
+                                                              exnid)
+                with self.llbuilder.if_then(llmatchingdata):
+                    target = self.map(target)
+                    self.add_pred(landingpadbb, target)
+                    self.add_pred(landingpadbb, self.llbuilder.basic_block)
+                    self.llbuilder.branch(target)
+                self.add_pred(landingpadbb, self.llbuilder.basic_block)
 
         if self.llbuilder.basic_block.terminator is None:
             if insn.has_cleanup:
-                self.llbuilder.branch(self.map(insn.cleanup()))
+                target = self.map(insn.cleanup())
+                self.add_pred(landingpadbb, target)
+                self.add_pred(landingpadbb, self.llbuilder.basic_block)
+                self.llbuilder.branch(target)
             else:
                 self.llbuilder.resume(lllandingpad)
 

--- a/artiq/coredevice/comm_kernel.py
+++ b/artiq/coredevice/comm_kernel.py
@@ -623,28 +623,59 @@ class CommKernel:
             self._flush()
 
     def _serve_exception(self, embedding_map, symbolizer, demangler):
-        name = self._read_string()
-        message = self._read_string()
-        params = [self._read_int64() for _ in range(3)]
+        exception_count = self._read_int32()
+        nested_exceptions = []
 
-        filename = self._read_string()
-        line = self._read_int32()
-        column = self._read_int32()
-        function = self._read_string()
+        def read_exception_string():
+            # note: if length == -1, the following int32 is the object key
+            length = self._read_int32()
+            if length == -1:
+                return embedding_map.retrieve_str(self._read_int32())
+            else:
+                return self._read(length).decode("utf-8")
 
-        backtrace = [self._read_int32() for _ in range(self._read_int32())]
+        for _ in range(exception_count):
+            name = embedding_map.retrieve_str(self._read_int32())
+            message = read_exception_string()
+            params = [self._read_int64() for _ in range(3)]
+
+            filename = read_exception_string()
+            line = self._read_int32()
+            column = self._read_int32()
+            function = read_exception_string()
+            nested_exceptions.append([name, message, params,
+                                      filename, line, column, function])
+
+        demangled_names = demangler([ex[6] for ex in nested_exceptions])
+        for i in range(exception_count):
+            nested_exceptions[i][6] = demangled_names[i]
+
+        exception_info = []
+        for _ in range(exception_count):
+            sp = self._read_int32()
+            initial_backtrace = self._read_int32()
+            current_backtrace = self._read_int32()
+            exception_info.append((sp, initial_backtrace, current_backtrace))
+
+        backtrace = []
+        stack_pointers = []
+        for _ in range(self._read_int32()):
+            backtrace.append(self._read_int32())
+            stack_pointers.append(self._read_int32())
+
         self._process_async_error()
 
-        traceback = list(reversed(symbolizer(backtrace))) + \
-            [(filename, line, column, *demangler([function]), None)]
-        core_exn = exceptions.CoreException(name, message, params, traceback)
+        traceback = list(symbolizer(backtrace))
+        core_exn = exceptions.CoreException(nested_exceptions, exception_info,
+                                            traceback, stack_pointers)
 
         if core_exn.id == 0:
             python_exn_type = getattr(exceptions, core_exn.name.split('.')[-1])
         else:
             python_exn_type = embedding_map.retrieve_object(core_exn.id)
 
-        python_exn = python_exn_type(message.format(*params))
+        python_exn = python_exn_type(
+            nested_exceptions[-1][1].format(*nested_exceptions[0][2]))
         python_exn.artiq_core_exception = core_exn
         raise python_exn
 

--- a/artiq/coredevice/exceptions.py
+++ b/artiq/coredevice/exceptions.py
@@ -16,50 +16,94 @@ AssertionError = builtins.AssertionError
 
 class CoreException:
     """Information about an exception raised or passed through the core device."""
+    def __init__(self, exceptions, exception_info, traceback, stack_pointers):
+        self.exceptions = exceptions
+        self.exception_info = exception_info
+        self.traceback = list(traceback)
+        self.stack_pointers = stack_pointers
 
-    def __init__(self, name, message, params, traceback):
+        first_exception = exceptions[0]
+        name = first_exception[0]
         if ':' in name:
             exn_id, self.name = name.split(':', 2)
             self.id = int(exn_id)
         else:
             self.id, self.name = 0, name
-        self.message, self.params = message, params
-        self.traceback = list(traceback)
+        self.message = first_exception[1]
+        self.params = first_exception[2]
+
+    def append_backtrace(self, record, inlined=False):
+        filename, line, column, function, address = record
+        stub_globals = {"__name__": filename, "__loader__": source_loader}
+        source_line = linecache.getline(filename, line, stub_globals)
+        indentation = re.search(r"^\s*", source_line).end()
+
+        if address is None:
+            formatted_address = ""
+        elif inlined:
+            formatted_address = " (inlined)"
+        else:
+            formatted_address = " (RA=+0x{:x})".format(address)
+
+        filename = filename.replace(artiq_dir, "<artiq>")
+        lines = []
+        if column == -1:
+            lines.append("    {}".format(source_line.strip() if source_line else "<unknown>"))
+            lines.append("  File \"{file}\", line {line}, in {function}{address}".
+                         format(file=filename, line=line, function=function,
+                                address=formatted_address))
+        else:
+            lines.append("    {}^".format(" " * (column - indentation)))
+            lines.append("    {}".format(source_line.strip() if source_line else "<unknown>"))
+            lines.append("  File \"{file}\", line {line}, column {column},"
+                         " in {function}{address}".
+                         format(file=filename, line=line, column=column + 1,
+                                function=function, address=formatted_address))
+        return lines
+
+    def single_traceback(self, exception_index):
+        # note that we insert in reversed order
+        lines = []
+        last_sp = 0
+        start_backtrace_index = self.exception_info[exception_index][1]
+        zipped = list(zip(self.traceback[start_backtrace_index:],
+                          self.stack_pointers[start_backtrace_index:]))
+        exception = self.exceptions[exception_index]
+        name = exception[0]
+        message = exception[1]
+        params = exception[2]
+        if ':' in name:
+            exn_id, name = name.split(':', 2)
+            exn_id = int(exn_id)
+        else:
+            exn_id = 0
+        lines.append("{}({}): {}".format(name, exn_id, message.format(*params)))
+        zipped.append(((exception[3], exception[4], exception[5], exception[6],
+                       None, []), None))
+
+        for ((filename, line, column, function, address, inlined), sp) in zipped:
+            # backtrace of nested exceptions may be discontinuous
+            # but the stack pointer must increase monotonically
+            if sp is not None and sp <= last_sp:
+                continue
+            last_sp = sp
+
+            for record in reversed(inlined):
+                lines += self.append_backtrace(record, True)
+            lines += self.append_backtrace((filename, line, column, function,
+                                            address))
+
+        lines.append("Traceback (most recent call first):")
+
+        return "\n".join(reversed(lines))
 
     def __str__(self):
-        lines = []
-        lines.append("Core Device Traceback (most recent call last):")
-        last_address = 0
-        for (filename, line, column, function, address) in self.traceback:
-            stub_globals = {"__name__": filename, "__loader__": source_loader}
-            source_line = linecache.getline(filename, line, stub_globals)
-            indentation = re.search(r"^\s*", source_line).end()
-
-            if address is None:
-                formatted_address = ""
-            elif address == last_address:
-                formatted_address = " (inlined)"
-            else:
-                formatted_address = " (RA=+0x{:x})".format(address)
-            last_address = address
-
-            filename = filename.replace(artiq_dir, "<artiq>")
-            if column == -1:
-                lines.append("  File \"{file}\", line {line}, in {function}{address}".
-                             format(file=filename, line=line, function=function,
-                                    address=formatted_address))
-                lines.append("    {}".format(source_line.strip() if source_line else "<unknown>"))
-            else:
-                lines.append("  File \"{file}\", line {line}, column {column},"
-                             " in {function}{address}".
-                             format(file=filename, line=line, column=column + 1,
-                                    function=function, address=formatted_address))
-                lines.append("    {}".format(source_line.strip() if source_line else "<unknown>"))
-                lines.append("    {}^".format(" " * (column - indentation)))
-
-        lines.append("{}({}): {}".format(self.name, self.id,
-                                         self.message.format(*self.params)))
-        return "\n".join(lines)
+        tracebacks = [self.single_traceback(i) for i in range(len(self.exceptions))]
+        traceback_str = ('\n\nDuring handling of the above exception, ' +
+                        'another exception occurred:\n\n').join(tracebacks)
+        return 'Core Device Traceback:\n' +\
+                traceback_str +\
+                '\n\nEnd of Code Device Traceback\n'
 
 
 class InternalError(Exception):

--- a/artiq/firmware/Cargo.lock
+++ b/artiq/firmware/Cargo.lock
@@ -253,6 +253,7 @@ dependencies = [
  "byteorder",
  "cslice",
  "dyld",
+ "eh",
  "failure",
  "failure_derive",
  "io",

--- a/artiq/firmware/ksupport/api.rs
+++ b/artiq/firmware/ksupport/api.rs
@@ -117,7 +117,8 @@ static mut API: &'static [(&'static str, *const ())] = &[
     api!(_Unwind_Resume = ::unwind::_Unwind_Resume),
     api!(__artiq_personality = ::eh_artiq::personality),
     api!(__artiq_raise = ::eh_artiq::raise),
-    api!(__artiq_reraise = ::eh_artiq::reraise),
+    api!(__artiq_resume = ::eh_artiq::resume),
+    api!(__artiq_end_catch = ::eh_artiq::end_catch),
 
     /* proxified syscalls */
     api!(core_log),

--- a/artiq/firmware/ksupport/eh_artiq.rs
+++ b/artiq/firmware/ksupport/eh_artiq.rs
@@ -10,12 +10,15 @@
 // except according to those terms.
 #![allow(non_camel_case_types)]
 
-use core::{ptr, mem};
-use cslice::CSlice;
+use core::mem;
+use cslice::AsCSlice;
 use unwind as uw;
 use libc::{c_int, c_void};
 
-use eh::dwarf::{self, EHAction, EHContext};
+use eh::{self, dwarf::{self, EHAction, EHContext}};
+
+pub type Exception<'a> = eh::eh_artiq::Exception<'a>;
+pub type StackPointerBacktrace = eh::eh_artiq::StackPointerBacktrace;
 
 type _Unwind_Stop_Fn = extern "C" fn(version: c_int,
                                      actions: uw::_Unwind_Action,
@@ -30,40 +33,74 @@ extern {
                             stop_parameter: *mut c_void) -> uw::_Unwind_Reason_Code;
 }
 
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct Exception<'a> {
-    pub name:     CSlice<'a, u8>,
-    pub file:     CSlice<'a, u8>,
-    pub line:     u32,
-    pub column:   u32,
-    pub function: CSlice<'a, u8>,
-    pub message:  CSlice<'a, u8>,
-    pub param:    [i64; 3]
-}
+pub static mut PAYLOAD_ADDRESS: usize = 0;
 
 const EXCEPTION_CLASS: uw::_Unwind_Exception_Class = 0x4d_4c_42_53_41_52_54_51; /* 'MLBSARTQ' */
 
+const MAX_INFLIGHT_EXCEPTIONS: usize = 10;
 const MAX_BACKTRACE_SIZE: usize = 128;
 
-#[repr(C)]
-struct ExceptionInfo {
-    uw_exception:   uw::_Unwind_Exception,
-    exception:      Option<Exception<'static>>,
-    handled:        bool,
-    backtrace:      [usize; MAX_BACKTRACE_SIZE],
-    backtrace_size: usize
+struct ExceptionBuffer {
+    // we need n _Unwind_Exception, because each will have their own private data
+    uw_exceptions: [uw::_Unwind_Exception; MAX_INFLIGHT_EXCEPTIONS],
+    exceptions: [Option<Exception<'static>>; MAX_INFLIGHT_EXCEPTIONS + 1],
+    exception_stack: [isize; MAX_INFLIGHT_EXCEPTIONS + 1],
+    // nested exceptions will share the backtrace buffer, treated as a tree
+    // backtrace contains a tuple of IP and SP
+    backtrace: [(usize, usize); MAX_BACKTRACE_SIZE],
+    backtrace_size: usize,
+    // stack pointers are stored to reconstruct backtrace for each exception
+    stack_pointers: [StackPointerBacktrace; MAX_INFLIGHT_EXCEPTIONS + 1],
+    // current allocated nested exceptions
+    exception_count: usize,
+}
+
+static mut EXCEPTION_BUFFER: ExceptionBuffer = ExceptionBuffer {
+    uw_exceptions: [uw::_Unwind_Exception {
+        exception_class:   EXCEPTION_CLASS,
+        exception_cleanup: cleanup,
+        private:           [0; uw::unwinder_private_data_size],
+    }; MAX_INFLIGHT_EXCEPTIONS],
+    exceptions: [None; MAX_INFLIGHT_EXCEPTIONS + 1],
+    exception_stack: [-1; MAX_INFLIGHT_EXCEPTIONS + 1],
+    backtrace: [(0, 0); MAX_BACKTRACE_SIZE],
+    backtrace_size: 0,
+    stack_pointers: [StackPointerBacktrace {
+        stack_pointer: 0,
+        initial_backtrace_size: 0,
+        current_backtrace_size: 0
+    }; MAX_INFLIGHT_EXCEPTIONS + 1],
+    exception_count: 0
+};
+
+pub unsafe extern fn reset_exception_buffer(payload_addr: usize) {
+    EXCEPTION_BUFFER.uw_exceptions = [uw::_Unwind_Exception {
+        exception_class:   EXCEPTION_CLASS,
+        exception_cleanup: cleanup,
+        private:           [0; uw::unwinder_private_data_size],
+    }; MAX_INFLIGHT_EXCEPTIONS];
+    EXCEPTION_BUFFER.exceptions = [None; MAX_INFLIGHT_EXCEPTIONS + 1];
+    EXCEPTION_BUFFER.exception_stack = [-1; MAX_INFLIGHT_EXCEPTIONS + 1];
+    EXCEPTION_BUFFER.backtrace_size = 0;
+    EXCEPTION_BUFFER.exception_count = 0;
+    PAYLOAD_ADDRESS = payload_addr;
 }
 
 #[cfg(target_arch = "x86_64")]
 const UNWIND_DATA_REG: (i32, i32) = (0, 1); // RAX, RDX
+#[cfg(target_arch = "x86_64")]
+// actually this is not the SP, but frame pointer
+// but it serves its purpose, and getting SP will somehow cause segfault...
+const UNW_FP_REG: c_int = 12;
 
 #[cfg(any(target_arch = "riscv32"))]
 const UNWIND_DATA_REG: (i32, i32) = (10, 11); // X10, X11
+#[cfg(any(target_arch = "riscv32"))]
+const UNW_FP_REG: c_int = 2;
 
 #[export_name="__artiq_personality"]
 pub extern fn personality(version: c_int,
-                          actions: uw::_Unwind_Action,
+                          _actions: uw::_Unwind_Action,
                           uw_exception_class: uw::_Unwind_Exception_Class,
                           uw_exception: *mut uw::_Unwind_Exception,
                           context: *mut uw::_Unwind_Context)
@@ -85,133 +122,236 @@ pub extern fn personality(version: c_int,
             get_data_start: &|| uw::_Unwind_GetDataRelBase(context),
         };
 
-        let exception_info = &mut *(uw_exception as *mut ExceptionInfo);
-        let exception = &exception_info.exception.unwrap();
+        let index = EXCEPTION_BUFFER.exception_stack[EXCEPTION_BUFFER.exception_count - 1];
+        assert!(index != -1);
+        let exception = EXCEPTION_BUFFER.exceptions[index as usize].as_ref().unwrap();
+        let id = exception.id;
 
-        let name_ptr = exception.name.as_ptr();
-        let len = exception.name.len();
-        let eh_action = match dwarf::find_eh_action(lsda, &eh_context, name_ptr, len) {
+        let eh_action = match dwarf::find_eh_action(lsda, &eh_context, id) {
             Ok(action) => action,
             Err(_) => return uw::_URC_FATAL_PHASE1_ERROR,
         };
 
-        if actions as u32 & uw::_UA_SEARCH_PHASE as u32 != 0 {
-            match eh_action {
-                EHAction::None |
-                EHAction::Cleanup(_) => return uw::_URC_CONTINUE_UNWIND,
-                EHAction::Catch(_) => return uw::_URC_HANDLER_FOUND,
-                EHAction::Terminate => return uw::_URC_FATAL_PHASE1_ERROR,
+        match eh_action {
+            EHAction::None => return uw::_URC_CONTINUE_UNWIND,
+            EHAction::Cleanup(lpad) |
+            EHAction::Catch(lpad) => {
+                // Pass a pair of the unwinder exception and ARTIQ exception
+                // (which immediately follows).
+                uw::_Unwind_SetGR(context, UNWIND_DATA_REG.0,
+                                  uw_exception as uw::_Unwind_Word);
+                uw::_Unwind_SetGR(context, UNWIND_DATA_REG.1,
+                                  exception as *const _ as uw::_Unwind_Word);
+                uw::_Unwind_SetIP(context, lpad);
+                return uw::_URC_INSTALL_CONTEXT;
             }
-        } else {
-            match eh_action {
-                EHAction::None => return uw::_URC_CONTINUE_UNWIND,
-                EHAction::Cleanup(lpad) |
-                EHAction::Catch(lpad) => {
-                    if actions as u32 & uw::_UA_HANDLER_FRAME as u32 != 0 {
-                        exception_info.handled = true
-                    }
-
-                    // Pass a pair of the unwinder exception and ARTIQ exception
-                    // (which immediately follows).
-                    uw::_Unwind_SetGR(context, UNWIND_DATA_REG.0,
-                                      uw_exception as uw::_Unwind_Word);
-                    uw::_Unwind_SetGR(context, UNWIND_DATA_REG.1,
-                                      exception as *const _ as uw::_Unwind_Word);
-                    uw::_Unwind_SetIP(context, lpad);
-                    return uw::_URC_INSTALL_CONTEXT;
-                }
-                EHAction::Terminate => return uw::_URC_FATAL_PHASE2_ERROR,
-            }
+            EHAction::Terminate => return uw::_URC_FATAL_PHASE2_ERROR,
         }
     }
+}
+
+#[export_name="__artiq_raise"]
+#[unwind(allowed)]
+pub unsafe extern fn raise(exception: *const Exception) -> ! {
+    let count = EXCEPTION_BUFFER.exception_count;
+    let stack = &mut EXCEPTION_BUFFER.exception_stack;
+    let diff = exception as isize - EXCEPTION_BUFFER.exceptions.as_ptr() as isize;
+    if 0 <= diff && diff <= (mem::size_of::<Option<Exception>>() * MAX_INFLIGHT_EXCEPTIONS) as isize {
+        let index = diff / (mem::size_of::<Option<Exception>>() as isize);
+        let mut found = false;
+        for i in 0..=MAX_INFLIGHT_EXCEPTIONS + 1 {
+            if found {
+                if stack[i] == -1 {
+                    stack[i - 1] = index;
+                    assert!(i == count);
+                    break;
+                } else {
+                    stack[i - 1] = stack[i];
+                }
+            } else {
+                if stack[i] == index {
+                    found = true;
+                }
+            }
+        }
+        assert!(found);
+        let _result = _Unwind_ForcedUnwind(&mut EXCEPTION_BUFFER.uw_exceptions[stack[count - 1] as usize],
+                                           stop_fn, core::ptr::null_mut());
+    } else {
+        if count < MAX_INFLIGHT_EXCEPTIONS {
+            let exception = &*exception;
+            for (i, slot) in EXCEPTION_BUFFER.exceptions.iter_mut().enumerate() {
+                // we should always be able to find a slot
+                if slot.is_none() {
+                    *slot = Some(
+                        *mem::transmute::<*const Exception, *const Exception<'static>>
+                        (exception));
+                    EXCEPTION_BUFFER.exception_stack[count] = i as isize;
+                    EXCEPTION_BUFFER.uw_exceptions[i].private =
+                        [0; uw::unwinder_private_data_size];
+                    EXCEPTION_BUFFER.stack_pointers[i] = StackPointerBacktrace {
+                        stack_pointer: 0,
+                        initial_backtrace_size: EXCEPTION_BUFFER.backtrace_size,
+                        current_backtrace_size: 0,
+                    };
+                    EXCEPTION_BUFFER.exception_count += 1;
+                    let _result = _Unwind_ForcedUnwind(&mut EXCEPTION_BUFFER.uw_exceptions[i],
+                                                       stop_fn, core::ptr::null_mut());
+                }
+            }
+        } else {
+            // TODO: better reporting?
+            let exception = Exception {
+                id:       get_exception_id("RuntimeError"),
+                file:     file!().as_c_slice(),
+                line:     line!(),
+                column:   column!(),
+                // https://github.com/rust-lang/rfcs/pull/1719
+                function: "__artiq_raise".as_c_slice(),
+                message:  "too many nested exceptions".as_c_slice(),
+                param:    [0, 0, 0]
+            };
+            EXCEPTION_BUFFER.exceptions[MAX_INFLIGHT_EXCEPTIONS] = Some(mem::transmute(exception));
+            EXCEPTION_BUFFER.stack_pointers[MAX_INFLIGHT_EXCEPTIONS] = Default::default();
+            EXCEPTION_BUFFER.exception_count += 1;
+            uncaught_exception()
+        }
+    }
+    unreachable!();
+}
+
+
+#[export_name="__artiq_resume"]
+#[unwind(allowed)]
+pub unsafe extern fn resume() -> ! {
+    assert!(EXCEPTION_BUFFER.exception_count != 0);
+    let i = EXCEPTION_BUFFER.exception_stack[EXCEPTION_BUFFER.exception_count - 1];
+    assert!(i != -1);
+    let _result = _Unwind_ForcedUnwind(&mut EXCEPTION_BUFFER.uw_exceptions[i as usize],
+                                       stop_fn, core::ptr::null_mut());
+    unreachable!()
+}
+
+#[export_name="__artiq_end_catch"]
+#[unwind(allowed)]
+pub unsafe extern fn end_catch() {
+    let mut count = EXCEPTION_BUFFER.exception_count;
+    assert!(count != 0);
+    // we remove all exceptions with SP <= current exception SP
+    // i.e. the outer exception escapes the finally block
+    let index = EXCEPTION_BUFFER.exception_stack[count - 1] as usize;
+    EXCEPTION_BUFFER.exception_stack[count - 1] = -1;
+    EXCEPTION_BUFFER.exceptions[index] = None;
+    let outer_sp = EXCEPTION_BUFFER.stack_pointers
+        [index].stack_pointer;
+    count -= 1;
+    for i in (0..count).rev() {
+        let index = EXCEPTION_BUFFER.exception_stack[i];
+        assert!(index != -1);
+        let index = index as usize;
+        let sp = EXCEPTION_BUFFER.stack_pointers[index].stack_pointer;
+        if sp >= outer_sp {
+            break;
+        }
+        EXCEPTION_BUFFER.exceptions[index] = None;
+        EXCEPTION_BUFFER.exception_stack[i] = -1;
+        count -= 1;
+    }
+    EXCEPTION_BUFFER.exception_count = count;
+    EXCEPTION_BUFFER.backtrace_size = if count > 0 {
+        let index = EXCEPTION_BUFFER.exception_stack[count - 1];
+        assert!(index != -1);
+        EXCEPTION_BUFFER.stack_pointers[index as usize].current_backtrace_size
+    } else {
+        0
+    };
 }
 
 extern fn cleanup(_unwind_code: uw::_Unwind_Reason_Code,
-                  uw_exception: *mut uw::_Unwind_Exception) {
-    unsafe {
-        let exception_info = &mut *(uw_exception as *mut ExceptionInfo);
+                  _uw_exception: *mut uw::_Unwind_Exception) {
+    unimplemented!()
+}
 
-        exception_info.exception = None;
+fn uncaught_exception() -> ! {
+    unsafe {
+        // dump way to reorder the stack
+        for i in 0..EXCEPTION_BUFFER.exception_count {
+            if EXCEPTION_BUFFER.exception_stack[i] != i as isize {
+                // find the correct index
+                let index = EXCEPTION_BUFFER.exception_stack
+                    .iter()
+                    .position(|v| *v == i as isize).unwrap();
+                let a = EXCEPTION_BUFFER.exception_stack[index];
+                let b = EXCEPTION_BUFFER.exception_stack[i];
+                assert!(a != -1 && b != -1);
+                core::mem::swap(&mut EXCEPTION_BUFFER.exception_stack[index],
+                                &mut EXCEPTION_BUFFER.exception_stack[i]);
+                core::mem::swap(&mut EXCEPTION_BUFFER.exceptions[a as usize],
+                                &mut EXCEPTION_BUFFER.exceptions[b as usize]);
+                core::mem::swap(&mut EXCEPTION_BUFFER.stack_pointers[a as usize],
+                                &mut EXCEPTION_BUFFER.stack_pointers[b as usize]);
+            }
+        }
+    }
+    unsafe {
+        ::terminate(
+            EXCEPTION_BUFFER.exceptions[..EXCEPTION_BUFFER.exception_count].as_ref(),
+            EXCEPTION_BUFFER.stack_pointers[..EXCEPTION_BUFFER.exception_count].as_ref(),
+            EXCEPTION_BUFFER.backtrace[..EXCEPTION_BUFFER.backtrace_size].as_mut())
     }
 }
 
-extern fn uncaught_exception(_version: c_int,
-                             actions: uw::_Unwind_Action,
-                             _uw_exception_class: uw::_Unwind_Exception_Class,
-                             uw_exception: *mut uw::_Unwind_Exception,
-                             context: *mut uw::_Unwind_Context,
-                             _stop_parameter: *mut c_void)
-                            -> uw::_Unwind_Reason_Code {
+
+// stop function which would be executed when we unwind each frame
+extern fn stop_fn(_version: c_int,
+                  actions: uw::_Unwind_Action,
+                  _uw_exception_class: uw::_Unwind_Exception_Class,
+                  _uw_exception: *mut uw::_Unwind_Exception,
+                  context: *mut uw::_Unwind_Context,
+                  _stop_parameter: *mut c_void) -> uw::_Unwind_Reason_Code {
     unsafe {
-        let exception_info = &mut *(uw_exception as *mut ExceptionInfo);
-
-        if exception_info.backtrace_size < exception_info.backtrace.len() {
+        let backtrace_size = EXCEPTION_BUFFER.backtrace_size;
+        if backtrace_size < MAX_BACKTRACE_SIZE {
             let ip = uw::_Unwind_GetIP(context);
-            exception_info.backtrace[exception_info.backtrace_size] = ip;
-            exception_info.backtrace_size += 1;
+            let fp = uw::_Unwind_GetGR(context, UNW_FP_REG);
+            if PAYLOAD_ADDRESS == 0 || ip > PAYLOAD_ADDRESS {
+                let ip = ip - PAYLOAD_ADDRESS;
+                EXCEPTION_BUFFER.backtrace[backtrace_size] = (ip, fp);
+                EXCEPTION_BUFFER.backtrace_size += 1;
+                let last_index = EXCEPTION_BUFFER.exception_stack[EXCEPTION_BUFFER.exception_count - 1];
+                assert!(last_index != -1);
+                let sp_info = &mut EXCEPTION_BUFFER.stack_pointers[last_index as usize];
+                sp_info.stack_pointer = fp;
+                sp_info.current_backtrace_size = backtrace_size + 1;
+            }
         }
-
         if actions as u32 & uw::_UA_END_OF_STACK as u32 != 0 {
-            ::terminate(&exception_info.exception.unwrap(),
-                        exception_info.backtrace[..exception_info.backtrace_size].as_mut())
+            uncaught_exception()
         } else {
             uw::_URC_NO_REASON
         }
     }
 }
 
-// We can unfortunately not use mem::zeroed in a static, so Option<> is used as a workaround.
-// See https://github.com/rust-lang/rust/issues/39498.
-static mut INFLIGHT: ExceptionInfo = ExceptionInfo {
-    uw_exception: uw::_Unwind_Exception {
-        exception_class:   EXCEPTION_CLASS,
-        exception_cleanup: cleanup,
-        private:           [0; uw::unwinder_private_data_size],
-    },
-    exception:      None,
-    handled:        true,
-    backtrace:      [0; MAX_BACKTRACE_SIZE],
-    backtrace_size: 0
-};
+static EXCEPTION_ID_LOOKUP: [(&str, u32); 10] = [
+    ("RuntimeError", 0),
+    ("RTIOUnderflow", 1),
+    ("RTIOOverflow", 2),
+    ("RTIODestinationUnreachable", 3),
+    ("DMAError", 4),
+    ("I2CError", 5),
+    ("CacheError", 6),
+    ("SPIError", 7),
+    ("ZeroDivisionError", 8),
+    ("IndexError", 9)
+];
 
-#[export_name="__artiq_raise"]
-#[unwind(allowed)]
-pub unsafe extern fn raise(exception: *const Exception) -> ! {
-    // Zing! The Exception<'a> to Exception<'static> transmute is not really sound in case
-    // the exception is ever captured. Fortunately, they currently aren't, and we save
-    // on the hassle of having to allocate exceptions somewhere except on stack.
-    INFLIGHT.exception = Some(mem::transmute::<Exception, Exception<'static>>(*exception));
-    INFLIGHT.handled   = false;
-
-    let result = uw::_Unwind_RaiseException(&mut INFLIGHT.uw_exception);
-    assert!(result == uw::_URC_END_OF_STACK);
-
-    INFLIGHT.backtrace_size = 0;
-    let _result = _Unwind_ForcedUnwind(&mut INFLIGHT.uw_exception,
-                                       uncaught_exception, ptr::null_mut());
-    unreachable!()
-}
-
-#[export_name="__artiq_reraise"]
-#[unwind(allowed)]
-pub unsafe extern fn reraise() -> ! {
-    use cslice::AsCSlice;
-
-    if INFLIGHT.handled {
-        match INFLIGHT.exception {
-            Some(ref exception) => raise(exception),
-            None => raise(&Exception {
-                name:     "0:artiq.coredevice.exceptions.RuntimeError".as_c_slice(),
-                file:     file!().as_c_slice(),
-                line:     line!(),
-                column:   column!(),
-                // https://github.com/rust-lang/rfcs/pull/1719
-                function: "__artiq_reraise".as_c_slice(),
-                message:  "No active exception to reraise".as_c_slice(),
-                param:    [0, 0, 0]
-            })
+pub fn get_exception_id(name: &str) -> u32 {
+    for (n, id) in EXCEPTION_ID_LOOKUP.iter() {
+        if *n == name {
+            return *id
         }
-    } else {
-        uw::_Unwind_Resume(&mut INFLIGHT.uw_exception)
     }
+    unimplemented!("unallocated internal exception id")
 }
+

--- a/artiq/firmware/libeh/dwarf.rs
+++ b/artiq/firmware/libeh/dwarf.rs
@@ -202,8 +202,7 @@ unsafe fn get_ttype_entry(
 pub unsafe fn find_eh_action(
     lsda: *const u8,
     context: &EHContext<'_>,
-    name: *const u8,
-    len: usize,
+    id: u32,
 ) -> Result<EHAction, ()> {
     if lsda.is_null() {
         return Ok(EHAction::None);
@@ -275,19 +274,9 @@ pub unsafe fn find_eh_action(
                                 return Ok(EHAction::Catch(lpad));
                             }
                             // this seems to be target dependent
-                            let clause_ptr = *(catch_type as *const CSlice<u8>);
-                            let clause_name_ptr = (clause_ptr).as_ptr();
-                            let clause_name_len = (clause_ptr).len();
-                            if clause_name_len == len {
-                                if (clause_name_ptr == core::ptr::null() ||
-                                    clause_name_ptr == name ||
-                                    // somehow their name pointers might differ, but the content is the
-                                    // same
-                                    core::slice::from_raw_parts(clause_name_ptr, clause_name_len) ==
-                                    core::slice::from_raw_parts(name, len))
-                                {
-                                    return Ok(EHAction::Catch(lpad));
-                                }
+                            let clause_id = *(catch_type as *const u32);
+                            if clause_id == id {
+                                return Ok(EHAction::Catch(lpad));
                             }
                         } else if ar_filter < 0 {
                             // FIXME: how to handle this?

--- a/artiq/firmware/libeh/eh_artiq.rs
+++ b/artiq/firmware/libeh/eh_artiq.rs
@@ -1,0 +1,47 @@
+// ARTIQ Exception struct declaration
+use cslice::CSlice;
+
+// Note: CSlice within an exception may not be actual cslice, they may be strings that exist only
+// in the host. If the length == usize:MAX, the pointer is actually a string key in the host.
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct Exception<'a> {
+    pub id:       u32,
+    pub file:     CSlice<'a, u8>,
+    pub line:     u32,
+    pub column:   u32,
+    pub function: CSlice<'a, u8>,
+    pub message:  CSlice<'a, u8>,
+    pub param:    [i64; 3]
+}
+
+fn str_err(_: core::str::Utf8Error) -> core::fmt::Error {
+    core::fmt::Error
+}
+
+fn exception_str<'a>(s: &'a CSlice<'a, u8>) -> Result<&'a str, core::str::Utf8Error> {
+    if s.len() == usize::MAX {
+        Ok("<host string>")
+    } else {
+        core::str::from_utf8(s.as_ref())
+    }
+}
+
+impl<'a> core::fmt::Debug for Exception<'a> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "Exception {} from {} in {}:{}:{}, message: {}",
+            self.id,
+            exception_str(&self.function).map_err(str_err)?,
+            exception_str(&self.file).map_err(str_err)?,
+            self.line, self.column,
+            exception_str(&self.message).map_err(str_err)?)
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default)]
+pub struct StackPointerBacktrace {
+    pub stack_pointer: usize,
+    pub initial_backtrace_size: usize,
+    pub current_backtrace_size: usize,
+}
+

--- a/artiq/firmware/libeh/eh_rust.rs
+++ b/artiq/firmware/libeh/eh_rust.rs
@@ -87,5 +87,5 @@ unsafe fn find_eh_action(context: *mut uw::_Unwind_Context) -> Result<EHAction, 
         get_text_start: &|| uw::_Unwind_GetTextRelBase(context),
         get_data_start: &|| uw::_Unwind_GetDataRelBase(context),
     };
-    dwarf::find_eh_action(lsda, &eh_context, core::ptr::null(), 0)
+    dwarf::find_eh_action(lsda, &eh_context, 0)
 }

--- a/artiq/firmware/libeh/lib.rs
+++ b/artiq/firmware/libeh/lib.rs
@@ -7,3 +7,4 @@ extern crate libc;
 
 pub mod dwarf;
 pub mod eh_rust;
+pub mod eh_artiq;

--- a/artiq/firmware/libproto_artiq/Cargo.toml
+++ b/artiq/firmware/libproto_artiq/Cargo.toml
@@ -15,6 +15,7 @@ cslice = { version = "0.3" }
 log = { version = "0.4", default-features = false, optional = true }
 io = { path = "../libio", features = ["byteorder"] }
 dyld = { path = "../libdyld" }
+eh = { path = "../libeh" }
 
 [features]
 alloc = ["io/alloc"]

--- a/artiq/firmware/libproto_artiq/kernel_proto.rs
+++ b/artiq/firmware/libproto_artiq/kernel_proto.rs
@@ -6,17 +6,6 @@ pub const KERNELCPU_PAYLOAD_ADDRESS: usize = 0x45060000;
 pub const KERNELCPU_LAST_ADDRESS:    usize = 0x4fffffff;
 pub const KSUPPORT_HEADER_SIZE:      usize = 0x80;
 
-#[derive(Debug, Clone)]
-pub struct Exception<'a> {
-    pub name:     &'a str,
-    pub file:     &'a str,
-    pub line:     u32,
-    pub column:   u32,
-    pub function: &'a str,
-    pub message:  &'a str,
-    pub param:    [i64; 3]
-}
-
 #[derive(Debug)]
 pub enum Message<'a> {
     LoadRequest(&'a [u8]),
@@ -47,8 +36,9 @@ pub enum Message<'a> {
 
     RunFinished,
     RunException {
-        exception: Exception<'a>,
-        backtrace: &'a [usize]
+        exceptions: &'a [Option<eh::eh_artiq::Exception<'a>>],
+        stack_pointers: &'a [eh::eh_artiq::StackPointerBacktrace],
+        backtrace: &'a [(usize, usize)]
     },
     RunAborted,
 
@@ -59,7 +49,7 @@ pub enum Message<'a> {
         data: *const *const ()
     },
     RpcRecvRequest(*mut ()),
-    RpcRecvReply(Result<usize, Exception<'a>>),
+    RpcRecvReply(Result<usize, eh::eh_artiq::Exception<'a>>),
     RpcFlush,
 
     CacheGetRequest { key: &'a str },

--- a/artiq/firmware/libproto_artiq/lib.rs
+++ b/artiq/firmware/libproto_artiq/lib.rs
@@ -13,6 +13,7 @@ extern crate log;
 extern crate byteorder;
 extern crate io;
 extern crate dyld;
+extern crate eh;
 
 // Internal protocols.
 pub mod kernel_proto;

--- a/artiq/test/libartiq_support/lib.rs
+++ b/artiq/test/libartiq_support/lib.rs
@@ -1,4 +1,4 @@
-#![feature(libc, panic_unwind, unwind_attributes, rustc_private, int_bits_const)]
+#![feature(libc, panic_unwind, unwind_attributes, rustc_private, int_bits_const, const_in_array_repeat_expressions)]
 #![crate_name = "artiq_support"]
 #![crate_type = "cdylib"]
 
@@ -58,23 +58,31 @@ mod cslice {
 pub mod eh {
     #[path = "../../firmware/libeh/dwarf.rs"]
     pub mod dwarf;
+    #[path = "../../firmware/libeh/eh_artiq.rs"]
+    pub mod eh_artiq;
 }
 #[path = "../../firmware/ksupport/eh_artiq.rs"]
 pub mod eh_artiq;
 
 use std::{str, process};
 
-fn terminate(exception: &eh_artiq::Exception, mut _backtrace: &mut [usize]) -> ! {
-    println!("Uncaught {}: {} ({}, {}, {})",
-             str::from_utf8(exception.name.as_ref()).unwrap(),
-             str::from_utf8(exception.message.as_ref()).unwrap(),
-             exception.param[0],
-             exception.param[1],
-             exception.param[2]);
-    println!("at {}:{}:{}",
-             str::from_utf8(exception.file.as_ref()).unwrap(),
-             exception.line,
-             exception.column);
+fn terminate(exceptions: &'static [Option<eh_artiq::Exception<'static>>],
+             _stack_pointers: &'static [eh_artiq::StackPointerBacktrace],
+             _backtrace: &'static mut [(usize, usize)]) -> ! {
+    println!("{}", exceptions.len());
+    for exception in exceptions.iter() {
+        let exception = exception.as_ref().unwrap();
+        println!("Uncaught {}: {} ({}, {}, {})",
+                 exception.id,
+                 str::from_utf8(exception.message.as_ref()).unwrap(),
+                 exception.param[0],
+                 exception.param[1],
+                 exception.param[2]);
+        println!("at {}:{}:{}",
+                 str::from_utf8(exception.file.as_ref()).unwrap(),
+                 exception.line,
+                 exception.column);
+    }
     process::exit(1);
 }
 

--- a/artiq/test/lit/exceptions/catch_all.py
+++ b/artiq/test/lit/exceptions/catch_all.py
@@ -8,7 +8,7 @@ def catch(f):
     except Exception as e:
         print(e)
 
-# CHECK-L: ZeroDivisionError
+# CHECK-L: 8(0, 0, 0)
 catch(lambda: 1/0)
-# CHECK-L: IndexError
+# CHECK-L: 9(10, 1, 0)
 catch(lambda: [1.0][10])

--- a/artiq/test/lit/exceptions/catch_multi.py
+++ b/artiq/test/lit/exceptions/catch_multi.py
@@ -10,7 +10,7 @@ def catch(f):
     except IndexError as ie:
         print(ie)
 
-# CHECK-L: ZeroDivisionError
+# CHECK-L: 8(0, 0, 0)
 catch(lambda: 1/0)
-# CHECK-L: IndexError
+# CHECK-L: 9(10, 1, 0)
 catch(lambda: [1.0][10])

--- a/artiq/test/lit/exceptions/reraise.py
+++ b/artiq/test/lit/exceptions/reraise.py
@@ -3,7 +3,7 @@
 # REQUIRES: exceptions
 
 def f():
-    # CHECK-L: Uncaught 0:ZeroDivisionError
+    # CHECK-L: Uncaught 8
     # CHECK-L: at input.py:${LINE:+1}:
     1/0
 

--- a/artiq/test/lit/exceptions/reraise_update.py
+++ b/artiq/test/lit/exceptions/reraise_update.py
@@ -9,7 +9,7 @@ def g():
     try:
         f()
     except Exception as e:
-        # CHECK-L: Uncaught 0:ZeroDivisionError
+        # CHECK-L: Uncaught 8
         # CHECK-L: at input.py:${LINE:+1}:
         raise e
 

--- a/artiq/test/lit/exceptions/uncaught.py
+++ b/artiq/test/lit/exceptions/uncaught.py
@@ -2,6 +2,6 @@
 # RUN: OutputCheck %s --file-to-check=%t
 # REQUIRES: exceptions
 
-# CHECK-L: Uncaught 0:ZeroDivisionError: cannot divide by zero (0, 0, 0)
+# CHECK-L: Uncaught 8: cannot divide by zero (0, 0, 0)
 # CHECK-L: at input.py:${LINE:+1}:
 1/0

--- a/flake.nix
+++ b/flake.nix
@@ -251,7 +251,7 @@
           cargoDeps = rustPlatform.fetchCargoTarball {
             name = "artiq-firmware-cargo-deps";
             src = "${self}/artiq/firmware";
-            sha256 = "sha256-Lf6M4M/jdRiO5MsWSoqtOSNfRIhbze+qvg4kaiiBWW4=";
+            sha256 = "sha256-YyycMsDzR+JRcMZJd6A/CRi2J9nKmaWY/KXUnAQaZ00=";
           };
           nativeBuildInputs = [
             (pkgs.python3.withPackages(ps: [ migen misoc artiq ]))


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

- The exception API is now changed to `raise`, `resume` and `end_catch`.
- Supports nested exceptions.
- Exception reraise will preserve backtrace.
- Supports nested try-catch block, the control flow now matches the behavior in CPython. Tested with a simple fuzzer, agrees with CPython if local access validator passes. (we may now generate some complicated irreducible CFG due to landingpads, which will cause local access validator to enter infinite recursion... but I only encountered this for pathological inputs from the fuzzer, so will ignore it for now)
- Avoids string allocation. Should have no memory corruption issue for now.

Tested on risc-v and zynq. (artiq-zynq PR: https://git.m-labs.hk/M-Labs/artiq-zynq/pulls/162)

All unit tests passed. Some simple cases for nested exceptions also passed. E.g.

```python
from artiq.experiment import *

class TestException(EnvExperiment):
    def build(self):
        self.setattr_device("core")

    @kernel
    def run(self):
        try:
            raise ValueError
        finally:
            try:
                raise IndexError()
            except:
                print('index error')
```
will print index error and backtrace of the uncaught value error.

```python
from artiq.experiment import *

class TestException(EnvExperiment):
    def build(self):
        self.setattr_device("core")

    @kernel
    def run(self):
        try:
            raise ValueError
        finally:
            raise IndexError()
```

will include the backtrace for both value error and index error.

### Related Issue
Closes #1491, #1813, #1836.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [ ] Close/update issues.
- [ ] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [ ] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
