### PR TITLE
Forward async errors from satellites to the artiq master

### DIFF
--- a/artiq/firmware/runtime/rtio_mgt.rs
+++ b/artiq/firmware/runtime/rtio_mgt.rs
@@ -218,15 +218,15 @@ pub mod drtio {
                                 destination_set_up(routing_table, up_destinations, destination, false),
                             Ok(drtioaux::Packet::DestinationOkReply) => (),
                             Ok(drtioaux::Packet::DestinationSequenceErrorReply { channel }) => {
-                                error!("[DEST#{}] RTIO sequence error involving channel 0x{:04x}", destination, channel),
+                                error!("[DEST#{}] RTIO sequence error involving channel 0x{:04x}", destination, channel);
                                 set_async_error_bits(ASYNC_ERROR_SEQUENCE_ERROR);
                             }
                             Ok(drtioaux::Packet::DestinationCollisionReply { channel }) => {
-                                error!("[DEST#{}] RTIO collision involving channel 0x{:04x}", destination, channel),
+                                error!("[DEST#{}] RTIO collision involving channel 0x{:04x}", destination, channel);
                                 set_async_error_bits(ASYNC_ERROR_COLLISION);
                             }
                             Ok(drtioaux::Packet::DestinationBusyReply { channel }) => {
-                                error!("[DEST#{}] RTIO busy error involving channel 0x{:04x}", destination, channel),
+                                error!("[DEST#{}] RTIO busy error involving channel 0x{:04x}", destination, channel);
                                 set_async_error_bits(ASYNC_ERROR_BUSY);
                             }
                             Ok(packet) => error!("[DEST#{}] received unexpected aux packet: {:?}", destination, packet),
@@ -358,9 +358,9 @@ pub mod drtio {
     }
 }
 
-const ASYNC_ERROR_COLLISION: u8 = 1;
-const ASYNC_ERROR_BUSY: u8 = 2;
-const ASYNC_ERROR_SEQUENCE_ERROR: u8 = 4;
+const ASYNC_ERROR_COLLISION: u8 = 1 << 0;
+const ASYNC_ERROR_BUSY: u8 = 1 << 1;
+const ASYNC_ERROR_SEQUENCE_ERROR: u8 = 1 << 2;
 static SEEN_ASYNC_ERRORS: AtomicU8 = AtomicU8::new(0);
 
 pub fn get_async_errors(io: &Io) -> Result<u8, Error> {
@@ -368,8 +368,8 @@ pub fn get_async_errors(io: &Io) -> Result<u8, Error> {
     Ok(SEEN_ASYNC_ERRORS.swap(0, Ordering::AcqRel))
 }
 
-fn set_async_error_bits(bit: u8) {
-    SEEN_ASYNC_ERRORS.fetch_or(bit, Ordering::AcqRel);
+fn set_async_error_bits(bitmask: u8) {
+    SEEN_ASYNC_ERRORS.fetch_or(bitmask, Ordering::AcqRel);
 }
 
 fn async_error_thread(io: Io) {

--- a/artiq/firmware/runtime/session.rs
+++ b/artiq/firmware/runtime/session.rs
@@ -436,7 +436,7 @@ fn process_kern_message(io: &Io, aux_mutex: &Mutex,
                     None => return Ok(true),
                     Some(ref mut stream) =>
                         host_write(stream, host::Reply::KernelFinished {
-                            async_errors: unsafe { get_async_errors() }
+                            async_errors: get_async_errors(io)?,
                         }).map_err(|e| e.into())
                 }
             }
@@ -462,7 +462,7 @@ fn process_kern_message(io: &Io, aux_mutex: &Mutex,
                             exceptions: exceptions,
                             stack_pointers: stack_pointers,
                             backtrace: backtrace,
-                            async_errors: unsafe { get_async_errors() }
+                            async_errors: get_async_errors(io)?,
                         }).map_err(|e| e.into())
                     }
                 }


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

When async errors, like RTIO sequence errors, happen on the master kasli they are reported in the artiq master logs against the experiment RID, which is useful for seeing if any these types of errors potentially affected your experiment. However if these types of error occur on an satellite, then although the satellite reports the error to the master kasli the master kasli wouldn't forward that error to the artiq master. Instead it was just logged. 

This change adds forwarding in the above case. 

In order to make sure that async errors are likely to have been forwarded to the kasli when errors are reported to the artiq master the DRTIO destination survey is explicitly triggered and waited for. Otherwise it's quite common for the errors not to have been reported from the satellite yet. 

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
