### PR TITLE
language: check for unprocessed arguments after constructing experiment

### DIFF
--- a/artiq/frontend/artiq_compile.py
+++ b/artiq/frontend/artiq_compile.py
@@ -53,6 +53,8 @@ def main():
         arguments = parse_arguments(args.arguments)
         argument_mgr = ProcessArgumentManager(arguments)
         exp_inst = exp((device_mgr, dataset_mgr, argument_mgr, {}))
+        argument_mgr.check_unprocessed_arguments()
+
 
         if not hasattr(exp.run, "artiq_embedded"):
             raise ValueError("Experiment entry point must be a kernel")

--- a/artiq/frontend/artiq_run.py
+++ b/artiq/frontend/artiq_run.py
@@ -184,7 +184,9 @@ def _build_experiment(device_mgr, dataset_mgr, args):
         "arguments": arguments
     }
     device_mgr.virtual_devices["scheduler"].expid = expid
-    return get_experiment(module, args.class_name)(managers)
+    exp_inst = get_experiment(module, args.class_name)(managers)
+    argument_mgr.check_unprocessed_arguments()
+    return exp_inst
 
 
 def run(with_file=False):

--- a/artiq/language/environment.py
+++ b/artiq/language/environment.py
@@ -209,8 +209,6 @@ class TraceArgumentManager:
         self.requested_args[key] = processor, group, tooltip
         return None
 
-    def check_unprocessed_arguments(self):
-        pass
 
 class ProcessArgumentManager:
     def __init__(self, unprocessed_arguments):
@@ -252,8 +250,6 @@ class HasEnvironment:
         self.__in_build = True
         self.build(*args, **kwargs)
         self.__in_build = False
-        if self.__argument_mgr is not None:
-            self.__argument_mgr.check_unprocessed_arguments()
 
     def register_child(self, child):
         self.children.append(child)

--- a/artiq/master/worker_impl.py
+++ b/artiq/master/worker_impl.py
@@ -333,6 +333,7 @@ def main():
                 os.chdir(dirname)
                 argument_mgr = ProcessArgumentManager(expid["arguments"])
                 exp_inst = exp((device_mgr, dataset_mgr, argument_mgr, {}))
+                argument_mgr.check_unprocessed_arguments()
                 put_completed()
             elif action == "prepare":
                 exp_inst.prepare()


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

### Problem 
`check_unprocessed_arguments` is called potentially before all arguments have had a chance to be processed.

### Solution
Check for unprocessed arguments only in instances of `Experiment`.

### Details
Check if `self` is an instance of `Experiment` before calling `check_unprocessed_arguments`. This ensures that the argument manager has been able to process all arguments built in `HasEnvironment` sub-components.

### Test

Based on the experiment in issue [#1641](https://github.com/m-labs/artiq/issues/1641)

``` python
from artiq.experiment import *


class SubComponent1(HasEnvironment):
    def build(self):
        self.setattr_device("core")
        self.setattr_argument(
            "propaganda", StringValue(default="Brainwash population")
        )

    @kernel
    def do(self):
        print(self.propaganda)


class SubComponent2(HasEnvironment):
    def build(self):
        self.setattr_device("core")
        self.setattr_argument(
            "important_param", StringValue(default="Fire the missiles")
        )

    @kernel
    def do(self):
        print(self.important_param)


class SubComponent3(EnvExperiment):
    def build(self):
        self.setattr_device("core")
        self.setattr_argument("hello", StringValue("I am an EnvExperiment"))
    
    @kernel
    def run(self):
        print(self.hello)


class DoSomething(EnvExperiment):
    def build(self):
        self.setattr_device("core")
        self.sc1 = SubComponent1(self)
        self.sc2 = SubComponent2(self)
        self.sc3 = SubComponent3(self)

    @kernel
    def run(self):
        self.sc1.do()
        self.sc2.do()
        self.sc3.run()


class ScheduleSomething(EnvExperiment):
    def build(self):
        self.setattr_device("scheduler")

    def run(self):
        new_expid = {
            "file": __file__,
            "class_name": DoSomething.__name__,
            "arguments": {
                "important_param": "Abort the mission",
                "propaganda": "Say no to war!",
                "hello": "Hi there.",
            },
            "log_level": 30,
            "repo_rev": "N/A",
        }

        self.scheduler.submit("main", new_expid)
```

Submit `ScheduleSomething` either from the dashboard or by using `artiq_client`.
If there is no typo in the spelling of `"important_param"`, `"propaganda"` and `"hello"`, the following will be printed to the log: 

```
print:Say no to war!
print:Abort the mission
print:Hi there.
```

If there is a typo in the spelling of `"important_param"` or `"propaganda"` or `"hello"` or all of them, the log will show e.g.:
```
AttributeError: Supplied argument(s) not queried in experiment: important_poram
```
or
```
AttributeError: Supplied argument(s) not queried in experiment: propoganda
```
or
```
AttributeError: Supplied argument(s) not queried in experiment: helo
```
or
```
AttributeError: Supplied argument(s) not queried in experiment: propoganda, important_poram, helo
```
respectively.

Submitting `DoSomething` through the dashboard (with default values) or via `artiq_client` will print the following to the log:
```
print:Brainwash population
print:Fire the missiles
print:I am an EnvExperiment
```

Using `artiq_run` and `artiq_compile` also produce similar results.

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

Closes [#2002](https://github.com/m-labs/artiq/issues/2002)

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Close/update issues.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [ ] Add and check docstrings and comments
- [ ] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

<!-- ### Documentation Changes

- [ ] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors. -->

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
