### PR TITLE
moninj: fix underflows for urukul freq set

### DIFF
--- a/artiq/dashboard/moninj.py
+++ b/artiq/dashboard/moninj.py
@@ -560,6 +560,7 @@ class _DeviceManager:
                 if len(cfg) > 0:
                     self.{cpld}.cfg_reg = cfg[0]
                 else:
+                    delay(10*ms)
                     self.{cpld}.init()
                     self.core_cache.put("_{cpld}_cfg", [self.{cpld}.cfg_reg])
                     cfg = self.core_cache.get("_{cpld}_cfg")
@@ -582,8 +583,8 @@ class _DeviceManager:
                 
             @kernel
             def run(self):
-                self.core.break_realtime()
-                delay(2*ms)
+                self.core.reset()
+                delay(5*ms)
                 {cpld_init}
                 self.{dds_channel}.init()
                 self.{dds_channel}.set({freq})
@@ -612,11 +613,12 @@ class _DeviceManager:
             @kernel
             def run(self):
                 self.core.break_realtime()
-                delay(2*ms)
+                delay(5*ms)
                 cfg = self.core_cache.get("_{cpld}_cfg")
                 if len(cfg) > 0:
                     self.{cpld}.cfg_reg = cfg[0]
                 else:
+                    delay(10*ms)
                     self.{cpld}.init()
                     self.core_cache.put("_{cpld}_cfg", [self.{cpld}.cfg_reg])
                     cfg = self.core_cache.get("_{cpld}_cfg")

--- a/artiq/dashboard/moninj.py
+++ b/artiq/dashboard/moninj.py
@@ -560,7 +560,7 @@ class _DeviceManager:
                 if len(cfg) > 0:
                     self.{cpld}.cfg_reg = cfg[0]
                 else:
-                    delay(10*ms)
+                    delay(15*ms)
                     self.{cpld}.init()
                     self.core_cache.put("_{cpld}_cfg", [self.{cpld}.cfg_reg])
                     cfg = self.core_cache.get("_{cpld}_cfg")
@@ -584,8 +584,8 @@ class _DeviceManager:
             @kernel
             def run(self):
                 self.core.reset()
-                delay(5*ms)
                 {cpld_init}
+                delay(5*ms)
                 self.{dds_channel}.init()
                 self.{dds_channel}.set({freq})
                 {cfg_sw}
@@ -598,7 +598,7 @@ class _DeviceManager:
                 "SetDDS", 
                 "Set DDS {} {}MHz".format(dds_channel, freq/1e6)))
 
-    def dds_channel_toggle(self, dds_model, sw=True):
+    def dds_channel_toggle(self, dds_channel, dds_model, sw=True):
         # urukul only
         toggle_exp = textwrap.dedent("""
         from artiq.experiment import *
@@ -612,16 +612,16 @@ class _DeviceManager:
                 
             @kernel
             def run(self):
-                self.core.break_realtime()
-                delay(5*ms)
+                self.core.reset()
                 cfg = self.core_cache.get("_{cpld}_cfg")
                 if len(cfg) > 0:
                     self.{cpld}.cfg_reg = cfg[0]
                 else:
-                    delay(10*ms)
+                    delay(15*ms)
                     self.{cpld}.init()
                     self.core_cache.put("_{cpld}_cfg", [self.{cpld}.cfg_reg])
                     cfg = self.core_cache.get("_{cpld}_cfg")
+                delay(5*ms)
                 self.{ch}.init()
                 self.{ch}.cfg_sw({sw})
                 cfg[0] = self.{cpld}.cfg_reg


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

On first run of setting frequency on AD9912 there's a chance of an RTIO underflow. This PR is intending to fix that.

Tested with real hardware, and as expected it doesn't happen anymore.

### Related Issue

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
