### PR TITLE
Dashboard urukul injection improvements

### DIFF
--- a/artiq/dashboard/moninj.py
+++ b/artiq/dashboard/moninj.py
@@ -314,6 +314,10 @@ class _DDSWidget(QtWidgets.QFrame):
         apply.clicked.connect(self.apply_changes)
         if self.dds_model.is_urukul:
             off_btn.clicked.connect(self.off_clicked)
+            off_btn.setToolTip(textwrap.dedent(
+                """Note: If TTL RTIO sw for the channel is switched high,
+                this button will not disable the channel.
+                Use the TTL override instead."""))
         self.value_edit.returnPressed.connect(lambda: self.apply_changes(None))
         self.value_edit.escapePressedConnect(self.cancel_changes)
         cancel.clicked.connect(self.cancel_changes)


### PR DESCRIPTION


# ARTIQ Pull Request

## Description of Changes

This pull request aims to improve the DDS injection functionality.

As discussed in #1941 - we'd like to initialize the CPLD and channels less, if some other experiment already enabled any channels before.

RF switches are based off STA now, rather than config state in core cache that's used only by the injected experiment. And at least for AD9912 (for now), we can detect if the channel was initialized or not, so any changes to the channel configuration will be kept.

Currently tested with AD9912 and AD9914.

There's two more things left to do, and that's why it's marked as WIP:
- [x] Check AD9910's behavior before and after init
- [x] Document the behavior (where?)

### Related Issue

(Hopefully) Closes #1941

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
