### PR TITLE
Fix mismatched signatures for the wide interface

### DIFF
--- a/artiq/firmware/ksupport/lib.rs
+++ b/artiq/firmware/ksupport/lib.rs
@@ -343,7 +343,7 @@ extern fn dma_record_output(target: i32, word: i32) {
 }
 
 #[unwind(aborts)]
-extern fn dma_record_output_wide(target: i32, words: CSlice<i32>) {
+extern fn dma_record_output_wide(target: i32, words: &CSlice<i32>) {
     assert!(words.len() <= 16); // enforce the hardware limit
 
     unsafe {

--- a/artiq/firmware/ksupport/rtio.rs
+++ b/artiq/firmware/ksupport/rtio.rs
@@ -89,7 +89,7 @@ mod imp {
         }
     }
 
-    pub extern fn output_wide(target: i32, data: CSlice<i32>) {
+    pub extern fn output_wide(target: i32, data: &CSlice<i32>) {
         unsafe {
             csr::rtio::target_write(target as u32);
             // writing target clears o_data
@@ -235,7 +235,7 @@ mod imp {
         unimplemented!("not(has_rtio)")
     }
 
-    pub extern fn output_wide(_target: i32, _data: CSlice<i32>) {
+    pub extern fn output_wide(_target: i32, _data: &CSlice<i32>) {
         unimplemented!("not(has_rtio)")
     }
 


### PR DESCRIPTION
Lists are passed by-reference from python code, and so should be &CSlice<_> not CSlice<_>.

<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
Lists are passed by-reference from python code, and so should be `&CSlice<_>` not `CSlice<_>`. This change was made for the cache already in af263ffe1fa5fcc94e4a55a068ce525de720724e, but not for the wide interface.

This is largely identical to [artiq-zynq#229](https://git.m-labs.hk/M-Labs/artiq-zynq/pulls/229).
## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.

I have configured a Kasli 2.0 with a single Fastino attached (with `log2_width=5`). Previously a simple call to `fastino.set_group_mu` would panic. As of this patch it no longer does, and inspecting the analyser shows it is generating the correct RTIO events.

I have not verified that the correct waveforms are generated, as I do not have easy access to a scope right now.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [ ] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
