### PR TITLE
flake: fix configuration over

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -506,6 +506,6 @@
   nixConfig = {
     extra-trusted-public-keys = "nixbld.m-labs.hk-1:5aSRVA5b320xbNvu30tqxVPXpld73bhtOeH6uAjRyHc=";
     extra-substituters = "https://nixbld.m-labs.hk";
-    sandboxPaths = ["/opt"];
+    extra-sandbox-paths = "/opt";
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -504,8 +504,8 @@
     };
 
   nixConfig = {
-    binaryCachePublicKeys = ["nixbld.m-labs.hk-1:5aSRVA5b320xbNvu30tqxVPXpld73bhtOeH6uAjRyHc="];
-    binaryCaches = ["https://nixbld.m-labs.hk" "https://cache.nixos.org"];
+    extra-trusted-public-keys = "nixbld.m-labs.hk-1:5aSRVA5b320xbNvu30tqxVPXpld73bhtOeH6uAjRyHc=";
+    extra-substituters = "https://nixbld.m-labs.hk";
     sandboxPaths = ["/opt"];
   };
 }


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Nix changed their configs (for example, they settled on hyphen-style instead of camelCase and allowed ``extra-`` instead of full overwrite), making flakes in artiq not override the configs as they should. This should fix exactly that. That includes both binary substituters and sandbox paths.

### Related Issue

Closes #1852 
## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
