### PR TITLE
Do not redirect applet stdout/stderr to log

### DIFF
--- a/artiq/gui/applets.py
+++ b/artiq/gui/applets.py
@@ -13,7 +13,7 @@ from PyQt5 import QtCore, QtGui, QtWidgets
 from sipyco.pipe_ipc import AsyncioParentComm
 from sipyco import pyon
 
-from artiq.gui.tools import QDockWidgetCloseDetect, LayoutWidget
+from artiq.gui.tools import QDockWidgetCloseDetect
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

when applets spawn, various QT and GTK related messages appear that badly pollute the log. this are about 9 messages for each starting/reloading applet. these messages seem to be impossible to suppress or otherwise prevent/mitigate. at the same time, applets do not report much meaningful logs, basically nothing. therefore I propose to undo #472 and have a cleaner log. any stdout/stderr messages still appear in the terminal if required for diagnosing problems with applets.

if people agree that this should be merged, I would also like to suggest a backport to ARTIQ 6. in my opinion this is basically a bug that pollutes the log.

### Related Issue

this will practically undo #472

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Close/update issues.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

- [x] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
