### PR TITLE
gateware: expand monitorable value to at least 32-bit

### DIFF
--- a/artiq/coredevice/comm_moninj.py
+++ b/artiq/coredevice/comm_moninj.py
@@ -84,9 +84,8 @@ class CommMonInj:
                 if not ty:
                     return
                 if ty == b"\x00":
-                    payload = await self._reader.readexactly(9)
-                    channel, probe, value = struct.unpack(
-                        self.endian + "lbl", payload)
+                    payload = await self._reader.readexactly(13)
+                    channel, probe, value = struct.unpack(self.endian + "lbq", payload)
                     self.monitor_cb(channel, probe, value)
                 elif ty == b"\x01":
                     payload = await self._reader.readexactly(6)

--- a/artiq/firmware/libproto_artiq/drtioaux_proto.rs
+++ b/artiq/firmware/libproto_artiq/drtioaux_proto.rs
@@ -34,7 +34,7 @@ pub enum Packet {
     RoutingAck,
 
     MonitorRequest { destination: u8, channel: u16, probe: u8 },
-    MonitorReply { value: u32 },
+    MonitorReply { value: u64 },
     InjectionRequest { destination: u8, channel: u16, overrd: u8, value: u8 },
     InjectionStatusRequest { destination: u8, channel: u16, overrd: u8 },
     InjectionStatusReply { value: u8 },
@@ -104,7 +104,7 @@ impl Packet {
                 probe: reader.read_u8()?
             },
             0x41 => Packet::MonitorReply {
-                value: reader.read_u32()?
+                value: reader.read_u64()?
             },
             0x50 => Packet::InjectionRequest {
                 destination: reader.read_u8()?,
@@ -252,7 +252,7 @@ impl Packet {
             },
             Packet::MonitorReply { value } => {
                 writer.write_u8(0x41)?;
-                writer.write_u32(value)?;
+                writer.write_u64(value)?;
             },
             Packet::InjectionRequest { destination, channel, overrd, value } => {
                 writer.write_u8(0x50)?;

--- a/artiq/firmware/libproto_artiq/moninj_proto.rs
+++ b/artiq/firmware/libproto_artiq/moninj_proto.rs
@@ -40,7 +40,7 @@ pub enum HostMessage {
 
 #[derive(Debug)]
 pub enum DeviceMessage {
-    MonitorStatus { channel: u32, probe: u8, value: u32 },
+    MonitorStatus { channel: u32, probe: u8, value: u64 },
     InjectionStatus { channel: u32, overrd: u8, value: u8 }
 }
 
@@ -82,7 +82,7 @@ impl DeviceMessage {
                 writer.write_u8(0)?;
                 writer.write_u32(channel)?;
                 writer.write_u8(probe)?;
-                writer.write_u32(value)?;
+                writer.write_u64(value)?;
             },
             DeviceMessage::InjectionStatus { channel, overrd, value } => {
                 writer.write_u8(1)?;

--- a/artiq/firmware/runtime/moninj.rs
+++ b/artiq/firmware/runtime/moninj.rs
@@ -18,7 +18,7 @@ mod local_moninj {
             csr::rtio_moninj::mon_chan_sel_write(channel as _);
             csr::rtio_moninj::mon_probe_sel_write(probe);
             csr::rtio_moninj::mon_value_update_write(1);
-            csr::rtio_moninj::mon_value_read() as u32
+            csr::rtio_moninj::mon_value_read()
         }
     }
 
@@ -55,7 +55,7 @@ mod remote_moninj {
     use sched::{Io, Mutex};
 
     pub fn read_probe(io: &Io, aux_mutex: &Mutex, linkno: u8, destination: u8, channel: u16, probe: u8) -> u32 {
-        let reply = drtio::aux_transact(io, aux_mutex, linkno, &drtioaux::Packet::MonitorRequest { 
+        let reply = drtio::aux_transact(io, aux_mutex, linkno, &drtioaux::Packet::MonitorRequest {
             destination: destination,
             channel: channel,
             probe: probe

--- a/artiq/firmware/runtime/moninj.rs
+++ b/artiq/firmware/runtime/moninj.rs
@@ -18,7 +18,7 @@ mod local_moninj {
             csr::rtio_moninj::mon_chan_sel_write(channel as _);
             csr::rtio_moninj::mon_probe_sel_write(probe);
             csr::rtio_moninj::mon_value_update_write(1);
-            csr::rtio_moninj::mon_value_read()
+            csr::rtio_moninj::mon_value_read() as _
         }
     }
 

--- a/artiq/firmware/runtime/moninj.rs
+++ b/artiq/firmware/runtime/moninj.rs
@@ -13,7 +13,7 @@ use board_artiq::drtio_routing;
 mod local_moninj {
     use board_misoc::csr;
 
-    pub fn read_probe(channel: u16, probe: u8) -> u32 {
+    pub fn read_probe(channel: u16, probe: u8) -> u64 {
         unsafe {
             csr::rtio_moninj::mon_chan_sel_write(channel as _);
             csr::rtio_moninj::mon_probe_sel_write(probe);
@@ -41,7 +41,7 @@ mod local_moninj {
 
 #[cfg(not(has_rtio_moninj))]
 mod local_moninj {
-    pub fn read_probe(_channel: u16, _probe: u8) -> u32 { 0 }
+    pub fn read_probe(_channel: u16, _probe: u8) -> u64 { 0 }
 
     pub fn inject(_channel: u16, _overrd: u8, _value: u8) { }
 
@@ -54,7 +54,7 @@ mod remote_moninj {
     use rtio_mgt::drtio;
     use sched::{Io, Mutex};
 
-    pub fn read_probe(io: &Io, aux_mutex: &Mutex, linkno: u8, destination: u8, channel: u16, probe: u8) -> u32 {
+    pub fn read_probe(io: &Io, aux_mutex: &Mutex, linkno: u8, destination: u8, channel: u16, probe: u8) -> u64 {
         let reply = drtio::aux_transact(io, aux_mutex, linkno, &drtioaux::Packet::MonitorRequest {
             destination: destination,
             channel: channel,

--- a/artiq/firmware/satman/main.rs
+++ b/artiq/firmware/satman/main.rs
@@ -201,7 +201,7 @@ fn process_aux_packet(_repeaters: &mut [repeater::Repeater],
 
         drtioaux::Packet::MonitorRequest { destination: _destination, channel, probe } => {
             forward!(_routing_table, _destination, *_rank, _repeaters, &packet);
-            let value;
+            let value: u32;
             #[cfg(has_rtio_moninj)]
             unsafe {
                 csr::rtio_moninj::mon_chan_sel_write(channel as _);
@@ -213,7 +213,7 @@ fn process_aux_packet(_repeaters: &mut [repeater::Repeater],
             {
                 value = 0;
             }
-            let reply = drtioaux::Packet::MonitorReply { value: value as u32 };
+            let reply = drtioaux::Packet::MonitorReply { value: value };
             drtioaux::send(0, &reply)
         },
         drtioaux::Packet::InjectionRequest { destination: _destination, channel, overrd, value } => {

--- a/artiq/firmware/satman/main.rs
+++ b/artiq/firmware/satman/main.rs
@@ -201,7 +201,7 @@ fn process_aux_packet(_repeaters: &mut [repeater::Repeater],
 
         drtioaux::Packet::MonitorRequest { destination: _destination, channel, probe } => {
             forward!(_routing_table, _destination, *_rank, _repeaters, &packet);
-            let value: u32;
+            let value: u64;
             #[cfg(has_rtio_moninj)]
             unsafe {
                 csr::rtio_moninj::mon_chan_sel_write(channel as _);

--- a/artiq/gateware/rtio/moninj.py
+++ b/artiq/gateware/rtio/moninj.py
@@ -12,7 +12,7 @@ class Monitor(Module, AutoCSR):
         self.chan_sel = CSRStorage(bits_for(len(chan_probes)-1))
         self.probe_sel = CSRStorage(bits_for(max_chan_probes-1))
         self.value_update = CSR()
-        self.value = CSRStatus(max(48, max_probe_len))
+        self.value = CSRStatus(max_probe_len)
 
         # # #
 

--- a/artiq/gateware/rtio/moninj.py
+++ b/artiq/gateware/rtio/moninj.py
@@ -12,7 +12,7 @@ class Monitor(Module, AutoCSR):
         self.chan_sel = CSRStorage(bits_for(len(chan_probes)-1))
         self.probe_sel = CSRStorage(bits_for(max_chan_probes-1))
         self.value_update = CSR()
-        self.value = CSRStatus(max_probe_len)
+        self.value = CSRStatus(max(48, max_probe_len))
 
         # # #
 


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Set monitorable value to at least 32-bit 

### Related Issue

Urukul monitor achieves monitoring by sniffing SPI bus, which is 32-bit in general. We should make it explicit that we monitor at least 32-bits. 

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
