### PR TITLE
doc: Add jsonschema to nix package list

### DIFF
--- a/doc/manual/installing.rst
+++ b/doc/manual/installing.rst
@@ -51,6 +51,7 @@ Installing multiple packages and making them visible to the ARTIQ commands requi
               #ps.scipy
               #ps.numba
               #ps.matplotlib
+              #ps.jsonschema # required by artiq_ddb_template
               # or if you need Qt (will recompile):
               #(ps.matplotlib.override { enableQt = true; })
               #ps.bokeh


### PR DESCRIPTION
# Add jsonschema to nix package list

## Description of Changes

Add jsonschema to the nix package list in the manual (section: installation) as it is required by artiq_ddb_template.

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :scroll: Docs |

### All Pull Requests

- [x] Use correct spelling and grammar.

### Documentation Changes

- [x] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
