### PR TITLE
Fixed two too low delay values in Phaser init

### DIFF
--- a/artiq/coredevice/phaser.py
+++ b/artiq/coredevice/phaser.py
@@ -275,7 +275,7 @@ class Phaser:
 
         for data in self.dac_mmap:
             self.dac_write(data >> 16, data)
-            delay(40*us)
+            delay(120*us)
         self.dac_sync()
         delay(40*us)
 
@@ -662,7 +662,7 @@ class Phaser:
         .. note:: Synchronising the NCO clears the phase-accumulator
         """
         config1f = self.dac_read(0x1f)
-        delay(.1*ms)
+        delay(.4*ms)
         self.dac_write(0x1f, config1f & ~int32(1 << 1))
         self.dac_write(0x1f, config1f | (1 << 1))
 


### PR DESCRIPTION
Signed-off-by: Fabian Schwartau <fabian@opencode.eu>

<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
Two delays in the Phaser's init function were too low for my setup. I doubled the values until it worked and then doubled them again to be on the safe side.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### Code Changes
I tested the code onmy setup, which is an Kasli v1.1 and a Phaser v1.0.
