### PR TITLE
Update seen async errors

### DIFF
--- a/artiq/firmware/runtime/rtio_mgt.rs
+++ b/artiq/firmware/runtime/rtio_mgt.rs
@@ -212,11 +212,11 @@ pub mod drtio {
                                 destination_set_up(routing_table, up_destinations, destination, false),
                             Ok(drtioaux::Packet::DestinationOkReply) => (),
                             Ok(drtioaux::Packet::DestinationSequenceErrorReply { channel }) =>
-                                error!("[DEST#{}] RTIO sequence error involving channel 0x{:04x}", destination, channel),
+                                SEEN_ASYNC_ERRORS |= 4;
                             Ok(drtioaux::Packet::DestinationCollisionReply { channel }) =>
-                                error!("[DEST#{}] RTIO collision involving channel 0x{:04x}", destination, channel),
+                                SEEN_ASYNC_ERRORS |= 1;
                             Ok(drtioaux::Packet::DestinationBusyReply { channel }) =>
-                                error!("[DEST#{}] RTIO busy error involving channel 0x{:04x}", destination, channel),
+                                SEEN_ASYNC_ERRORS |= 2;
                             Ok(packet) => error!("[DEST#{}] received unexpected aux packet: {:?}", destination, packet),
                             Err(e) => error!("[DEST#{}] communication failed ({})", destination, e)
                         }

--- a/artiq/firmware/runtime/rtio_mgt.rs
+++ b/artiq/firmware/runtime/rtio_mgt.rs
@@ -6,6 +6,9 @@ use board_misoc::clock;
 use board_artiq::drtio_routing;
 use sched::Io;
 use sched::Mutex;
+const ASYNC_ERROR_COLLISION: u8 = 1 << 0;
+const ASYNC_ERROR_BUSY: u8 = 1 << 1;
+const ASYNC_ERROR_SEQUENCE_ERROR: u8 = 1 << 2;
 
 #[cfg(has_drtio)]
 pub mod drtio {
@@ -211,12 +214,18 @@ pub mod drtio {
                             Ok(drtioaux::Packet::DestinationDownReply) =>
                                 destination_set_up(routing_table, up_destinations, destination, false),
                             Ok(drtioaux::Packet::DestinationOkReply) => (),
-                            Ok(drtioaux::Packet::DestinationSequenceErrorReply { channel }) =>
-                                unsafe{SEEN_ASYNC_ERRORS |= 4},
-                            Ok(drtioaux::Packet::DestinationCollisionReply { channel }) =>
-                                unsafe{SEEN_ASYNC_ERRORS |= 1},
-                            Ok(drtioaux::Packet::DestinationBusyReply { channel }) =>
-                                unsafe{SEEN_ASYNC_ERRORS |= 2},
+                            Ok(drtioaux::Packet::DestinationSequenceErrorReply { channel }) => {
+                                error!("[DEST#{}] RTIO sequence error involving channel 0x{:04x}", destination, channel);
+                                unsafe { SEEN_ASYNC_ERRORS |= ASYNC_ERROR_SEQUENCE_ERROR };
+                            }
+                            Ok(drtioaux::Packet::DestinationCollisionReply { channel }) => {
+                                error!("[DEST#{}] RTIO collision involving channel 0x{:04x}", destination, channel);
+                                unsafe { SEEN_ASYNC_ERRORS |= ASYNC_ERROR_COLLISION };
+                            }
+                            Ok(drtioaux::Packet::DestinationBusyReply { channel }) => {
+                                error!("[DEST#{}] RTIO busy error involving channel 0x{:04x}", destination, channel);
+                                unsafe { SEEN_ASYNC_ERRORS |= ASYNC_ERROR_BUSY };
+                            }
                             Ok(packet) => error!("[DEST#{}] received unexpected aux packet: {:?}", destination, packet),
                             Err(e) => error!("[DEST#{}] communication failed ({})", destination, e)
                         }
@@ -339,15 +348,15 @@ fn async_error_thread(io: Io) {
         unsafe {
             io.until(|| csr::rtio_core::async_error_read() != 0).unwrap();
             let errors = csr::rtio_core::async_error_read();
-            if errors & 1 != 0 {
+            if errors & ASYNC_ERROR_COLLISION != 0 {
                 error!("RTIO collision involving channel {}",
                        csr::rtio_core::collision_channel_read());
             }
-            if errors & 2 != 0 {
+            if errors & ASYNC_ERROR_BUSY != 0 {
                 error!("RTIO busy error involving channel {}",
                        csr::rtio_core::busy_channel_read());
             }
-            if errors & 4 != 0 {
+            if errors & ASYNC_ERROR_SEQUENCE_ERROR != 0 {
                 error!("RTIO sequence error involving channel {}",
                        csr::rtio_core::sequence_error_channel_read());
             }

--- a/artiq/firmware/runtime/rtio_mgt.rs
+++ b/artiq/firmware/runtime/rtio_mgt.rs
@@ -212,11 +212,11 @@ pub mod drtio {
                                 destination_set_up(routing_table, up_destinations, destination, false),
                             Ok(drtioaux::Packet::DestinationOkReply) => (),
                             Ok(drtioaux::Packet::DestinationSequenceErrorReply { channel }) =>
-                                SEEN_ASYNC_ERRORS |= 4;
+                                unsafe{SEEN_ASYNC_ERRORS |= 4},
                             Ok(drtioaux::Packet::DestinationCollisionReply { channel }) =>
-                                SEEN_ASYNC_ERRORS |= 1;
+                                unsafe{SEEN_ASYNC_ERRORS |= 1},
                             Ok(drtioaux::Packet::DestinationBusyReply { channel }) =>
-                                SEEN_ASYNC_ERRORS |= 2;
+                                unsafe{SEEN_ASYNC_ERRORS |= 2},
                             Ok(packet) => error!("[DEST#{}] received unexpected aux packet: {:?}", destination, packet),
                             Err(e) => error!("[DEST#{}] communication failed ({})", destination, e)
                         }


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
Update the SEEN_ASYNC_ERRORS and add unsafe to it 
### Related Issue
 destination_survey should update SEEN_ASYNC_ERRORS #1895 
<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Close/update issues.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.


### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
