### PR TITLE
llvm_ir: stack leak on ffi call

### DIFF
--- a/artiq/compiler/transforms/llvm_ir_generator.py
+++ b/artiq/compiler/transforms/llvm_ir_generator.py
@@ -1359,11 +1359,24 @@ class LLVMIRGenerator:
         else:
             llfun = self.map(insn.static_target_function)
         llenv     = self.llbuilder.extract_value(llclosure, 0, name="env.fun")
-        return llfun, [llenv] + list(llargs), {}
+        return llfun, [llenv] + list(llargs), {}, None
 
     def _prepare_ffi_call(self, insn):
         llargs = []
         llarg_attrs = {}
+
+        stack_save_needed = False
+        for i, arg in enumerate(insn.arguments()):
+            llarg = self.map(arg)            
+            if isinstance(llarg.type, (ll.LiteralStructType, ll.IdentifiedStructType)):
+                stack_save_needed = True
+                break
+
+        if stack_save_needed:
+            llcallstackptr = self.llbuilder.call(self.llbuiltin("llvm.stacksave"), [])
+        else:
+            llcallstackptr = None
+
         for i, arg in enumerate(insn.arguments()):
             llarg = self.map(arg)
             if isinstance(llarg.type, (ll.LiteralStructType, ll.IdentifiedStructType)):
@@ -1399,7 +1412,7 @@ class LLVMIRGenerator:
             if 'nowrite' in insn.target_function().type.flags:
                 llfun.attributes.add('inaccessiblememonly')
 
-        return llfun, list(llargs), llarg_attrs
+        return llfun, list(llargs), llarg_attrs, llcallstackptr
 
     def _build_rpc(self, fun_loc, fun_type, args, llnormalblock, llunwindblock):
         llservice = ll.Constant(lli32, fun_type.service)
@@ -1535,9 +1548,9 @@ class LLVMIRGenerator:
                                    insn.arguments(),
                                    llnormalblock=None, llunwindblock=None)
         elif types.is_external_function(functiontyp):
-            llfun, llargs, llarg_attrs = self._prepare_ffi_call(insn)
+            llfun, llargs, llarg_attrs, llcallstackptr = self._prepare_ffi_call(insn)
         else:
-            llfun, llargs, llarg_attrs = self._prepare_closure_call(insn)
+            llfun, llargs, llarg_attrs, llcallstackptr = self._prepare_closure_call(insn)
 
         if self.has_sret(functiontyp):
             llstackptr = self.llbuilder.call(self.llbuiltin("llvm.stacksave"), [])
@@ -1555,6 +1568,9 @@ class LLVMIRGenerator:
                 # We have NoneType-returning functions return void, but None is
                 # {} elsewhere.
                 llresult = ll.Constant(llunit, [])
+
+        if llcallstackptr != None:
+            self.llbuilder.call(self.llbuiltin("llvm.stackrestore"), [llcallstackptr])
 
         return llresult
 


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Added stack save for alloca calls during FFI function preamble (in LLVMIRGenerator._prepare_ffi_call).
Without this, a syscall with args that need to be allocated (such as TStr) will cause the stack pointer to be permanently decremented, similar to the issue fixed in #1802.

I have tested this by configuring a syscall to print the address of a variable allocated on the stack. The syscall accepts a TStr as an argument, and repeatedly decrements the stack pointer by 8 when called successively.

Without this PR:
```
[    49.278399s]  INFO(kernel): Stack pointer: 0x4ffffe78
[    49.283415s]  INFO(kernel): Stack pointer: 0x4ffffe70
[    49.288464s]  INFO(kernel): Stack pointer: 0x4ffffe68
[    49.293513s]  INFO(kernel): Stack pointer: 0x4ffffe60
```

With this PR:
```
[    92.268171s]  INFO(kernel): Stack pointer: 0x4ffffe74
[    92.273352s]  INFO(kernel): Stack pointer: 0x4ffffe74
[    92.278236s]  INFO(kernel): Stack pointer: 0x4ffffe74
[    92.283284s]  INFO(kernel): Stack pointer: 0x4ffffe74
```

I am not sure whether the specific changes made here are sensible in a broader context, but this has fixed our memory leak in the kernel stack.
@dnadlinger thoughts?

### Related Issue

Related to #1798 & #1802

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


### Code Changes

- [ ] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [ ] Test your changes or have someone test them. Mention what was tested and how.
- [ ] Add and check docstrings and comments
- [ ] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
