### PR TITLE
worker_impl: Remove misleading update() from ExamineDatasetMgr [nfc]

### DIFF
--- a/artiq/master/worker_impl.py
+++ b/artiq/master/worker_impl.py
@@ -186,10 +186,6 @@ class ExamineDatasetMgr:
     def get(key, archive=False):
         return ParentDatasetDB.get(key)
 
-    @staticmethod
-    def update(self, mod):
-        pass
-
 
 def examine(device_mgr, dataset_mgr, file):
     previous_keys = set(sys.modules.keys())


### PR DESCRIPTION
`update(mod)` would be on the DatasetDB, not the manager. Rather,
modifications currently just fail due to e.g. `set(…)` not being
defined.
