### PR TITLE
alternative I2C io expander chip

### DIFF
--- a/artiq/firmware/libboard_misoc/io_expander.rs
+++ b/artiq/firmware/libboard_misoc/io_expander.rs
@@ -1,5 +1,14 @@
-use i2c;
 use csr;
+use i2c;
+
+// Only the bare minimum registers. Bits/IO connections equivalent between IC types.
+struct Registers {
+    // PCA9539 equivalent register names in comments
+    iodira: u8, // Configuration Port 0
+    iodirb: u8, // Configuration Port 1
+    gpioa: u8,  // Output Port 0
+    gpiob: u8,  // Output Port 1
+}
 
 pub struct IoExpander {
     busno: u8,
@@ -9,15 +18,17 @@ pub struct IoExpander {
     iodir: [u8; 2],
     out_current: [u8; 2],
     out_target: [u8; 2],
+    registers: Registers,
 }
 
 impl IoExpander {
     #[cfg(all(soc_platform = "kasli", hw_rev = "v2.0"))]
-    pub fn new(index: u8) -> Self {
+    pub fn new(index: u8) -> Result<Self, &'static str> {
         const VIRTUAL_LED_MAPPING0: [(u8, u8, u8); 2] = [(0, 0, 6), (1, 1, 6)];
         const VIRTUAL_LED_MAPPING1: [(u8, u8, u8); 2] = [(2, 0, 6), (3, 1, 6)];
+
         // Both expanders on SHARED I2C bus
-        match index {
+        let mut io_expander = match index {
             0 => IoExpander {
                 busno: 0,
                 port: 11,
@@ -26,6 +37,12 @@ impl IoExpander {
                 iodir: [0xff; 2],
                 out_current: [0; 2],
                 out_target: [0; 2],
+                registers: Registers {
+                    iodira: 0x00,
+                    iodirb: 0x01,
+                    gpioa: 0x12,
+                    gpiob: 0x13,
+                },
             },
             1 => IoExpander {
                 busno: 0,
@@ -35,9 +52,33 @@ impl IoExpander {
                 iodir: [0xff; 2],
                 out_current: [0; 2],
                 out_target: [0; 2],
+                registers: Registers {
+                    iodira: 0x00,
+                    iodirb: 0x01,
+                    gpioa: 0x12,
+                    gpiob: 0x13,
+                },
             },
-            _ => panic!("incorrect I/O expander index"),
+            _ => return Err("incorrect I/O expander index"),
+        };
+        if !io_expander.check_ack()? {
+            #[cfg(feature = "log")]
+            log::info!(
+                "MCP23017 io expander {} not found. Checking for PCA9539.",
+                index
+            );
+            io_expander.address += 0xa8; // translate to PCA9539 addresses (see schematic)
+            io_expander.registers = Registers {
+                iodira: 0x06,
+                iodirb: 0x07,
+                gpioa: 0x02,
+                gpiob: 0x03,
+            };
+            if !io_expander.check_ack()? {
+                return Err("Neither MCP23017 nor PCA9539 io expander found.");
+            };
         }
+        Ok(io_expander)
     }
 
     #[cfg(soc_platform = "kasli")]
@@ -57,9 +98,18 @@ impl IoExpander {
         Ok(())
     }
 
+    fn check_ack(&self) -> Result<bool, &'static str> {
+        // Check for ack from io expander
+        self.select()?;
+        i2c::start(self.busno)?;
+        let ack = i2c::write(self.busno, self.address)?;
+        i2c::stop(self.busno)?;
+        Ok(ack)
+    }
+
     fn update_iodir(&self) -> Result<(), &'static str> {
-        self.write(0x00, self.iodir[0])?;
-        self.write(0x01, self.iodir[1])?;
+        self.write(self.registers.iodira, self.iodir[0])?;
+        self.write(self.registers.iodirb, self.iodir[1])?;
         Ok(())
     }
 
@@ -72,9 +122,9 @@ impl IoExpander {
         self.update_iodir()?;
 
         self.out_current[0] = 0x00;
-        self.write(0x12, 0x00)?;
+        self.write(self.registers.gpioa, 0x00)?;
         self.out_current[1] = 0x00;
-        self.write(0x13, 0x00)?;
+        self.write(self.registers.gpiob, 0x00)?;
         Ok(())
     }
 
@@ -94,20 +144,18 @@ impl IoExpander {
 
     pub fn service(&mut self) -> Result<(), &'static str> {
         for (led, port, bit) in self.virtual_led_mapping.iter() {
-            let level = unsafe {
-                (csr::virtual_leds::status_read() >> led) & 1
-            };
+            let level = unsafe { (csr::virtual_leds::status_read() >> led) & 1 };
             self.set(*port, *bit, level != 0);
         }
 
         if self.out_target != self.out_current {
             self.select()?;
             if self.out_target[0] != self.out_current[0] {
-                self.write(0x12, self.out_target[0])?;
+                self.write(self.registers.gpioa, self.out_target[0])?;
                 self.out_current[0] = self.out_target[0];
             }
             if self.out_target[1] != self.out_current[1] {
-                self.write(0x13, self.out_target[1])?;
+                self.write(self.registers.gpiob, self.out_target[1])?;
                 self.out_current[1] = self.out_target[1];
             }
         }

--- a/artiq/firmware/runtime/main.rs
+++ b/artiq/firmware/runtime/main.rs
@@ -104,8 +104,8 @@ fn startup() {
     let (mut io_expander0, mut io_expander1);
     #[cfg(all(soc_platform = "kasli", hw_rev = "v2.0"))]
     {
-        io_expander0 = board_misoc::io_expander::IoExpander::new(0);
-        io_expander1 = board_misoc::io_expander::IoExpander::new(1);
+        io_expander0 = board_misoc::io_expander::IoExpander::new(0).unwrap();
+        io_expander1 = board_misoc::io_expander::IoExpander::new(1).unwrap();
         io_expander0.init().expect("I2C I/O expander #0 initialization failed");
         io_expander1.init().expect("I2C I/O expander #1 initialization failed");
 

--- a/artiq/firmware/satman/main.rs
+++ b/artiq/firmware/satman/main.rs
@@ -488,8 +488,8 @@ pub extern fn main() -> i32 {
     let (mut io_expander0, mut io_expander1);
     #[cfg(all(soc_platform = "kasli", hw_rev = "v2.0"))]
     {
-        io_expander0 = board_misoc::io_expander::IoExpander::new(0);
-        io_expander1 = board_misoc::io_expander::IoExpander::new(1);
+        io_expander0 = board_misoc::io_expander::IoExpander::new(0).unwrap();
+        io_expander1 = board_misoc::io_expander::IoExpander::new(1).unwrap();
         io_expander0.init().expect("I2C I/O expander #0 initialization failed");
         io_expander1.init().expect("I2C I/O expander #1 initialization failed");
         #[cfg(has_wrpll)]


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

This PR implements the minimal software for https://github.com/sinara-hw/Kasli/releases/tag/v2.0.2#:~:text=Added%20PCA9539%20as%20an%20alternative%20GPIO%20expander, an alternative I2C IO expander chip in Kasli V2.0.2. The SW first checks for an I2C ack from the usual MCP23017 chip and if it doesn't get it it checks for the PCA9539. The respective I2C addresses are in the schematic. 
The addresses of the IO direction and output values are different for the two chips so the codes translates those if it finds a PCA9539.
The bits/IOs of the two register banks should be equivalent according to schematic but I did not check each IO individually. But I see correct LEDs, SFP config, etc. so everything looks good.

## Type of Changes

| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.

Tested on both satellite and master systems for a Kasli V2.0.2 with PCA9593 and on a satellite system for a Kasli with MCP23017. I can't think of a reason why a master should be different. For testing 47581e0de9ec135a82a1448d8966111dc03545ee was used due to https://github.com/m-labs/artiq/issues/2028

### Licensing

Signed-off-by: Norman Krackow <nk@quartiq.com>
