### PR TITLE
prioritize min as part of default value resolution in dashboard

### DIFF
--- a/artiq/gui/entries.py
+++ b/artiq/gui/entries.py
@@ -102,10 +102,11 @@ class NumberEntryInt(QtWidgets.QSpinBox):
         else:
             have_max = "max" in procdesc and procdesc["max"] is not None
             have_min = "min" in procdesc and procdesc["min"] is not None
-            if have_max and have_min and procdesc["min"] <= 0 < procdesc["max"]:
-                return 0
+            if have_max and have_min:
+                if procdesc["min"] <= 0 < procdesc["max"]:
+                    return 0
             elif have_min and not have_max:
-                if procdesc["min"] > 0:
+                if procdesc["min"] >= 0:
                     return procdesc["min"]
             elif not have_min and have_max:
                 if procdesc["max"] < 0:

--- a/artiq/gui/entries.py
+++ b/artiq/gui/entries.py
@@ -99,7 +99,7 @@ class NumberEntryInt(QtWidgets.QSpinBox):
     def default_state(procdesc):
         if "default" in procdesc:
             return procdesc["default"]
-        elif "min" in procdesc and procdesc["min"]:
+        elif "min" in procdesc and procdesc["min"] is not None:
             # when the min value is negative, we clamp it to 0 instead
             return max(0, procdesc["min"])
         else:

--- a/artiq/gui/entries.py
+++ b/artiq/gui/entries.py
@@ -100,8 +100,7 @@ class NumberEntryInt(QtWidgets.QSpinBox):
         if "default" in procdesc:
             return procdesc["default"]
         elif "min" in procdesc and procdesc["min"] is not None:
-            # when the min value is negative, we clamp it to 0 instead
-            return max(0, procdesc["min"])
+            return procdesc["min"]
         else:
             return 0
 

--- a/artiq/gui/entries.py
+++ b/artiq/gui/entries.py
@@ -99,6 +99,9 @@ class NumberEntryInt(QtWidgets.QSpinBox):
     def default_state(procdesc):
         if "default" in procdesc:
             return procdesc["default"]
+        elif "min" in procdesc and procdesc["min"]:
+            # when the min value is negative, we clamp it to 0 instead
+            return max(0, procdesc["min"])
         else:
             return 0
 

--- a/artiq/gui/entries.py
+++ b/artiq/gui/entries.py
@@ -99,9 +99,17 @@ class NumberEntryInt(QtWidgets.QSpinBox):
     def default_state(procdesc):
         if "default" in procdesc:
             return procdesc["default"]
-        elif "min" in procdesc and procdesc["min"] is not None:
-            return procdesc["min"]
         else:
+            have_max = "max" in procdesc and procdesc["max"] is not None
+            have_min = "min" in procdesc and procdesc["min"] is not None
+            if have_max and have_min and procdesc["min"] <= 0 < procdesc["max"]:
+                return 0
+            elif have_min and not have_max:
+                if procdesc["min"] > 0:
+                    return procdesc["min"]
+            elif not have_min and have_max:
+                if procdesc["max"] < 0:
+                    return procdesc["max"]
             return 0
 
 


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

This solves an issue where the dashboard value will appear to go out of bound when the default initial value on dashboard refresh is less than the minimum value of the argument (not rendered correctly). This could be solved with a forced re-render, but it is much better to handle it by setting the default value to min if min is positive, and 0 if min is negative

### Related Issue

Closes #1811 

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
