### PR TITLE
browser: read artiq_version from HDF5 as string

### DIFF
--- a/artiq/browser/files.py
+++ b/artiq/browser/files.py
@@ -106,7 +106,7 @@ class Hdf5FileSystemModel(QtWidgets.QFileSystemModel):
                     start_time = datetime.fromtimestamp(h5["start_time"][()]) if "start_time" in h5 else "<none>"
                     v = ("artiq_version: {}\nrepo_rev: {}\nfile: {}\n"
                          "class_name: {}\nrid: {}\nstart_time: {}").format(
-                             h5["artiq_version"][()] if "artiq_version" in h5 else "<none>",
+                             h5["artiq_version"].asstr()[()] if "artiq_version" in h5 else "<none>",
                              expid.get("repo_rev", "<none>"),
                              expid.get("file", "<none>"), expid.get("class_name", "<none>"),
                              h5["rid"][()] if "rid" in h5 else "<none>", start_time)
@@ -178,7 +178,7 @@ class FilesDock(QtWidgets.QDockWidget):
                 expid = pyon.decode(f["expid"][()]) if "expid" in f else dict()
                 start_time = datetime.fromtimestamp(f["start_time"][()]) if "start_time" in f else "<none>"
                 v = {
-                    "artiq_version": f["artiq_version"][()] if "artiq_version" in f else "<none>",
+                    "artiq_version": f["artiq_version"].asstr()[()] if "artiq_version" in f else "<none>",
                     "repo_rev": expid.get("repo_rev", "<none>"),
                     "file": expid.get("file", "<none>"),
                     "class_name": expid.get("class_name", "<none>"),


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Decode artiq_version string from HDF5, as described in [documentation](https://docs.h5py.org/en/stable/strings.html).

### Related Issue

[Subsequent of #2013 ](https://github.com/m-labs/artiq/issues/2013#issuecomment-1333482939)

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
