### PR TITLE
llvm: change addr2line to symbolizer

### DIFF
--- a/artiq/compiler/targets.py
+++ b/artiq/compiler/targets.py
@@ -91,7 +91,7 @@ class Target:
 
     tool_ld = "ld.lld"
     tool_strip = "llvm-strip"
-    tool_addr2line = "llvm-addr2line"
+    tool_symbolizer = "llvm-symbolizer"
     tool_cxxfilt = "llvm-cxxfilt"
 
     def __init__(self):
@@ -218,8 +218,8 @@ class Target:
         # the backtrace entry should point at.
         last_inlined = None
         offset_addresses = [hex(addr - 1) for addr in addresses]
-        with RunTool([self.tool_addr2line, "--addresses",  "--functions", "--inlines",
-                      "--demangle", "--exe={library}"] + offset_addresses,
+        with RunTool([self.tool_symbolizer, "--addresses",  "--functions", "--inlines",
+                      "--demangle", "--output-style=GNU", "--exe={library}"] + offset_addresses,
                      library=library) \
                 as results:
             lines = iter(results["__stdout__"].read().rstrip().split("\n"))
@@ -275,7 +275,7 @@ class RV32IMATarget(Target):
 
     tool_ld = "ld.lld"
     tool_strip = "llvm-strip"
-    tool_addr2line = "llvm-addr2line"
+    tool_symbolizer = "llvm-symbolizer"
     tool_cxxfilt = "llvm-cxxfilt"
 
 class RV32GTarget(Target):
@@ -288,7 +288,7 @@ class RV32GTarget(Target):
 
     tool_ld = "ld.lld"
     tool_strip = "llvm-strip"
-    tool_addr2line = "llvm-addr2line"
+    tool_symbolizer = "llvm-symbolizer"
     tool_cxxfilt = "llvm-cxxfilt"
 
 class CortexA9Target(Target):
@@ -301,5 +301,5 @@ class CortexA9Target(Target):
 
     tool_ld = "ld.lld"
     tool_strip = "llvm-strip"
-    tool_addr2line = "llvm-addr2line"
+    tool_symbolizer = "llvm-symbolizer"
     tool_cxxfilt = "llvm-cxxfilt"


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Changes symbolize tool in `artiq/complier/targets.py` from `llvm-addr2line` to `llvm-symbolizer`.

### Related Issue

Closes #1969.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Close/update issues.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.

The following minimum working example experiment with symbolizer usage is tested on Linux/nix, Windows/conda, and Windows/venv (with `llvm` installed). This experiment raises an `InternalError` as expected. I do not know how to add the m-labs source to `pacman` so Windows/msys2 is not tested.

```python
from artiq.coredevice.exceptions import InternalError
from artiq.experiment import EnvExperiment, kernel


class TestLLVMSymbolizer(EnvExperiment):
    def build(self):
        self.setattr_device("core")

    def prepare(self):
        self._variable = True

    @kernel
    def run(self):
        self.core.reset()
        kernel_var = self._variable  # necessary for avoiding a ConnectionResetError.
        raise InternalError("An internel error.")
```

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
