### PR TITLE
Add API to attach hdf5 attributes to datasets

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -19,6 +19,7 @@ ARTIQ-9 (Unreleased)
 * Python 3.12 support.
 * Compiler can now give automatic suggestions for ``kernel_invariants``. 
 * Idle kernels now restart when written with ``artiq_coremgmt`` and stop when erased/removed from config.
+* HDF5 attributes can be attached to datasets using ``set_dataset_metadata()``.
 
 ARTIQ-8
 -------

--- a/artiq/examples/no_hardware/repository/hdf5_attributes.py
+++ b/artiq/examples/no_hardware/repository/hdf5_attributes.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+from artiq.experiment import *
+
+
+class HDF5Attributes(EnvExperiment):
+    """Archive data to HDF5 with attributes"""
+
+    def run(self):
+        dummy = np.empty(20)
+        dummy.fill(np.nan)
+        self.set_dataset("dummy", dummy,
+                         broadcast=True, archive=True)
+        self.set_dataset_metadata("dummy", "k1", "v1")
+        self.set_dataset_metadata("dummy", "k2", "v2")

--- a/artiq/language/environment.py
+++ b/artiq/language/environment.py
@@ -446,6 +446,21 @@ class HasEnvironment:
         efficiently as incremental modifications in broadcast mode."""
         self.__dataset_mgr.append_to(key, value)
 
+    @rpc(flags={"async"})
+    def set_dataset_metadata(self, key, metadata_key, metadata_value):
+        """Attach metadata to the dataset.
+
+        The metadata is saved as HDF5 attributes if there was a call to
+        ``set_dataset(..., archive=True)`` with the same key.
+
+        :param key: The already existing dataset, to which you want to attach the metadata.
+        If absent, KeyError will be raised.
+        :param metadata_key: The metadata key of type string. If already exists, rewrites the metadata.
+        :param metadata_value: Value to be attached to ``metadata_key``. Can be any valid HDF5 datatype.
+        See HDF5 documentation for additional information.
+        """
+        self.__dataset_mgr.set_metadata(key, metadata_key, metadata_value)
+
     def get_dataset(self, key, default=NoDefault, archive=True):
         """Returns the contents of a dataset.
 

--- a/artiq/test/test_hdf5_attributes.py
+++ b/artiq/test/test_hdf5_attributes.py
@@ -1,0 +1,59 @@
+import unittest
+import io
+import numpy as np
+import h5py
+
+from artiq.experiment import *
+from artiq.test.hardware_testbench import ExperimentCase
+
+
+class HDF5Attributes(EnvExperiment):
+    """Archive data to HDF5 with attributes"""
+
+    def run(self):
+        # Attach attributes metadata to the HDF5 key
+        # The key should exist in the resulting HDF5 file (archive=True).
+        self.set_dataset("dummy", np.full(20, np.nan), broadcast=True, archive=True)
+        self.set_dataset_metadata("dummy", "k1", "v1")
+        self.set_dataset_metadata("dummy", "k2", "v2")
+
+
+class TestHDF5Attributes(ExperimentCase):
+    def setUp(self):
+        super().setUp()
+        self.exp = self.execute(HDF5Attributes)
+        self.dump()
+
+    def dump(self):
+        self.bio = io.BytesIO()
+        with h5py.File(self.bio, "w") as f:
+            self.dataset_mgr.write_hdf5(f)
+
+        self.bio.seek(0)
+        self.h5file = h5py.File(self.bio, "r")
+        self.datasets = self.h5file.get("datasets")
+
+    def test_dataset_metadata(self):
+        self.assertEqual(self.datasets["dummy"].attrs, {"k1": "v1", "k2": "v2"})
+        self.assertTrue(np.all((self.datasets["dummy"], np.full(20, np.nan))))
+
+    def test_write_none(self):
+        with self.assertRaises(KeyError):
+            self.exp.set_dataset_metadata(None, "test", "none")
+        self.exp.set_dataset_metadata("dummy", None, "none")
+        with self.assertRaises(TypeError):
+            self.dump()
+
+    def test_write_absent(self):
+        with self.assertRaises(KeyError):
+            self.exp.set_dataset_metadata("absent", "test", "absent")
+
+    def test_rewrite(self):
+        self.exp.set_dataset_metadata("dummy", "k2", "rewrite")
+        self.dump()
+        self.assertEqual(self.datasets["dummy"].attrs, {"k1": "v1", "k2": "rewrite"})
+
+    def test_non_archive(self):
+        self.exp.set_dataset("non_archive", np.full(30, np.nan), broadcast=True, archive=False)
+        with self.assertRaises(KeyError):
+            self.exp.set_dataset_metadata("non_archive", "k1", "v1")


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

### Related Issue

Closes #1691  
Closes #1978 

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Close/update issues.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

- [x] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Tests

```sh
ARTIQ_ROOT=./ python -m unittest  artiq.test.test_hdf5_attributes
```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
