### PR TITLE
List representation

### DIFF
--- a/artiq/firmware/ksupport/lib.rs
+++ b/artiq/firmware/ksupport/lib.rs
@@ -15,7 +15,7 @@ extern crate proto_artiq;
 extern crate riscv;
 
 use core::{mem, ptr, slice, str, convert::TryFrom};
-use cslice::{CSlice, AsCSlice};
+use cslice::CSlice;
 use io::Cursor;
 use dyld::Library;
 use board_artiq::{mailbox, rpc_queue};
@@ -190,13 +190,12 @@ fn terminate(exceptions: &'static [Option<eh_artiq::Exception<'static>>],
 }
 
 #[unwind(aborts)]
-extern fn cache_get<'a>(ret: &'a mut CSlice<i32>, key: &CSlice<u8>) -> &'a CSlice<'a, i32> {
+extern fn cache_get<'a>(key: &CSlice<u8>) -> *const CSlice<'a, i32> {
     send(&CacheGetRequest {
         key:   str::from_utf8(key.as_ref()).unwrap()
     });
     recv!(&CacheGetReply { value } => {
-        *ret = value.as_c_slice();
-        ret
+        value
     })
 }
 

--- a/artiq/firmware/libproto_artiq/kernel_proto.rs
+++ b/artiq/firmware/libproto_artiq/kernel_proto.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use cslice::CSlice;
 use dyld;
 
 pub const KERNELCPU_EXEC_ADDRESS:    usize = 0x45000000;
@@ -53,7 +54,7 @@ pub enum Message<'a> {
     RpcFlush,
 
     CacheGetRequest { key: &'a str },
-    CacheGetReply   { value: &'static [i32] },
+    CacheGetReply   { value: *const CSlice<'static, i32> },
     CachePutRequest { key: &'a str, value: &'a [i32] },
     CachePutReply   { succeeded: bool },
 

--- a/artiq/firmware/runtime/session.rs
+++ b/artiq/firmware/runtime/session.rs
@@ -418,7 +418,7 @@ fn process_kern_message(io: &Io, aux_mutex: &Mutex,
                 kern_send(io, &kern::CacheGetReply {
                     // Zing! This transmute is only safe because we dynamically track
                     // whether the kernel has borrowed any values from the cache.
-                    value: unsafe { mem::transmute::<*const [i32], &'static [i32]>(value) }
+                    value: unsafe { mem::transmute(value) }
                 })
             }
 


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Changed list representation from `CSlice<T>` to `&CSlice<T>`. 

### Related Issue

Closes #1833 

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [ ] Close/update issues.
- [ ] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [ ] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [ ] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
