### PR TITLE
[WIP] Dashboard: DDS Injection

### DIFF
--- a/artiq/dashboard/experiments.py
+++ b/artiq/dashboard/experiments.py
@@ -703,6 +703,26 @@ class ExperimentManager:
             scheduling["priority"], scheduling["due_date"],
             scheduling["flush"]))
 
+    def submit_by_content(self, content, class_name):
+        expid = {
+            "log_level": logging.WARNING,
+            "content": content,
+            "class_name": class_name,
+            "arguments": []
+        }
+        scheduling = {
+            "pipeline_name": "main",
+            "priority": 0,
+            "due_date": None,
+            "flush": False
+        }
+        asyncio.ensure_future(self._submit_task(
+            "Content",
+            scheduling["pipeline_name"],
+            expid,
+            scheduling["priority"], scheduling["due_date"],
+            scheduling["flush"]))
+
     async def _request_term_multiple(self, rids):
         for rid in rids:
             try:

--- a/artiq/dashboard/experiments.py
+++ b/artiq/dashboard/experiments.py
@@ -703,26 +703,6 @@ class ExperimentManager:
             scheduling["priority"], scheduling["due_date"],
             scheduling["flush"]))
 
-    def submit_by_content(self, content, class_name, description=None):
-        expid = {
-            "log_level": logging.WARNING,
-            "content": content,
-            "class_name": class_name,
-            "arguments": []
-        }
-        scheduling = {
-            "pipeline_name": "main",
-            "priority": 0,
-            "due_date": None,
-            "flush": False
-        }
-        asyncio.ensure_future(self._submit_task(
-            description or expid["class_name"],
-            scheduling["pipeline_name"],
-            expid,
-            scheduling["priority"], scheduling["due_date"],
-            scheduling["flush"]))
-
     async def _request_term_multiple(self, rids):
         for rid in rids:
             try:

--- a/artiq/dashboard/experiments.py
+++ b/artiq/dashboard/experiments.py
@@ -703,7 +703,7 @@ class ExperimentManager:
             scheduling["priority"], scheduling["due_date"],
             scheduling["flush"]))
 
-    def submit_by_content(self, content, class_name):
+    def submit_by_content(self, content, class_name, description=None):
         expid = {
             "log_level": logging.WARNING,
             "content": content,
@@ -717,7 +717,7 @@ class ExperimentManager:
             "flush": False
         }
         asyncio.ensure_future(self._submit_task(
-            "Content",
+            description or expid["class_name"],
             scheduling["pipeline_name"],
             expid,
             scheduling["priority"], scheduling["due_date"],

--- a/artiq/dashboard/moninj.py
+++ b/artiq/dashboard/moninj.py
@@ -507,7 +507,7 @@ class _DeviceManager:
         """.format(dds_channel=dds_channel, freq=freq,
                    cpld_dev=cpld_dev, cpld_init=cpld_init,
                    cfg_sw=cfg_sw))
-        self.expmgr.submit_by_content(dds_exp, "SetDDS")
+        self.expmgr.submit_by_content(dds_exp, "SetDDS", "Set DDS")
 
     def setup_ttl_monitoring(self, enable, channel):
         if self.mi_connection is not None:

--- a/artiq/dashboard/moninj.py
+++ b/artiq/dashboard/moninj.py
@@ -701,12 +701,12 @@ class _MonInjDock(QtWidgets.QDockWidget):
 
 
 class MonInj:
-    def __init__(self, expmgr):
+    def __init__(self, schedule_ctl):
         self.ttl_dock = _MonInjDock("TTL")
         self.dds_dock = _MonInjDock("DDS")
         self.dac_dock = _MonInjDock("DAC")
 
-        self.dm = _DeviceManager(expmgr)
+        self.dm = _DeviceManager(schedule_ctl)
         self.dm.ttl_cb = lambda: self.ttl_dock.layout_widgets(
                             self.dm.ttl_widgets.values())
         self.dm.dds_cb = lambda: self.dds_dock.layout_widgets(

--- a/artiq/dashboard/moninj.py
+++ b/artiq/dashboard/moninj.py
@@ -507,7 +507,7 @@ class _DeviceManager:
         """.format(dds_channel=dds_channel, freq=freq,
                    cpld_dev=cpld_dev, cpld_init=cpld_init,
                    cfg_sw=cfg_sw))
-        self.expmgr.submit_by_content(dds_exp, "SetDDS", "Set DDS")
+        self.expmgr.submit_by_content(dds_exp, "SetDDS", "Set DDS {}".format(dds_channel))
 
     def setup_ttl_monitoring(self, enable, channel):
         if self.mi_connection is not None:

--- a/artiq/dashboard/moninj.py
+++ b/artiq/dashboard/moninj.py
@@ -486,13 +486,13 @@ class _DeviceManager:
             # keep previous config if it was set already
             cpld_dev = """self.setattr_device("core_cache")
                 self.setattr_device("{}")""".format(dds_cpld)
-            cpld_init = """cfg = self.core_cache.get("_urukulcfg")
+            cpld_init = """cfg = self.core_cache.get("_{cpld}_cfg")
                 if len(cfg) > 0:
                     self.{cpld}.cfg_reg = cfg[0]
                 else:
                     self.{cpld}.init()
-                    self.core_cache.put("_urukulcfg", [self.{cpld}.cfg_reg])
-                    cfg = self.core_cache.get("_urukulcfg")
+                    self.core_cache.put("_{cpld}_cfg", [self.{cpld}.cfg_reg])
+                    cfg = self.core_cache.get("_{cpld}_cfg")
             """.format(cpld=dds_cpld)
             cfg_sw = """self.{}.cfg_sw(True)
                 cfg[0] = self.{}.cfg_reg

--- a/artiq/dashboard/moninj.py
+++ b/artiq/dashboard/moninj.py
@@ -332,6 +332,8 @@ def setup_from_ddb(ddb):
                 comment = v.get("comment")
                 if v["type"] == "local":
                     if v["module"] == "artiq.coredevice.ttl":
+                        if "ttl_urukul" in k:
+                            continue
                         channel = v["arguments"]["channel"]
                         force_out = v["class"] == "TTLOut"
                         widget = _WidgetDesc(k, comment, _TTLWidget, (channel, force_out, k))

--- a/artiq/dashboard/moninj.py
+++ b/artiq/dashboard/moninj.py
@@ -243,12 +243,14 @@ def setup_from_ddb(ddb):
 
 
 class _DeviceManager:
-    def __init__(self):
+    def __init__(self, expmgr):
         self.mi_addr = None
         self.mi_port = None
         self.reconnect_mi = asyncio.Event()
         self.mi_connection = None
         self.mi_connector_task = asyncio.ensure_future(self.mi_connector())
+
+        self.expmgr = expmgr
 
         self.ddb = dict()
         self.description = set()

--- a/artiq/frontend/artiq_dashboard.py
+++ b/artiq/frontend/artiq_dashboard.py
@@ -184,7 +184,7 @@ def main():
     smgr.register(d_applets)
     broadcast_clients["ccb"].notify_cbs.append(d_applets.ccb_notify)
 
-    d_ttl_dds = moninj.MonInj(expmgr)
+    d_ttl_dds = moninj.MonInj(rpc_clients["schedule"])
     loop.run_until_complete(d_ttl_dds.start(args.server, args.port_notify))
     atexit_register_coroutine(d_ttl_dds.stop)
 

--- a/artiq/frontend/artiq_dashboard.py
+++ b/artiq/frontend/artiq_dashboard.py
@@ -184,7 +184,7 @@ def main():
     smgr.register(d_applets)
     broadcast_clients["ccb"].notify_cbs.append(d_applets.ccb_notify)
 
-    d_ttl_dds = moninj.MonInj()
+    d_ttl_dds = moninj.MonInj(expmgr)
     loop.run_until_complete(d_ttl_dds.start(args.server, args.port_notify))
     atexit_register_coroutine(d_ttl_dds.stop)
 


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

This PR adds ability to set DDS channel frequency in the dashboard. Works with AD9914, AD9912, AD9910.

It works by generating a kernel with given frequency and sending it by content to the device.

The widget for each channel displays the frequency as before. If you move your cursor over one, OVR button will pop up:

![Screenshot from 2022-06-06 12-11-13](https://user-images.githubusercontent.com/1278433/172096783-eebbb994-3143-4741-9f61-b65eeb7db9be.png)

And if you press it, you will be able to change the frequency, and either apply or cancel the changes. Using Enter keys to apply and Esc to cancel works as well.

![Screenshot from 2022-06-06 12-11-40](https://user-images.githubusercontent.com/1278433/172096799-f7aeaf38-c08b-4e8e-a005-7a8e477aadce.png)

Tested with kc705 (looking into logs, kernel is run, not verified AD9914 functionality), and a Kasli with an AD9912. The core functionality works - frequency can be easily changed - but has some limitations:
- new frequency is not displayed in the menu (moninj does not report it back, I suppose?). I suppose displaying the user value doesn't make sense as it doesn't have to exactly match the reality (device can be restarted, and also see below).
- since they're all newly generated kernels, if you set one channel of an Urukul card, the rest are re-initialized and become 0 again. This would require changes in the Urukul driver to retrieve config and keep previous state somehow, instead of starting from scratch every time. Thus at this point only one channel per card can be really used.

Thus before merging I'd like to address these issues and discuss if and what should be done within this one (or maybe another one, to keep issues separate?) - that's why even though the feature itself feels complete, I'm marking it as WIP.

### Related Issue

Related #1142

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
