### PR TITLE
Fix ARTIQ browser HDF5 group handling

### DIFF
--- a/artiq/browser/files.py
+++ b/artiq/browser/files.py
@@ -188,15 +188,24 @@ class FilesDock(QtWidgets.QDockWidget):
             except:
                 logger.warning("unable to read metadata from %s",
                                info.filePath(), exc_info=True)
-            rd = dict()
+
+            rd = {}
             if "archive" in f:
-                rd = {k: (True, v[()]) for k, v in f["archive"].items()}
+                def visitor(k, v):
+                    if isinstance(v, h5py.Dataset):
+                        rd[k] = (True, v[()])
+
+                f["archive"].visititems(visitor)
+
             if "datasets" in f:
-                for k, v in f["datasets"].items():
-                    if k in rd:
-                        logger.warning("dataset '%s' is both in archive and "
-                                       "outputs", k)
-                    rd[k] = (True, v[()])
+                def visitor(k, v):
+                    if isinstance(v, h5py.Dataset):
+                        if k in rd:
+                            logger.warning("dataset '%s' is both in archive "
+                                           "and outputs", k)
+                        rd[k] = (True, v[()])
+
+                f["datasets"].visititems(visitor)
 
             self.datasets.init(rd)
 

--- a/artiq/browser/files.py
+++ b/artiq/browser/files.py
@@ -197,8 +197,9 @@ class FilesDock(QtWidgets.QDockWidget):
                         logger.warning("dataset '%s' is both in archive and "
                                        "outputs", k)
                     rd[k] = (True, v[()])
-            if rd:
-                self.datasets.init(rd)
+
+            self.datasets.init(rd)
+
         self.dataset_changed.emit(info.filePath())
 
     def list_activated(self, idx):


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

ARTIQ browser handles HDF5 groups correctly instead of crashing.

This is a fix for release 6, but both commits can be cherry-picked onto master.

### Related Issue

Closes #1879 .
<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Close/update issues.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [ ] Add and check docstrings and comments
- [ ] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

- [ ] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
