### PR TITLE
Add external 80 MHz reference using PLL, 125 MHz output

### DIFF
--- a/artiq/firmware/runtime/rtio_clocking.rs
+++ b/artiq/firmware/runtime/rtio_clocking.rs
@@ -10,6 +10,7 @@ pub enum RtioClock {
     Int_100,
     Ext0_Bypass,
     Ext0_Synth0_10to125,
+    Ext0_Synth0_80to125,
     Ext0_Synth0_100to125,
     Ext0_Synth0_125to125,
 }
@@ -24,6 +25,7 @@ fn get_rtio_clock_cfg() -> RtioClock {
             Ok("ext0_bypass_125") => RtioClock::Ext0_Bypass,
             Ok("ext0_bypass_100") => RtioClock::Ext0_Bypass,
             Ok("ext0_synth0_10to125") => RtioClock::Ext0_Synth0_10to125,
+            Ok("ext0_synth0_80to125") => RtioClock::Ext0_Synth0_80to125,
             Ok("ext0_synth0_100to125") => RtioClock::Ext0_Synth0_100to125,
             Ok("ext0_synth0_125to125") => RtioClock::Ext0_Synth0_125to125,
             Ok("i") => {
@@ -44,6 +46,8 @@ fn get_rtio_clock_cfg() -> RtioClock {
             warn!("si5324_ext_ref and ext_ref_frequency compile-time options are deprecated. Please use the rtio_clock coreconfig settings instead.");
             #[cfg(all(rtio_frequency = "125.0", si5324_ext_ref, ext_ref_frequency = "10.0"))]
             return RtioClock::Ext0_Synth0_10to125;
+            #[cfg(all(rtio_frequency = "125.0", si5324_ext_ref, ext_ref_frequency = "80.0"))]
+            return RtioClock::Ext0_Synth0_80to125;
             #[cfg(all(rtio_frequency = "125.0", si5324_ext_ref, ext_ref_frequency = "100.0"))]
             return RtioClock::Ext0_Synth0_100to125;
             #[cfg(all(rtio_frequency = "125.0", si5324_ext_ref, ext_ref_frequency = "125.0"))]
@@ -104,6 +108,22 @@ fn setup_si5324_pll(cfg: RtioClock) {
                     n2_ls  : 300,
                     n31    : 6,
                     n32    : 6,
+                    bwsel  : 4,
+                    crystal_as_ckin2: false
+                },
+                SI5324_EXT_INPUT
+            )
+        },
+        RtioClock::Ext0_Synth0_80to125 => { // 125 MHz output from 80 MHz CLKINx reference, 611 Hz BW
+        info!("using 80MHz reference to make 125MHz RTIO clock with PLL");
+            (
+                si5324::FrequencySettings {
+                    n1_hs  : 4,
+                    nc1_ls : 10,
+                    n2_hs  : 10,
+                    n2_ls  : 250,
+                    n31    : 40,
+                    n32    : 40,
                     bwsel  : 4,
                     crystal_as_ckin2: false
                 },

--- a/doc/manual/core_device.rst
+++ b/doc/manual/core_device.rst
@@ -175,6 +175,7 @@ KC705 in DRTIO variants and Kasli generates the RTIO clock using a PLL locked ei
     * ``int_100`` - internal crystal oscillator using PLL, 100 MHz output,
     * ``int_150`` - internal crystal oscillator using PLL, 150 MHz output,
     * ``ext0_synth0_10to125`` - external 10 MHz reference using PLL, 125 MHz output,
+    * ``ext0_synth0_80to125`` - external 80 MHz reference using PLL, 125 MHz output,
     * ``ext0_synth0_100to125`` - external 100 MHz reference using PLL, 125 MHz output,
     * ``ext0_synth0_125to125`` - external 125 MHz reference using PLL, 125 MHz output,
     * ``ext0_bypass``, ``ext0_bypass_125``, ``ext0_bypass_100`` - external clock - with explicit aliases available.

--- a/doc/manual/installing.rst
+++ b/doc/manual/installing.rst
@@ -343,8 +343,9 @@ The KC705 may use either an external clock signal, or its internal clock with ex
 
 Other options include:
   - ``ext0_synth0_10to125`` - external 10MHz reference clock used by Si5324 to synthesize a 125MHz RTIO clock,
-  - ``ext0_synth0_100to125`` - exteral 100MHz reference clock used by Si5324 to synthesize a 125MHz RTIO clock,
-  - ``ext0_synth0_125to125`` - exteral 125MHz reference clock used by Si5324 to synthesize a 125MHz RTIO clock,
+  - ``ext0_synth0_80to125`` - external 80MHz reference clock used by Si5324 to synthesize a 125MHz RTIO clock,
+  - ``ext0_synth0_100to125`` - external 100MHz reference clock used by Si5324 to synthesize a 125MHz RTIO clock,
+  - ``ext0_synth0_125to125`` - external 125MHz reference clock used by Si5324 to synthesize a 125MHz RTIO clock,
   - ``int_100`` - internal crystal reference is used by Si5324 to synthesize a 100MHz RTIO clock,
   - ``int_150`` - internal crystal reference is used by Si5324 to synthesize a 150MHz RTIO clock.
   - ``ext0_bypass_125`` and ``ext0_bypass_100`` - explicit aliases for ``ext0_bypass``.


### PR DESCRIPTION
# ARTIQ Pull Request

Needs to be backported to the release-7 branch

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps

DSPLLsim output:

```
Si5324 Frequency Plan

CKIN Frequencies (MHz)
  CKIN1: 80.000000

fosc: 5.000000 GHz

Output Clock Multiplication Ratios 
  CKOUT1 to CKIN1: 25 / 16

CKOUT Frequencies (MHz)
  CKOUT1: 125.000000

PLL Divider Settings
(Note: These are not binary register values.)
  N1_HS: 4
  NC1_LS: 10

  N2_HS: 10
  N2_LS: 250

  N31: 40

f3: 2.000000 MHz

Available Loop Bandwidths using BWSEL (Hz)
  9 (BWSEL_REG = 10)
  18 (BWSEL_REG = 9)
  36 (BWSEL_REG = 8)
  72 (BWSEL_REG = 7)
  145 (BWSEL_REG = 6)
  295 (BWSEL_REG = 5)
  611 (BWSEL_REG = 4)

Input Frequency Operating Range (MHz)
   CKIN1 Min: 77.600000  Max: 80.000000

Output Frequency Operating Range (MHz)
   CKOUT1 Min: 121.250000  Max: 125.000000

Phase Offset Resolution for Independent Skew: 0.8000 ns
```


### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
