### PR TITLE
SUServo Experimentals: fix after RTIO channel name changes

### DIFF
--- a/experimental-features/suservo_coherent.diff
+++ b/experimental-features/suservo_coherent.diff
@@ -104,15 +104,15 @@ index 1d0a72dad1..f7b516a4e7 100644
      :param core_device: Core device name
      """
      kernel_invariants = {"channel", "core", "pgia", "cplds", "ddses",
--                         "ref_period_mu"}
+-                         "ref_period_mu", "corrected_fs"}
 +                         "ref_period_mu", "num_channels", "coeff_sel",
 +                         "state_sel", "io_dly_addr", "config_addr",
-+                         "write_enable"}
++                         "corrected_fs", "write_enable"}
  
      def __init__(self, dmgr, channel, pgia_device,
                   cpld_devices, dds_devices,
-@@ -83,9 +85,20 @@ def __init__(self, dmgr, channel, pgia_device,
-             self.core.coarse_ref_period)
+@@ -83,13 +85,24 @@ def __init__(self, dmgr, channel, pgia_device,
+         self.corrected_fs = sampler.Sampler.use_corrected_fs(sampler_hw_rev)
          assert self.ref_period_mu == self.core.ref_multiplier
  
 +        # The width of parts of the servo memory address depends on the number
@@ -126,6 +126,10 @@ index 1d0a72dad1..f7b516a4e7 100644
 +        self.coeff_sel = 1 << coeff_depth
 +        self.write_enable = 1 << (coeff_depth + 1)
 +
+     @staticmethod
+     def get_rtio_channels(channel, **kwargs):
+         return [(channel, None)]
+
      @kernel
      def init(self):
 -        """Initialize the servo, Sampler and both Urukuls.
@@ -191,9 +195,9 @@ index 1d0a72dad1..f7b516a4e7 100644
  
      @kernel
      def set_pgia_mu(self, channel, gain):
-@@ -236,6 +262,18 @@ def get_adc(self, channel):
+@@ -242,6 +268,18 @@ def get_adc(self, channel):
          gain = (self.gains >> (channel*2)) & 0b11
-         return adc_mu_to_volts(val, gain)
+         return adc_mu_to_volts(val, gain, self.corrected_fs)
  
 +    @kernel
 +    def set_io_update_delays(self, dlys):
@@ -211,7 +215,7 @@ index 1d0a72dad1..f7b516a4e7 100644
  class Channel:
      """Sampler-Urukul Servo channel
 @@ -256,7 +294,7 @@ def __init__(self, dmgr, channel, servo_device):
-         self.dds = self.servo.ddses[self.servo_channel // 4]
+         return [(channel, None)]
  
      @kernel
 -    def set(self, en_out, en_iir=0, profile=0):

--- a/experimental-features/suservo_coherent_after_var.diff
+++ b/experimental-features/suservo_coherent_after_var.diff
@@ -80,9 +80,9 @@ index a89cdcca..f7b516a4 100644
      """
      kernel_invariants = {"channel", "core", "pgia", "cplds", "ddses",
                           "ref_period_mu", "num_channels", "coeff_sel",
--                         "state_sel", "config_addr", "write_enable"}
+-                         "corrected_fs", "state_sel", "config_addr", "write_enable"}
 +                         "state_sel", "io_dly_addr", "config_addr",
-+                         "write_enable"}
++                         "corrected_fs", "write_enable"}
  
      def __init__(self, dmgr, channel, pgia_device,
                   cpld_devices, dds_devices,
@@ -117,7 +117,7 @@ index a89cdcca..f7b516a4 100644
          """Write to servo memory.
 @@ -245,6 +262,18 @@ class SUServo:
          gain = (self.gains >> (channel*2)) & 0b11
-         return adc_mu_to_volts(val, gain)
+         return adc_mu_to_volts(val, gain, self.corrected_fs)
  
 +    @kernel
 +    def set_io_update_delays(self, dlys):
@@ -135,7 +135,7 @@ index a89cdcca..f7b516a4 100644
  class Channel:
      """Sampler-Urukul Servo channel
 @@ -265,7 +294,7 @@ class Channel:
-         self.dds = self.servo.ddses[self.servo_channel // 4]
+         return [(channel, None)]
  
      @kernel
 -    def set(self, en_out, en_iir=0, profile=0):

--- a/experimental-features/suservo_var_urukul.diff
+++ b/experimental-features/suservo_var_urukul.diff
@@ -48,14 +48,14 @@ index 1d0a72dad..a89cdcca4 100644
      :param core_device: Core device name
      """
      kernel_invariants = {"channel", "core", "pgia", "cplds", "ddses",
--                         "ref_period_mu"}
+-                         "ref_period_mu", "corrected_fs"}
 +                         "ref_period_mu", "num_channels", "coeff_sel",
-+                         "state_sel", "config_addr", "write_enable"}
++                         "corrected_fs", "state_sel", "config_addr", "write_enable"}
  
      def __init__(self, dmgr, channel, pgia_device,
                   cpld_devices, dds_devices,
-@@ -83,9 +81,19 @@ def __init__(self, dmgr, channel, pgia_device,
-             self.core.coarse_ref_period)
+@@ -83,13 +81,23 @@ def __init__(self, dmgr, channel, pgia_device,
+         self.corrected_fs = sampler.Sampler.use_corrected_fs(sampler_hw_rev)
          assert self.ref_period_mu == self.core.ref_multiplier
  
 +        # The width of parts of the servo memory address depends on the number
@@ -68,6 +68,10 @@ index 1d0a72dad..a89cdcca4 100644
 +        self.coeff_sel = 1 << coeff_depth
 +        self.write_enable = 1 << (coeff_depth + 1)
 +
+     @staticmethod
+     def get_rtio_channels(channel, **kwargs):
+         return [(channel, None)]
+
      @kernel
      def init(self):
 -        """Initialize the servo, Sampler and both Urukuls.


### PR DESCRIPTION

# ARTIQ Pull Request

## Description of Changes

Quick fix for experimental features - applying the patches has been broken after RTIO channel name was included, and voltage reference was fixed.

Untested beyond applying the patches, but the main code was not changed at all.

Basis for variable Urukul support in JSON that will be coming later.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
