### PR TITLE
libdyld: Support nac3ld

### DIFF
--- a/artiq/firmware/libdyld/lib.rs
+++ b/artiq/firmware/libdyld/lib.rs
@@ -179,6 +179,16 @@ impl<'a> Library<'a> {
                     }
                 }
 
+                R_RISCV_CALL_PLT => {
+                    let sym = self.symtab.get(ELF32_R_SYM(rela.r_info) as usize)
+                                         .ok_or("symbol out of bounds of symbol table")?;
+                    let sym_name = self.name_starting_at(sym.st_name as usize)?;
+
+                    if sym_name == name {
+                        self.update_rela(rela, addr - (self.image_off + rela.r_offset))?
+                    }
+                }
+
                 // No associated symbols for other relocation types.
                 _ => ()
             }


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
This PR is the runtime linker portion to nac3ld. As nac3ld does not generate unnecessary sections such as PLT & GOT, this patch relocates directly onto the .text section.

Due to the lack of PLT, symbol rebinding cannot be completed just by solely updating a value. The linker will instead attempt to apply the new value to all PLT relocated value.

## Test
See nac3ld PR in NAC3.

### Related Issue
#1883

### Corresponding nac3ld PR
[NAC3 PR 292](https://git.m-labs.hk/M-Labs/nac3/pulls/292)

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Close/update issues.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
