### PR TITLE
Add feature/qtprogressbar to master

### DIFF
--- a/artiq/applets/progress_bar.py
+++ b/artiq/applets/progress_bar.py
@@ -8,30 +8,26 @@ from artiq.applets.simple import SimpleApplet
 class ProgressWidget(QtWidgets.QProgressBar):
     def __init__(self, args):
         QtWidgets.QProgressBar.__init__(self)
-        self.setMaximum(args.max)
         self.setMinimum(args.min)
-        self.dataset_n = args.n
-        self.dataset_n_max = args.n_max
+        self.setMaximum(args.max)
+        self.dataset_value = args.value
 
     def data_changed(self, data, mods):
         try:
-            n = int(round(data[self.dataset_n][1]))
-            n_max = int(round(data[self.dataset_n_max][1]))
+            value = round(data[self.dataset_value][1])
         except (KeyError, ValueError, TypeError):
-            n = 0
-            n_max = 0
-        self.setMaximum(n_max)
-        self.setValue(n)
+            value = 0
+        self.setValue(value)
+
 
 
 def main():
     applet = SimpleApplet(ProgressWidget)
-    applet.add_dataset("n", "counter")
-    applet.add_dataset("n_max", "maximimum counter")
+    applet.add_dataset("value", "counter")
     applet.argparser.add_argument("--min", type=int, default=0,
-                                  help="minimum")
+                                  help="minimum (left) value of the bar")
     applet.argparser.add_argument("--max", type=int, default=100,
-                                  help="maximum")
+                                  help="maximum (right) value of the bar")
     applet.run()
 
 if __name__ == "__main__":

--- a/artiq/applets/progress_bar.py
+++ b/artiq/applets/progress_bar.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+from PyQt5 import QtWidgets
+
+from artiq.applets.simple import SimpleApplet
+
+
+class ProgressWidget(QtWidgets.QProgressBar):
+    def __init__(self, args):
+        QtWidgets.QProgressBar.__init__(self)
+        self.setMaximum(args.max)
+        self.setMinimum(args.min)
+        self.dataset_n = args.n
+        self.dataset_n_max = args.n_max
+
+    def data_changed(self, data, mods):
+        try:
+            n = int(round(data[self.dataset_n][1]))
+            n_max = int(round(data[self.dataset_n_max][1]))
+        except (KeyError, ValueError, TypeError):
+            n = 0
+            n_max = 0
+        self.setMaximum(n_max)
+        self.setValue(n)
+
+
+def main():
+    applet = SimpleApplet(ProgressWidget)
+    applet.add_dataset("n", "counter")
+    applet.add_dataset("n_max", "maximimum counter")
+    applet.argparser.add_argument("--min", type=int, default=0,
+                                  help="minimum")
+    applet.argparser.add_argument("--max", type=int, default=100,
+                                  help="maximum")
+    applet.run()
+
+if __name__ == "__main__":
+    main()

--- a/artiq/gui/applets.py
+++ b/artiq/gui/applets.py
@@ -225,7 +225,7 @@ _templates = [
                        "HIST_BIN_BOUNDARIES_DATASET "
                        "HISTS_COUNTS_DATASET"),
     ("Image", "${artiq_applet}image IMG_DATASET"),
-    ("Progress bar", "${artiq_applet}progress_bar COUNTER COUNTER_MAX"),
+    ("Progress bar", "${artiq_applet}progress_bar VALUE"),
 ]
 
 

--- a/artiq/gui/applets.py
+++ b/artiq/gui/applets.py
@@ -225,6 +225,7 @@ _templates = [
                        "HIST_BIN_BOUNDARIES_DATASET "
                        "HISTS_COUNTS_DATASET"),
     ("Image", "${artiq_applet}image IMG_DATASET"),
+    ("Progress bar", "${artiq_applet}progress_bar COUNTER COUNTER_MAX"),
 ]
 
 


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
A small QtQuick widget to realize a progress bar for datasets. This can be useful if you have some kind of run counter.

  * It has as much documentation as `artiq.applets.big_number` has :sweat_smile:
  * code is working in our production env, tested as standalone window and inside the dashboard
  * commits can potentially be squashed

### Related Issue
https://github.com/m-labs/artiq/pull/1792


## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
