### PR TITLE
Don't try to make rtm_binary_dir if binary_dir unset

### DIFF
--- a/artiq/frontend/artiq_flash.py
+++ b/artiq/frontend/artiq_flash.py
@@ -347,7 +347,10 @@ def main():
         raise ValueError("the directory containing the binaries need to be specified using -d.")
 
     binary_dir = args.dir
-    rtm_binary_dir = os.path.join(binary_dir, "rtm")
+    if binary_dir is not None:
+        rtm_binary_dir = os.path.join(binary_dir, "rtm")
+    else:
+        rtm_binary_dir = None
 
     if args.host is None:
         client = LocalClient()


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Fixes flashing when a --dir argument isn't set. If --dir isn't set then `binary_dir` will be `None` and `os.path.join` will throw a `ValueError`. This can happen if for example you're flashing the storage.

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
