### PR TITLE
rtio core: fix minimum_coarse_timestamp

### DIFF
--- a/artiq/gateware/rtio/core.py
+++ b/artiq/gateware/rtio/core.py
@@ -66,7 +66,7 @@ class Core(Module, AutoCSR):
             interface=self.cri)
         self.submodules += outputs
         self.comb += outputs.coarse_timestamp.eq(tsc.coarse_ts)
-        self.sync += outputs.minimum_coarse_timestamp.eq(tsc.coarse_ts + 16)
+        self.sync += outputs.minimum_coarse_timestamp.eq(tsc.coarse_ts + 12)
 
         inputs = InputCollector(tsc, channels,
             quash_channels=quash_channels,


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

As I mentioned in the artiq-zynq issue linked below, ``coarse_ts_sys`` was removed in favor of keeping just ``coarse_ts`` [here](https://github.com/m-labs/artiq/commit/ad000609ced68ab84457265bd5b12b28429cf0a4#diff-5e06a98d471b8294533a49a8a654b41349ff57e21557a0cb21e5a66d554eec15L69). 
They were basically equal values, with the difference being the clock domain they operated on - ``coarse_ts_sys`` was just ``coarse_ts`` with clock domain transfer. At least in simulation, the transfer took 4 cycles, so at any point ``coarse_ts_sys`` would be equal to ``coarse_ts - 4``.

And RTIO core before set ``SED.minimum_coarse_timestamp`` to ``coarse_ts_sys + 16``, that got replaced with just ``coarse_ts + 16``, without adjustment to the value.

That had a minor consequence of zynq DMA test not fitting within minimum_coarse_timestamp. With this PR the previous behavior is restored and that test passes again. Possibly it would also fix some other, uncaught yet underflow errors.

I ran the gateware sim tests from ARTIQ and nothing is broken by this change.

### Related Issue

Fixes DMA test on [artiq-zynq#222](https://git.m-labs.hk/M-Labs/artiq-zynq/issues/222)

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
