### PR TITLE
Fix gateware sim tests

### DIFF
--- a/artiq/gateware/drtio/core.py
+++ b/artiq/gateware/drtio/core.py
@@ -77,7 +77,7 @@ class DRTIOSatellite(Module):
         self.reset = CSRStorage(reset=1)
         self.reset_phy = CSRStorage(reset=1)
         self.tsc_loaded = CSR()
-        # master interface in the rtio domain
+        # master interface in the sys domain
         self.cri = cri.Interface()
         self.async_errors = Record(async_errors_layout)
 

--- a/artiq/gateware/test/drtio/test_full_stack.py
+++ b/artiq/gateware/test/drtio/test_full_stack.py
@@ -303,7 +303,7 @@ class TestFullStack(unittest.TestCase):
                 yield
             yield dut.master.rt_packet.echo_stb.eq(0)
 
-            for i in range(15):
+            for i in range(17):
                 yield
 
             self.assertEqual((yield dut.master.rt_packet.packet_cnt_tx), 1)

--- a/artiq/gateware/test/drtio/test_full_stack.py
+++ b/artiq/gateware/test/drtio/test_full_stack.py
@@ -227,16 +227,16 @@ class TestFullStack(unittest.TestCase):
             errors = yield from saterr.protocol_error.read()
             self.assertEqual(errors, 0)
             yield from csrs.underflow_margin.write(0)
-            tb.delay(100)
+            tb.delay(80)
             yield from tb.write(42, 1)
-            for i in range(12):
+            for i in range(21):
                yield
             errors = yield from saterr.protocol_error.read()
             underflow_channel = yield from saterr.underflow_channel.read()
             underflow_timestamp_event = yield from saterr.underflow_timestamp_event.read()
             self.assertEqual(errors, 8)  # write underflow
             self.assertEqual(underflow_channel, 42)
-            self.assertEqual(underflow_timestamp_event, 100)
+            self.assertEqual(underflow_timestamp_event, 80)
             yield from saterr.protocol_error.write(errors)
             yield
             errors = yield from saterr.protocol_error.read()

--- a/artiq/gateware/test/drtio/test_full_stack.py
+++ b/artiq/gateware/test/drtio/test_full_stack.py
@@ -169,7 +169,7 @@ class TestFullStack(unittest.TestCase):
             yield from tb.sync()
 
         run_simulation(tb.dut,
-            {"sys": test()}, self.clocks)
+            {"sys": [test(), tb.check_ttls(ttl_changes)]}, self.clocks)
         self.assertEqual(ttl_changes, correct_ttl_changes)
 
     def test_underflow(self):
@@ -214,7 +214,7 @@ class TestFullStack(unittest.TestCase):
             yield from tb.sync()
 
         run_simulation(tb.dut,
-            {"sys": test()}, self.clocks)
+            {"sys": [test(), tb.check_ttls(ttl_changes)]}, self.clocks)
         self.assertEqual(ttl_changes, correct_ttl_changes)
 
     def test_write_underflow(self):
@@ -284,7 +284,7 @@ class TestFullStack(unittest.TestCase):
             yield dut.phy2.rtlink.i.stb.eq(0)
 
         run_simulation(dut,
-            {"sys": test()}, self.clocks)
+            {"sys": [test(), generate_input()]}, self.clocks)
 
     def test_echo(self):
         dut = DUT(2)

--- a/artiq/gateware/test/rtio/test_dma.py
+++ b/artiq/gateware/test/rtio/test_dma.py
@@ -203,11 +203,11 @@ class TestDMA(unittest.TestCase):
         run_simulation(tb[32], {"sys": [
             do_dma(tb[32].dut, 0), monitor(32),
             (None for _ in range(70)),
-        ]}, {"sys": 8, "sys": 8, "rio": 8, "rio_phy": 8})
+        ]}, {"sys": 8, "rio": 8, "rio_phy": 8})
         run_simulation(tb[64], {"sys": [
             do_dma(tb[64].dut, 0), monitor(64),
             (None for _ in range(70)),
-        ]}, {"sys": 8, "sys": 8, "rio": 8, "rio_phy": 8})
+        ]}, {"sys": 8, "rio": 8, "rio_phy": 8})
 
         correct_changes = [(timestamp + 11, channel)
                            for channel, timestamp, _, _ in test_writes_full_stack]


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Timing has changed with different clocks, so the tests themselves had to be adjusted as well.

```
[spaqin@hera:~/m-labs/artiq]$ python -m unittest discover -v artiq.gateware.test
test_aux_controller (artiq.gateware.test.drtio.test_aux_controller.TestAuxController) ... ok
test_cross_domain_notification (artiq.gateware.test.drtio.test_cdc.TestCDC) ... ok
test_cross_domain_request (artiq.gateware.test.drtio.test_cdc.TestCDC) ... ok
test_buffer_space (artiq.gateware.test.drtio.test_full_stack.TestFullStack) ... ok
test_echo (artiq.gateware.test.drtio.test_full_stack.TestFullStack) ... ok
test_inputs (artiq.gateware.test.drtio.test_full_stack.TestFullStack) ... ok
test_large_data (artiq.gateware.test.drtio.test_full_stack.TestFullStack) ... ok
test_pulses (artiq.gateware.test.drtio.test_full_stack.TestFullStack) ... ok
test_underflow (artiq.gateware.test.drtio.test_full_stack.TestFullStack) ... ok
test_write_underflow (artiq.gateware.test.drtio.test_full_stack.TestFullStack) ... ok
test_packets (artiq.gateware.test.drtio.test_link_layer.TestLinkLayer) ... ok
test_buffer_space (artiq.gateware.test.drtio.test_rt_packet_repeater.TestRepeater) ... ok
test_input (artiq.gateware.test.drtio.test_rt_packet_repeater.TestRepeater) ... ok
test_output (artiq.gateware.test.drtio.test_rt_packet_repeater.TestRepeater) ... ok
test_set_time (artiq.gateware.test.drtio.test_rt_packet_repeater.TestRepeater) ... ok
test_echo (artiq.gateware.test.drtio.test_rt_packet_satellite.TestSatellite) ... ok
test_set_time (artiq.gateware.test.drtio.test_rt_packet_satellite.TestSatellite) ... ok
test_inputs (artiq.gateware.test.drtio.test_switching.TestSwitching) ... ok
test_outputs (artiq.gateware.test.drtio.test_switching.TestSwitching) ... ok
test_dma_noerror (artiq.gateware.test.rtio.test_dma.TestDMA) ... ok
test_full_stack (artiq.gateware.test.rtio.test_dma.TestDMA) ... ok
test_init (artiq.gateware.test.rtio.test_edge_counter.TestEdgeCounter) ... ok
test_reset (artiq.gateware.test.rtio.test_edge_counter.TestEdgeCounter) ... ok
test_saturation (artiq.gateware.test.rtio.test_edge_counter.TestEdgeCounter) ... ok
test_sensitivity (artiq.gateware.test.rtio.test_edge_counter.TestEdgeCounter) ... ok
test_frame (artiq.gateware.test.rtio.test_fastlink.TestFastino) ... ok
test_init (artiq.gateware.test.rtio.test_fastlink.TestFastino) ... ok
test_frame (artiq.gateware.test.rtio.test_fastlink.TestPhaser) ... ok
test_init (artiq.gateware.test.rtio.test_fastlink.TestPhaser) ... ok
test_get_data (artiq.gateware.test.rtio.test_input_collector.TestInput) ... ok
test_overflow (artiq.gateware.test.rtio.test_input_collector.TestInput) ... ok
test_timeout (artiq.gateware.test.rtio.test_input_collector.TestInput) ... ok
test_lane_switch (artiq.gateware.test.rtio.test_sed_lane_distributor.TestLaneDistributor) ... ok
test_lane_switch_lc (artiq.gateware.test.rtio.test_sed_lane_distributor.TestLaneDistributor) ... ok
test_regular (artiq.gateware.test.rtio.test_sed_lane_distributor.TestLaneDistributor) ... ok
test_regular_lc (artiq.gateware.test.rtio.test_sed_lane_distributor.TestLaneDistributor) ... ok
test_sequence_error (artiq.gateware.test.rtio.test_sed_lane_distributor.TestLaneDistributor) ... ok
test_spread (artiq.gateware.test.rtio.test_sed_lane_distributor.TestLaneDistributor) ... ok
test_underflow (artiq.gateware.test.rtio.test_sed_lane_distributor.TestLaneDistributor) ... ok
test_underflow_lc (artiq.gateware.test.rtio.test_sed_lane_distributor.TestLaneDistributor) ... ok
test_wait_time (artiq.gateware.test.rtio.test_sed_lane_distributor.TestLaneDistributor) ... ok
test_busy (artiq.gateware.test.rtio.test_sed_output_driver.TestOutputNetwork) ... ok
test_collision (artiq.gateware.test.rtio.test_sed_output_driver.TestOutputNetwork) ... ok
test_one_ttl (artiq.gateware.test.rtio.test_sed_output_driver.TestOutputNetwork) ... ok
test_replace (artiq.gateware.test.rtio.test_sed_output_driver.TestOutputNetwork) ... ok
test_simultaneous_ttl (artiq.gateware.test.rtio.test_sed_output_driver.TestOutputNetwork) ... ok
test_no_replace (artiq.gateware.test.rtio.test_sed_output_network.TestOutputNetwork) ... ok
test_replace (artiq.gateware.test.rtio.test_sed_output_network.TestOutputNetwork) ... ok
test_replace (artiq.gateware.test.rtio.test_sed_top.TestSED) ... ok
test_replace_rollover (artiq.gateware.test.rtio.test_sed_top.TestSED) ... ok
test_sed (artiq.gateware.test.rtio.test_sed_top.TestSED) ... ok
test_input (artiq.gateware.test.rtio.test_ttl_serdes.TestTTLSerdes) ... ok
test_output (artiq.gateware.test.rtio.test_ttl_serdes.TestTTLSerdes) ... ok
test_run (artiq.gateware.test.suservo.test_adc.ADCTest) ... ok
test_run (artiq.gateware.test.suservo.test_dds.DDSTest) ... ok
test_run (artiq.gateware.test.suservo.test_iir.IIRTest) ... ok
test_run (artiq.gateware.test.suservo.test_servo.ServoTest) ... ok

----------------------------------------------------------------------
Ran 57 tests in 77.567s

OK
```

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```