### PR TITLE
comm_moninj: set lifetime for socket

### DIFF
--- a/artiq/coredevice/comm_moninj.py
+++ b/artiq/coredevice/comm_moninj.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import struct
 from enum import Enum
-
+from .comm import set_keepalive
 
 __all__ = ["TTLProbe", "TTLOverride", "CommMonInj"]
 
@@ -29,6 +29,8 @@ class CommMonInj:
 
     async def connect(self, host, port=1383):
         self._reader, self._writer = await asyncio.open_connection(host, port)
+        set_keepalive(self._writer.transport.get_extra_info('socket'), 1, 1, 3)
+
         try:
             self._writer.write(b"ARTIQ moninj\n")
             # get device endian


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

> For a TCP socket would not disconnect immediately if the connection to core device is suddenly disrupted (e.g. power loss, panic), because we have TCP retransmission (RTT) and SYN retry window as some form of compromises in difficult network situations (and this explains why the stream drops only after 10 seconds or so).
> 
> As such it is better to set SO_KEEPALIVE in order to stop the proxy as soon as the connection stops.

Note: SYN retries and TCP retransmissions can be tuned by changing `/proc/sys/net/ipv4/{tcp_syn_retries,tcp_retries1,tcp_retries2}` in Linux. 

For Windows it is controlled by `TcpMaxDataRetransmissions` and `TCPInitialRtt` under `HKLM\System\CurrentControlSet\Services\Tcpip\Parameters` in WIndows registry. There is no straightforward way to control RTT in Linux unless you would like to [tinker with the black magic of eBPF](https://serverfault.com/a/1043874/233581)

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
