### PR TITLE
language.environment: Add check_unused_arguments

### DIFF
--- a/artiq/language/environment.py
+++ b/artiq/language/environment.py
@@ -213,18 +213,21 @@ class TraceArgumentManager:
 class ProcessArgumentManager:
     def __init__(self, unprocessed_arguments):
         self.unprocessed_arguments = unprocessed_arguments
+        self._processed_arguments = []
 
     def get(self, key, processor, group, tooltip):
         if key in self.unprocessed_arguments:
             r = processor.process(self.unprocessed_arguments[key])
-            self.unprocessed_arguments.pop(key)
+            self._processed_arguments.append(key)
         else:
             r = processor.default()
         return r
 
     def check_unprocessed_arguments(self):
-        if self.unprocessed_arguments:
-            args = ", ".join(self.unprocessed_arguments.keys())
+        unprocessed = set(self.unprocessed_arguments.keys()) -\
+                      set(self._processed_arguments)
+        args = ", ".join(list(unprocessed))
+        if unprocessed:
             raise AttributeError("Unprocessed argument(s): " + args)
 
 class HasEnvironment:

--- a/artiq/language/environment.py
+++ b/artiq/language/environment.py
@@ -215,19 +215,19 @@ class TraceArgumentManager:
 class ProcessArgumentManager:
     def __init__(self, unprocessed_arguments):
         self.unprocessed_arguments = unprocessed_arguments
-        self._processed_arguments = []
+        self._processed_arguments = set()
 
     def get(self, key, processor, group, tooltip):
         if key in self.unprocessed_arguments:
             r = processor.process(self.unprocessed_arguments[key])
-            self._processed_arguments.append(key)
+            self._processed_arguments.add(key)
         else:
             r = processor.default()
         return r
 
     def check_unprocessed_arguments(self):
         unprocessed = set(self.unprocessed_arguments.keys()) -\
-                      set(self._processed_arguments)
+                      self._processed_arguments
         if unprocessed:
             raise AttributeError("Unprocessed argument(s): " +
                                  ", ".join(unprocessed))

--- a/artiq/language/environment.py
+++ b/artiq/language/environment.py
@@ -222,15 +222,10 @@ class ProcessArgumentManager:
             r = processor.default()
         return r
 
-    def check_unused_arguments(self):
-        if len(self.unprocessed_arguments) > 0:
-            args = ""
-            for key in self.unprocessed_arguments.keys():
-                if args == "":
-                    args += str(key)
-                else:
-                    args += (", "+str(key))
-            raise Exception("Unused argument(s): " + args)
+    def check_unprocessed_arguments(self):
+        if self.unprocessed_arguments:
+            args = ", ".join(self.unprocessed_arguments.keys())
+            raise AttributeError("Unprocessed argument(s): " + args)
 
 class HasEnvironment:
     """Provides methods to manage the environment of an experiment (arguments,
@@ -253,7 +248,7 @@ class HasEnvironment:
         self.build(*args, **kwargs)
         self.__in_build = False
         if isinstance(self.__argument_mgr, ProcessArgumentManager):
-            self.__argument_mgr.check_unused_arguments()
+            self.__argument_mgr.check_unprocessed_arguments()
 
     def register_child(self, child):
         self.children.append(child)

--- a/artiq/language/environment.py
+++ b/artiq/language/environment.py
@@ -229,7 +229,7 @@ class ProcessArgumentManager:
                 if args == "":
                     args += str(key)
                 else:
-                    args += (" ,"+str(key))
+                    args += (", "+str(key))
             raise Exception("Unused argument(s): " + args)
 
 class HasEnvironment:

--- a/artiq/language/environment.py
+++ b/artiq/language/environment.py
@@ -229,7 +229,7 @@ class ProcessArgumentManager:
         unprocessed = set(self.unprocessed_arguments.keys()) -\
                       self._processed_arguments
         if unprocessed:
-            raise AttributeError("Unprocessed argument(s): " +
+            raise AttributeError("Invalid argument(s): " +
                                  ", ".join(unprocessed))
 
 class HasEnvironment:

--- a/artiq/language/environment.py
+++ b/artiq/language/environment.py
@@ -209,6 +209,8 @@ class TraceArgumentManager:
         self.requested_args[key] = processor, group, tooltip
         return None
 
+    def check_unprocessed_arguments(self):
+        pass
 
 class ProcessArgumentManager:
     def __init__(self, unprocessed_arguments):
@@ -250,8 +252,7 @@ class HasEnvironment:
         self.__in_build = True
         self.build(*args, **kwargs)
         self.__in_build = False
-        if isinstance(self.__argument_mgr, ProcessArgumentManager):
-            self.__argument_mgr.check_unprocessed_arguments()
+        self.__argument_mgr.check_unprocessed_arguments()
 
     def register_child(self, child):
         self.children.append(child)

--- a/artiq/language/environment.py
+++ b/artiq/language/environment.py
@@ -229,8 +229,8 @@ class ProcessArgumentManager:
         unprocessed = set(self.unprocessed_arguments.keys()) -\
                       set(self._processed_arguments)
         if unprocessed:
-            args = ", ".join(list(unprocessed))
-            raise AttributeError("Unprocessed argument(s): " + args)
+            raise AttributeError("Unprocessed argument(s): " +
+                                 ", ".join(unprocessed))
 
 class HasEnvironment:
     """Provides methods to manage the environment of an experiment (arguments,

--- a/artiq/language/environment.py
+++ b/artiq/language/environment.py
@@ -217,10 +217,20 @@ class ProcessArgumentManager:
     def get(self, key, processor, group, tooltip):
         if key in self.unprocessed_arguments:
             r = processor.process(self.unprocessed_arguments[key])
+            self.unprocessed_arguments.pop(key)
         else:
             r = processor.default()
         return r
 
+    def check_unused_arguments(self):
+        if len(self.unprocessed_arguments) > 0:
+            args = ""
+            for key in self.unprocessed_arguments.keys():
+                if args == "":
+                    args += str(key)
+                else:
+                    args += (" ,"+str(key))
+            raise Exception("Unused argument(s): " + args)
 
 class HasEnvironment:
     """Provides methods to manage the environment of an experiment (arguments,
@@ -242,6 +252,8 @@ class HasEnvironment:
         self.__in_build = True
         self.build(*args, **kwargs)
         self.__in_build = False
+        if isinstance(self.__argument_mgr, ProcessArgumentManager):
+            self.__argument_mgr.check_unused_arguments()
 
     def register_child(self, child):
         self.children.append(child)

--- a/artiq/language/environment.py
+++ b/artiq/language/environment.py
@@ -226,8 +226,8 @@ class ProcessArgumentManager:
     def check_unprocessed_arguments(self):
         unprocessed = set(self.unprocessed_arguments.keys()) -\
                       set(self._processed_arguments)
-        args = ", ".join(list(unprocessed))
         if unprocessed:
+            args = ", ".join(list(unprocessed))
             raise AttributeError("Unprocessed argument(s): " + args)
 
 class HasEnvironment:


### PR DESCRIPTION

<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
**Problem**: scheduler device might have added incorrect arguments as stated in issue #1641

**Solution**: Check the unused arguments in expid in unprocessed_arguments after build

**Details**: remove argument in unprocessed_arguments after get() during build. Call check_unused_arguments() after build to see what argument is left. Raise exception and state those arguments.

**Test result**:
![Screenshot from 2022-06-29 15-24-48](https://user-images.githubusercontent.com/48083317/176382932-48069894-a5ae-4a42-b790-b773bbb03268.png)
Based on the example in #1641 
After submitting RID 40, exception occur and stating what arguments were not being used.
After correcting the typo, submit it as RID 42 and successfully changed the text output.

### Related Issue #1641 

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #1641
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
|   | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Close/update issues.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [ ] Add and check docstrings and comments
- [ ] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

- [ ] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
