### PR TITLE
libboard_misoc: config::read returns Error instead of empty value if key was not found

### DIFF
--- a/artiq/coredevice/comm_mgmt.py
+++ b/artiq/coredevice/comm_mgmt.py
@@ -160,7 +160,12 @@ class CommMgmt:
     def config_read(self, key):
         self._write_header(Request.ConfigRead)
         self._write_string(key)
-        self._read_expect(Reply.ConfigData)
+        ty = self._read_header()
+        if ty == Reply.Error:
+            raise IOError("Device failed to read config. The key may not exist.")
+        elif ty != Reply.ConfigData:
+            raise IOError("Incorrect reply from device: {} (expected {})".
+                          format(ty, Reply.ConfigData))
         return self._read_string()
 
     def config_write(self, key, value):

--- a/artiq/coredevice/comm_mgmt.py
+++ b/artiq/coredevice/comm_mgmt.py
@@ -110,9 +110,10 @@ class CommMgmt:
         return ty
 
     def _read_expect(self, ty):
-        if self._read_header() != ty:
+        header = self._read_header()
+        if header != ty:
             raise IOError("Incorrect reply from device: {} (expected {})".
-                          format(self._read_type, ty))
+                          format(header, ty))
 
     def _read_int32(self):
         (value, ) = struct.unpack(self.endian + "l", self._read(4))

--- a/artiq/firmware/runtime/session.rs
+++ b/artiq/firmware/runtime/session.rs
@@ -529,7 +529,7 @@ fn flash_kernel_worker(io: &Io, aux_mutex: &Mutex,
 
     config::read(config_key, |result| {
         match result {
-            Ok(kernel) if kernel.len() > 0 => unsafe {
+            Ok(kernel) => unsafe {
                 // kernel CPU cannot access the SPI flash address space directly,
                 // so make a copy.
                 kern_load(io, &mut session, Vec::from(kernel).as_ref())


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

After recent changes, master with not configured DRTIO routing table would display the following warning in the logs:
```
WARN(board_artiq::drtio_routing): length of the configured routing table is incorrect
```

This error was misleading in that it could cause the user to think there was some sort of data corruption at play. 
This was caused by ``libboard_misoc`` ``config::read`` returning an empty value if the key was not found - so other code had also to check if the returned value's length was bigger than 0. 

Funnily enough, ``config::read_str`` handles any missing data or other errors and returns its own UTF8 error - so in a way that was already covered.

After this change, the warning disappears and no other firmware code is affected - although I did remove the check from ``runtime/sessions.rs`` since it seems no longer necessary.

From Python side however, I fixed a bug in comm_mgmt and added handling of errors.

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
