### PR TITLE
Fix ADF3536 having RTIO channel names

### DIFF
--- a/artiq/coredevice/adf5356.py
+++ b/artiq/coredevice/adf5356.py
@@ -74,8 +74,8 @@ class ADF5356:
         self._init_registers()
 
     @staticmethod
-    def get_rtio_channels(channel, **kwargs):
-        return [(channel, None)]
+    def get_rtio_channels(**kwargs):
+        return []
 
     @kernel
     def init(self, blind=False):


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
The channel in this device refers to a channel on the mirny, not an RTIO channel. Without this patch we generate a device map containing mirny channels (in the range 0..4) as well as RTIO channels.

Tested by generating a new device map and flashing it to a Kasli 2.0.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)
### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
