### PR TITLE
Write results by the relative path instead of chdir

### DIFF
--- a/artiq/master/worker_impl.py
+++ b/artiq/master/worker_impl.py
@@ -284,9 +284,10 @@ def main():
     exp = None
     exp_inst = None
     repository_path = None
+    results_directory = None
 
     def write_results():
-        filename = "{:09}-{}.h5".format(rid, exp.__name__)
+        filename = "{}/{:09}-{}.h5".format(results_directory, rid, exp.__name__)
         with h5py.File(filename, "w") as f:
             dataset_mgr.write_hdf5(f)
             f["artiq_version"] = artiq_version
@@ -326,11 +327,10 @@ def main():
                 device_mgr.virtual_devices["scheduler"].set_run_info(
                     rid, obj["pipeline_name"], expid, obj["priority"])
                 start_local_time = time.localtime(start_time)
-                dirname = os.path.join("results",
+                results_directory = os.path.join("results",
                                    time.strftime("%Y-%m-%d", start_local_time),
                                    time.strftime("%H", start_local_time))
-                os.makedirs(dirname, exist_ok=True)
-                os.chdir(dirname)
+                os.makedirs(results_directory, exist_ok=True)
                 argument_mgr = ProcessArgumentManager(expid["arguments"])
                 exp_inst = exp((device_mgr, dataset_mgr, argument_mgr, {}))
                 argument_mgr.check_unprocessed_arguments()


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Use relative path on writing results instead of chdir.

### Related Issue

Closes #2021 

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

### Testing

Tested with the test case, described in #2021, and also via the dashboard. Also tested that results are being written to the same locations.

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
