### PR TITLE
Fix bug #2007

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import subprocess
+import platform
 
 VERSION_FILE = """
 def get_version():
@@ -11,14 +12,20 @@ def get_rev():
 """
 
 def get_version():
-    return os.getenv("VERSIONEER_OVERRIDE", default="8" + "." + \
-     subprocess.check_output(['git', 'rev-list', '--count', 'HEAD']).decode('ascii').strip() + "." + \
-     subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode('ascii').strip() + "." + \
-     "beta")
+    if platform.system() == 'Windows':
+        return os.getenv("VERSIONEER_OVERRIDE", default="8" + "." + \
+         subprocess.check_output(['git', 'rev-list', '--count', 'HEAD']).decode('ascii').strip() + "." + \
+         subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode('ascii').strip() + "." + \
+         "beta")
+    else:
+        return os.getenv("VERSIONEER_OVERRIDE", default="8.0.beta")
 
 def get_rev():
-    return os.getenv("VERSIONEER_REV", default= \
-     subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('ascii').strip())
+    if platform.system() == 'Windows':
+        return os.getenv("VERSIONEER_REV", default= \
+         subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('ascii').strip())
+    else:
+        return os.getenv("VERSIONEER_REV", default="unknown")
 
 def write_to_version_file(filename, version, rev):
     os.unlink(filename)

--- a/versioneer.py
+++ b/versioneer.py
@@ -1,6 +1,6 @@
 import os
 import sys
-
+import subprocess
 
 VERSION_FILE = """
 def get_version():
@@ -11,10 +11,14 @@ def get_rev():
 """
 
 def get_version():
-    return os.getenv("VERSIONEER_OVERRIDE", default="8.0.beta")
+    return os.getenv("VERSIONEER_OVERRIDE", default="8" + "." + \
+     subprocess.check_output(['git', 'rev-list', '--count', 'HEAD']).decode('ascii').strip() + "." + \
+     subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode('ascii').strip() + "." + \
+     "beta")
 
 def get_rev():
-    return os.getenv("VERSIONEER_REV", default="unknown")
+    return os.getenv("VERSIONEER_REV", default= \
+     subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('ascii').strip())
 
 def write_to_version_file(filename, version, rev):
     os.unlink(filename)


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
versioneer.py can return git version and rev in msys 

### Related Issue
#2007

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [ ] Close/update issues.
- [ ] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [ ] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [ ] Add and check docstrings and comments
- [ ] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)
