### PR TITLE
release-6: artiq_flash: fix for satellite boards

### DIFF
--- a/artiq/frontend/artiq_flash.py
+++ b/artiq/frontend/artiq_flash.py
@@ -440,7 +440,7 @@ def main():
             storage_img = args.storage
             programmer.write_binary(*config["storage"], storage_img)
         elif action == "firmware":
-            if variant.endswith("satellite"):
+            if "satellite" in variant:
                 firmware = "satman"
             else:
                 firmware = "runtime"


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

This should fix flashing boards that don't explicitely end with "satellite" (e.g. when there's "satellite1" and "satellite2").

Tested with a dry run on a ``cqtsatellite1`` board.

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
