### PR TITLE
rtio: SED, InputCollector use rio clock domain

### DIFF
--- a/artiq/gateware/rtio/core.py
+++ b/artiq/gateware/rtio/core.py
@@ -60,17 +60,17 @@ class Core(Module, AutoCSR):
         # Outputs/Inputs
         quash_channels = [n for n, c in enumerate(channels) if isinstance(c, LogChannel)]
 
-        outputs = SED(channels, tsc.glbl_fine_ts_width,
+        outputs = ClockDomainsRenamer("rio")(SED(channels, tsc.glbl_fine_ts_width,
             quash_channels=quash_channels,
             lane_count=lane_count, fifo_depth=fifo_depth,
-            interface=self.cri)
+            interface=self.cri))
         self.submodules += outputs
         self.comb += outputs.coarse_timestamp.eq(tsc.coarse_ts)
         self.sync += outputs.minimum_coarse_timestamp.eq(tsc.coarse_ts + 12)
 
-        inputs = InputCollector(tsc, channels,
+        inputs = ClockDomainsRenamer("rio")(InputCollector(tsc, channels,
             quash_channels=quash_channels,
-            interface=self.cri)
+            interface=self.cri))
         self.submodules += inputs
 
         # Asychronous output errors


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Before the clock merge, different components in ``SED`` and ``InputCollector`` used ``rio`` and ``rsys`` clock domains; after the clock merge they got put into the ``sys`` domain instead. While RTIO was working seemingly fine with that, the state of these components would not reset after ``core.reset()``. 
This PR simply wraps them to use ``rio`` - it does not have to be as complex as before because ``rsys`` domain does not exist anymore; and restores the reset functionality.

Tested on a Kasli 2.0 with experiment from #2083; also ran full HITL on kc705 to make sure nothing else is broken.

### Related Issue

Closes #2083 

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
