### PR TITLE
dashboard: add device database reload action on context menu

### DIFF
--- a/artiq/dashboard/explorer.py
+++ b/artiq/dashboard/explorer.py
@@ -251,8 +251,7 @@ class ExplorerDock(QtWidgets.QDockWidget):
         scan_repository_action.triggered.connect(scan_repository)
         self.el.addAction(scan_repository_action)
 
-        scan_ddb_action = QtWidgets.QAction("Scan device database",
-                                                   self.el)
+        scan_ddb_action = QtWidgets.QAction("Scan device database", self.el)
         def scan_ddb():
             asyncio.ensure_future(device_db_ctl.scan())
         scan_ddb_action.triggered.connect(scan_ddb)

--- a/artiq/dashboard/explorer.py
+++ b/artiq/dashboard/explorer.py
@@ -251,13 +251,12 @@ class ExplorerDock(QtWidgets.QDockWidget):
         scan_repository_action.triggered.connect(scan_repository)
         self.el.addAction(scan_repository_action)
 
-        rescan_ddb_action = QtWidgets.QAction("Re-scan device database on master",
+        scan_ddb_action = QtWidgets.QAction("Scan device database",
                                                    self.el)
-        def rescan_ddb():
-            logger.info("Reloading device database...")
+        def scan_ddb():
             asyncio.ensure_future(device_db_ctl.scan())
-        rescan_ddb_action.triggered.connect(rescan_ddb)
-        self.el.addAction(rescan_ddb_action)
+        scan_ddb_action.triggered.connect(scan_ddb)
+        self.el.addAction(scan_ddb_action)
 
         self.current_directory = ""
         open_file_action = QtWidgets.QAction("Open file outside repository",

--- a/artiq/dashboard/explorer.py
+++ b/artiq/dashboard/explorer.py
@@ -159,7 +159,7 @@ class WaitingPanel(LayoutWidget):
 class ExplorerDock(QtWidgets.QDockWidget):
     def __init__(self, exp_manager, d_shortcuts,
                  explist_sub, explist_status_sub,
-                 schedule_ctl, experiment_db_ctl):
+                 schedule_ctl, experiment_db_ctl, device_db_ctl):
         QtWidgets.QDockWidget.__init__(self, "Explorer")
         self.setObjectName("Explorer")
         self.setFeatures(QtWidgets.QDockWidget.DockWidgetMovable |
@@ -250,6 +250,14 @@ class ExplorerDock(QtWidgets.QDockWidget):
             asyncio.ensure_future(experiment_db_ctl.scan_repository_async())
         scan_repository_action.triggered.connect(scan_repository)
         self.el.addAction(scan_repository_action)
+
+        rescan_ddb_action = QtWidgets.QAction("Re-scan device database on master",
+                                                   self.el)
+        def rescan_ddb():
+            logger.info("Reloading device database...")
+            asyncio.ensure_future(device_db_ctl.scan())
+        rescan_ddb_action.triggered.connect(rescan_ddb)
+        self.el.addAction(rescan_ddb_action)
 
         self.current_directory = ""
         open_file_action = QtWidgets.QAction("Open file outside repository",

--- a/artiq/frontend/artiq_dashboard.py
+++ b/artiq/frontend/artiq_dashboard.py
@@ -109,7 +109,7 @@ def main():
 
     # create connections to master
     rpc_clients = dict()
-    for target in "schedule", "experiment_db", "dataset_db":
+    for target in "schedule", "experiment_db", "dataset_db", "device_db":
         client = AsyncioClient()
         loop.run_until_complete(client.connect_rpc(
             args.server, args.port_control, "master_" + target))
@@ -171,7 +171,8 @@ def main():
                                        sub_clients["explist"],
                                        sub_clients["explist_status"],
                                        rpc_clients["schedule"],
-                                       rpc_clients["experiment_db"])
+                                       rpc_clients["experiment_db"],
+                                       rpc_clients["device_db"])
     smgr.register(d_explorer)
 
     d_datasets = datasets.DatasetsDock(sub_clients["datasets"],


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Add an action on the context menu of explorer dock that reloads device database

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
