### PR TITLE
master/worker_db: Support lists of strings when writing to HDF5

### DIFF
--- a/artiq/master/worker_db.py
+++ b/artiq/master/worker_db.py
@@ -5,8 +5,10 @@ standalone command line tools).
 """
 
 from operator import setitem
+import h5py
 import importlib
 import logging
+import numpy
 
 from sipyco.sync_struct import Notifier
 from sipyco.pc_rpc import AutoTarget, Client, BestEffortClient
@@ -177,6 +179,10 @@ def _write(group, k, v):
     # Add context to exception message when the user writes a dataset that is
     # not representable in HDF5.
     try:
+        if isinstance(v, list):
+            v = numpy.asarray(v)
+            if v.dtype.type == numpy.unicode_:
+                v = numpy.array(v, dtype=h5py.special_dtype(vlen=str))
         group[k] = v
     except TypeError as e:
         raise TypeError("Error writing dataset '{}' of type '{}': {}".format(


### PR DESCRIPTION
This does the obvious thing of writing list of strings as datasets
of variable-length UTF string datasets. h5py does this automatically
for dataset attributes, but for whatever reason not for datasets
themselves.
