### PR TITLE
Disconnect corelog properly when core device connection failed

### DIFF
--- a/artiq/frontend/aqctl_corelog.py
+++ b/artiq/frontend/aqctl_corelog.py
@@ -14,7 +14,6 @@ from sipyco.keepalive import async_open_connection
 
 from artiq.coredevice.comm_mgmt import Request, Reply
 
-logger = logging.getLogger(__name__)
 
 def get_argparser():
     parser = argparse.ArgumentParser(
@@ -63,7 +62,7 @@ async def get_logs(host):
             length, = struct.unpack(endian + "l", await reader.readexactly(4))
             log = await reader.readexactly(length)
         except IOError:
-            logger.error("Terminated due to connection lost with %s", host)
+            logger.error("Core log Terminated due to core device connection error")
             raise
 
         for line in log.decode("utf-8").splitlines():

--- a/artiq/frontend/aqctl_corelog.py
+++ b/artiq/frontend/aqctl_corelog.py
@@ -59,7 +59,6 @@ async def get_logs(host):
     await writer.drain()
 
     while True:
-
         length, = struct.unpack(endian + "l", await reader.readexactly(4))
         log = await reader.readexactly(length)
 
@@ -101,20 +100,16 @@ def main():
                         [signal_handler.wait_terminate(),
                          server.wait_terminate(),
                          get_logs_task
-                        ],
+                         ],
                         return_when=asyncio.FIRST_COMPLETED))
                     for task in pending:
                         task.cancel()
                 finally:
                     loop.run_until_complete(server.stop())
             finally:
-                get_logs_task.cancel()
-                try:
-                    loop.run_until_complete(get_logs_task)
-                except asyncio.CancelledError:
-                    pass
-        except:
-            logger.error("Lost connection to the core device due to: ", exc_info = True)
+                pass
+        except Exception:
+            logger.error("Termination due to exception", exc_info=True)
         finally:
             signal_handler.teardown()
     finally:

--- a/artiq/frontend/aqctl_corelog.py
+++ b/artiq/frontend/aqctl_corelog.py
@@ -14,6 +14,7 @@ from sipyco.keepalive import async_open_connection
 
 from artiq.coredevice.comm_mgmt import Request, Reply
 
+logger = logging.getLogger(__name__)
 
 def get_argparser():
     parser = argparse.ArgumentParser(
@@ -62,7 +63,7 @@ async def get_logs(host):
             length, = struct.unpack(endian + "l", await reader.readexactly(4))
             log = await reader.readexactly(length)
         except IOError:
-            logger.error("Core log Terminated due to core device connection error")
+            logger.error("Terminated due to connection lost with %s", host)
             raise
 
         for line in log.decode("utf-8").splitlines():

--- a/artiq/frontend/aqctl_corelog.py
+++ b/artiq/frontend/aqctl_corelog.py
@@ -113,9 +113,8 @@ def main():
                     loop.run_until_complete(get_logs_task)
                 except asyncio.CancelledError:
                     pass
-        except Exception as e:
-            logger.error(e)
-            logger.error("Lost connection to the core device")
+        except:
+            logger.error("Lost connection to the core device due to: ", exc_info = True)
         finally:
             signal_handler.teardown()
     finally:


### PR DESCRIPTION

<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
Replace asyncio.open_connection with async_open_connection that
has keepalive
Put get_logs_task inside asyncio.wait() for termination when
disconnected

### Related Issue #1897

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #1897 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Close/update issues.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
