### PR TITLE
Satellite: re-enable PMP, alternative L2 cache flush

### DIFF
--- a/artiq/firmware/satman/dma.rs
+++ b/artiq/firmware/satman/dma.rs
@@ -1,5 +1,6 @@
-use board_misoc::{csr, cache::flush_l2_cache};
+use board_misoc::csr;
 use alloc::{vec::Vec, collections::btree_map::BTreeMap};
+use flush_l2_cache_satman;
 
 const ALIGNMENT: usize = 64;
 
@@ -92,7 +93,7 @@ impl Manager {
             }
             entry.complete = true;
             entry.padding_len = padding;
-            flush_l2_cache();
+            flush_l2_cache_satman();
         }
         Ok(())
     }


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

The stack guard panic had a simple cause: the satman firmware is smaller than L2 cache, so the L2 flush function - that just reads data from the beginning of main RAM, to twice the size of L2 - would try to read from the stack guard:
```
&_sstack_guard: 0x4003a000
l2_size: 0x20000
main_ram + 2*l2: 0x40040000
```
So obviously that attempt would lead to a panic at exactly stack guard address:
```
panic at satman/main.rs:665:13: exception Exception(LoadFault) at PC 0x4000073c, trap value 0x4003a000
```

In satman then there's a need for an alternative L2 flushing function - in which the stack guard would be skipped - so it's reading from the beginning of the heap, instead.

Tested with Kasli 1.1.

### Related Issue

Closes #2067 

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
