### PR TITLE
Mirny: set attenuation value from decibel

### DIFF
--- a/artiq/coredevice/adf5356.py
+++ b/artiq/coredevice/adf5356.py
@@ -103,6 +103,18 @@ class ADF5356:
             self.sync()
 
     @kernel
+    def set_att(self, att):
+        """Set digital step attenuator in SI units.
+
+        This method will write the attenuator settings of the channel.
+
+        .. seealso:: :meth:`artiq.coredevice.mirny.Mirny.set_att`
+
+        :param att: Attenuation in dB.
+        """
+        self.cpld.set_att(self.channel, att)
+
+    @kernel
     def set_att_mu(self, att):
         """Set digital step attenuator in machine units.
 

--- a/artiq/coredevice/mirny.py
+++ b/artiq/coredevice/mirny.py
@@ -1,7 +1,7 @@
 """RTIO driver for Mirny (4 channel GHz PLLs)
 """
 
-from artiq.language.core import kernel, delay
+from artiq.language.core import kernel, delay, portable
 from artiq.language.units import us
 
 from numpy import int32
@@ -132,6 +132,18 @@ class Mirny:
         self.write_reg(1, (self.clk_sel << 4))
         delay(1000 * us)
 
+    @portable(flags={"fast-math"})
+    def att_to_mu(self, att):
+        """Convert an attenuation setting in dB to machine units.
+
+        :param att: Attenuation setting in dB.
+        :return: Digital attenuation setting.
+        """
+        code = int32(255) - int32(round(att * 8))
+        if code < 0 or code > 255:
+            raise ValueError("Invalid Mirny attenuation!")
+        return code
+
     @kernel
     def set_att_mu(self, channel, att):
         """Set digital step attenuator in machine units.
@@ -140,6 +152,21 @@ class Mirny:
         """
         self.bus.set_config_mu(SPI_CONFIG | spi.SPI_END, 16, SPIT_WR, SPI_CS)
         self.bus.write(((channel | 8) << 25) | (att << 16))
+
+    @kernel
+    def set_att(self, channel, att):
+        """Set digital step attenuator in SI units.
+
+        This method will write the attenuator settings of the selected channel.
+
+        .. seealso:: :meth:`set_att_mu`
+
+        :param channel: Attenuator channel (0-3).
+        :param att: Attenuation setting in dB. Higher value is more
+            attenuation. Minimum attenuation is 0*dB, maximum attenuation is
+            31.5*dB.
+        """
+        self.set_att_mu(channel, self.att_to_mu(att))
 
     @kernel
     def write_ext(self, addr, length, data, ext_div=SPIT_WR):

--- a/artiq/frontend/artiq_sinara_tester.py
+++ b/artiq/frontend/artiq_sinara_tester.py
@@ -331,7 +331,7 @@ class SinaraTester(EnvExperiment):
         self.core.break_realtime()
         channel.init()
 
-        channel.set_att_mu(160)
+        channel.set_att(11.5*dB)
         channel.sw.on()
         self.core.break_realtime()
 


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

This PR adds `set_att` methods to Mirny and ADF5356 classes, so attenuation can be set directly using decibel.
The dB-to-mu conversion is identical to the implementation in Urukul.
The line that sets the attenuation of a Mirny channel in `artiq_sinara_tester` is also changed to use the new method.

## Tests
- Tested with bladeRF, output power of each channel changes accordingly when `ADF5356.set_att()` is invoked.
- Mirny v1.1 tested successfully with `artiq_sinara_tester`.
- Compared `set_att_mu(160)` and `set_att(11.5*dB)` in `artiq_sinara_tester`. The same peak is observed in Gqrx.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments

### Documentation Changes

- [x] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
