### PR TITLE
dashboard: Plumb through datasets client to ExperimentManager

### DIFF
--- a/artiq/dashboard/experiments.py
+++ b/artiq/dashboard/experiments.py
@@ -544,7 +544,7 @@ class _QuickOpenDialog(QtWidgets.QDialog):
 
 
 class ExperimentManager:
-    def __init__(self, main_window,
+    def __init__(self, main_window, dataset_sub,
                  explist_sub, schedule_sub,
                  schedule_ctl, experiment_db_ctl):
         self.main_window = main_window
@@ -556,6 +556,8 @@ class ExperimentManager:
         self.submission_options = dict()
         self.submission_arguments = dict()
 
+        self.datasets = dict()
+        dataset_sub.add_setmodel_callback(self.set_dataset_model)
         self.explist = dict()
         explist_sub.add_setmodel_callback(self.set_explist_model)
         self.schedule = dict()
@@ -569,6 +571,9 @@ class ExperimentManager:
             main_window)
         quick_open_shortcut.setContext(QtCore.Qt.ApplicationShortcut)
         quick_open_shortcut.activated.connect(self.show_quick_open)
+
+    def set_dataset_model(self, model):
+        self.datasets = model
 
     def set_explist_model(self, model):
         self.explist = model.backing_store

--- a/artiq/frontend/artiq_dashboard.py
+++ b/artiq/frontend/artiq_dashboard.py
@@ -160,6 +160,7 @@ def main():
 
     # create UI components
     expmgr = experiments.ExperimentManager(main_window,
+                                           sub_clients["datasets"],
                                            sub_clients["explist"],
                                            sub_clients["schedule"],
                                            rpc_clients["schedule"],


### PR DESCRIPTION
This is analogous to the explist/schedule subscribers, and allows
custom argument editors (such as ndscan) to provide hints/defaults/…
from datasets once available.
