### PR TITLE
Expose TTLClockGen for Kasli JSONs

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -12,6 +12,7 @@ Highlights:
    - Kasli-SoC, a new EEM carrier based on a Zynq SoC, enabling much faster kernel execution.
    - HVAMP_8CH 8 channel HV amplifier for Fastino / Zotinos
    - Almazny mezzanine board for Mirny
+* TTL device output can be now configured to work as a clock generator.
 * Softcore targets now use the RISC-V architecture (VexRiscv) instead of OR1K (mor1kx).
 * Gateware FPU is supported on KC705 and Kasli 2.0.
 * Faster compilation for large arrays/lists.

--- a/artiq/coredevice/coredevice_generic.schema.json
+++ b/artiq/coredevice/coredevice_generic.schema.json
@@ -170,11 +170,11 @@
                         },
                         "bank_direction_low": {
                             "type": "string",
-                            "enum": ["input", "output"]
+                            "enum": ["input", "output", "clkgen"]
                         },
                         "bank_direction_high": {
                             "type": "string",
-                            "enum": ["input", "output"]
+                            "enum": ["input", "output", "clkgen"]
                         }
                     },
                     "required": ["ports", "bank_direction_low", "bank_direction_high"]

--- a/artiq/frontend/artiq_ddb_template.py
+++ b/artiq/frontend/artiq_ddb_template.py
@@ -94,7 +94,8 @@ class PeripheralManager:
     def process_dio(self, rtio_offset, peripheral, num_channels=8):
         class_names = {
             "input": "TTLInOut",
-            "output": "TTLOut"
+            "output": "TTLOut",
+            "clkgen": "TTLClockGen"
         }
         classes = [
             class_names[peripheral["bank_direction_low"]],

--- a/artiq/gateware/eem.py
+++ b/artiq/gateware/eem.py
@@ -232,7 +232,7 @@ class Urukul(_EEM):
 
         pads = target.platform.request("urukul{}_dds_reset_sync_in".format(eem))
         if sync_gen_cls is not None:  # AD9910 variant and SYNC_IN from EEM
-            phy = sync_gen_cls(pad=pads.p, pad_n = pads.n, ftw_width=4)
+            phy = sync_gen_cls(pad=pads.p, pad_n=pads.n, ftw_width=4)
             target.submodules += phy
             target.rtio_channels.append(rtio.Channel.from_phy(phy))
 

--- a/artiq/gateware/eem.py
+++ b/artiq/gateware/eem.py
@@ -231,10 +231,8 @@ class Urukul(_EEM):
         target.rtio_channels.append(rtio.Channel.from_phy(phy, ififo_depth=4))
 
         pads = target.platform.request("urukul{}_dds_reset_sync_in".format(eem))
-        pad = Signal(reset=0)
-        target.specials += DifferentialOutput(pad, pads.p, pads.n)
         if sync_gen_cls is not None:  # AD9910 variant and SYNC_IN from EEM
-            phy = sync_gen_cls(pad, ftw_width=4)
+            phy = sync_gen_cls(pad=pads.p, pad_n = pads.n, ftw_width=4)
             target.submodules += phy
             target.rtio_channels.append(rtio.Channel.from_phy(phy))
 

--- a/artiq/gateware/eem_7series.py
+++ b/artiq/gateware/eem_7series.py
@@ -5,7 +5,8 @@ from artiq.gateware.rtio.phy import ttl_simple, ttl_serdes_7series, edge_counter
 def peripheral_dio(module, peripheral, **kwargs):
     ttl_classes = {
         "input": ttl_serdes_7series.InOut_8X,
-        "output": ttl_serdes_7series.Output_8X
+        "output": ttl_serdes_7series.Output_8X,
+        "clkgen": ttl_simple.ClockGen
     }
     if len(peripheral["ports"]) != 1:
         raise ValueError("wrong number of ports")

--- a/artiq/gateware/rtio/phy/ttl_simple.py
+++ b/artiq/gateware/rtio/phy/ttl_simple.py
@@ -145,11 +145,18 @@ class InOut(Module):
 
 
 class ClockGen(Module):
-    def __init__(self, pad, ftw_width=24):
+    def __init__(self, pad, pad_n=None, ftw_width=24, dci=False):
         self.rtlink = rtlink.Interface(rtlink.OInterface(ftw_width))
 
         # # #
 
+        pad_o = Signal()
+        if pad_n is None:
+            self.comb += pad.eq(pad_o)
+        else:
+            self.specials += Instance("IOBUFDS",
+                i_I=pad_o,
+                io_IO=pad, io_IOB=pad_n)
         ftw = Signal(ftw_width)
         acc = Signal(ftw_width)
         self.sync.rio += If(self.rtlink.o.stb, ftw.eq(self.rtlink.o.data))
@@ -165,5 +172,5 @@ class ClockGen(Module):
                     acc.eq(0)
                 )
             ),
-            pad.eq(acc[-1])
+            pad_o.eq(acc[-1])
         ]

--- a/artiq/gateware/rtio/phy/ttl_simple.py
+++ b/artiq/gateware/rtio/phy/ttl_simple.py
@@ -154,9 +154,7 @@ class ClockGen(Module):
         if pad_n is None:
             self.comb += pad.eq(pad_o)
         else:
-            self.specials += Instance("IOBUFDS",
-                i_I=pad_o,
-                io_IO=pad, io_IOB=pad_n)
+            self.specials += DifferentialOutput(pad_o, pad, pad_n)
         ftw = Signal(ftw_width)
         acc = Signal(ftw_width)
         self.sync.rio += If(self.rtlink.o.stb, ftw.eq(self.rtlink.o.data))


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

TTLClockGen module is available already, but it's not exposed in JSONs. While the class is used in KC705-based systems, but for Kasli it was not yet possible to have DIO clock generation available. This PR only allows usage of clockgen with kasli systems.

Tested by running a simple ARTIQ experiment using the clockgen and looking at the output on oscilloscope.

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
