### PR TITLE
Fix deprecated warnings on nix develop

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 import sys
 
 import versioneer
@@ -66,7 +66,7 @@ Topic :: System :: Hardware
 """.splitlines(),
     install_requires=requirements,
     extras_require={},
-    packages=find_packages(),
+    packages=find_namespace_packages(exclude=["artiq.test.lit", "artiq.test.lit.*", "doc.manual"], ),
     namespace_packages=[],
     include_package_data=True,
     ext_modules=[],


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

### Related Issue

Closes #2009

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### Verify

1. Obtain `nix develop` logs before this patch
2. Obtain `nix develop` logs with this patch
3. Compare them with the code below
```py
import re
from sys import argv

# copying artiq/coredevice/edge_counter.py -> build/lib/artiq/coredevice
copying = re.compile(r"(copying .*? -> .*?)\n")
creating = re.compile(r"(creating .*? -> .*?)\n")
# adding 'artiq/gateware/test/wrpll/test_thls.py'
adding = re.compile(r"(adding '.*?')\n")


def main():
    with open(argv[1], "r") as f:
        lhs = f.read()
    with open(argv[2], "r") as f:
        rhs = f.read()
    lcopy, lcreate, ladd = set(copying.findall(lhs)), set(creating.findall(lhs)), set(adding.findall(lhs))
    rcopy, rcreate, radd = set(copying.findall(rhs)), set(creating.findall(rhs)), set(adding.findall(rhs))

    for lhs, rhs in [(lcopy, rcopy), (lcreate, rcreate), (ladd, radd)]:
        print("\nlhs - rhs:")
        print("\n".join(lhs.difference(rhs)))
        print("\nrhs - lhs:")
        print("\n".join(rhs.difference(lhs)))


if __name__ == '__main__':
    main()
```

5. Output should be as follows:
```sh
> python test_namespace_package_transition.py log_fixed2 log_old

lhs - rhs:


rhs - lhs:


lhs - rhs:


rhs - lhs:


lhs - rhs:


rhs - lhs:
```