### PR TITLE
Distributed Analyzer

### DIFF
--- a/artiq/firmware/Cargo.lock
+++ b/artiq/firmware/Cargo.lock
@@ -352,6 +352,7 @@ dependencies = [
  "board_misoc",
  "build_misoc",
  "log",
+ "proto_artiq",
  "riscv",
 ]
 

--- a/artiq/firmware/libproto_artiq/drtioaux_proto.rs
+++ b/artiq/firmware/libproto_artiq/drtioaux_proto.rs
@@ -14,8 +14,8 @@ impl<T> From<IoError<T>> for Error<T> {
     }
 }
 
-/* 512 (max size) - 4 (CRC) - 1 (packet ID) - 1 (destination) - 4 (trace ID) - 1 (last) - 2 (length) */
-pub const DMA_TRACE_MAX_SIZE: usize = 499;
+pub const DMA_TRACE_MAX_SIZE: usize = /*max size*/512 - /*CRC*/4 - /*packet ID*/1 - /*trace ID*/4 - /*last*/1 -/*length*/2;
+pub const ANALYZER_MAX_SIZE: usize  = /*max size*/512 - /*CRC*/4 - /*packet ID*/1 - /*last*/1 - /*length*/2;
 
 #[derive(PartialEq, Debug)]
 pub enum Packet {
@@ -58,6 +58,9 @@ pub enum Packet {
     SpiReadReply { succeeded: bool, data: u32 },
     SpiBasicReply { succeeded: bool },
 
+    AnalyzerRequest { destination: u8 },
+    AnalyzerData { last: bool, length: u16, data: [u8; ANALYZER_MAX_SIZE]},
+
     DmaAddTraceRequest { destination: u8, id: u32, last: bool, length: u16, trace: [u8; DMA_TRACE_MAX_SIZE] },
     DmaAddTraceReply { succeeded: bool },
     DmaRemoveTraceRequest { destination: u8, id: u32 },
@@ -65,7 +68,6 @@ pub enum Packet {
     DmaPlaybackRequest { destination: u8, id: u32, timestamp: u64 },
     DmaPlaybackReply { succeeded: bool },
     DmaPlaybackStatus { destination: u8, id: u32, error: u8, channel: u32, timestamp: u64 }
-
 }
 
 impl Packet {
@@ -196,6 +198,22 @@ impl Packet {
             0x95 => Packet::SpiBasicReply {
                 succeeded: reader.read_bool()?
             },
+
+            0xa0 => Packet::AnalyzerRequest {
+                destination: reader.read_u8()?
+            },
+
+            0xa1 => {
+                let last = reader.read_bool()?;
+                let length = reader.read_u16()?;
+                let mut data: [u8; ANALYZER_MAX_SIZE] = [0; ANALYZER_MAX_SIZE];
+                reader.read_exact(&mut trace[0..length as usize])?;
+                Packet::AnalyzerData {
+                    last: last,
+                    length: length,
+                    data: data
+                }
+            }
 
             0xb0 => { 
                 let destination = reader.read_u8()?;
@@ -395,6 +413,17 @@ impl Packet {
             Packet::SpiBasicReply { succeeded } => {
                 writer.write_u8(0x95)?;
                 writer.write_bool(succeeded)?;
+            },
+
+            Packet::AnalyzerRequest { destination } => {
+                writer.write_u8(0xa0)?;
+                writer.write_u8(destination)?;
+            },
+            Packet::AnalyzerData { last, length, data } => {
+                writer.write_u8(0xa1)?;
+                writer.write_bool(last)?;
+                writer.write_u16(length)?;
+                writer.write_all(&data[0..length as usize])?;
             },
 
             Packet::DmaAddTraceRequest { destination, id, last, trace, length } => {

--- a/artiq/firmware/runtime/analyzer.rs
+++ b/artiq/firmware/runtime/analyzer.rs
@@ -1,7 +1,11 @@
 use io::{Write, Error as IoError};
 use board_misoc::{csr, cache};
-use sched::{Io, TcpListener, TcpStream, Error as SchedError};
+use sched::{Io, Mutex, TcpListener, TcpStream, Error as SchedError};
 use analyzer_proto::*;
+use alloc::vec::Vec;
+use urc::Urc;
+use board_artiq::drtio_routing;
+use core::cell::RefCell;
 
 const BUFFER_SIZE: usize = 512 * 1024;
 
@@ -35,17 +39,78 @@ fn disarm() {
     }
 }
 
-fn worker(stream: &mut TcpStream) -> Result<(), IoError<SchedError>> {
-    let data = unsafe { &BUFFER.data[..] };
-    let overflow_occurred = unsafe { csr::rtio_analyzer::message_encoder_overflow_read() != 0 };
-    let total_byte_count = unsafe { csr::rtio_analyzer::dma_byte_count_read() };
-    let pointer = (total_byte_count % BUFFER_SIZE as u64) as usize;
-    let wraparound = total_byte_count >= BUFFER_SIZE as u64;
+#[cfg(has_drtio)]
+pub mod remote_analyzer {
+    use super::*;
+    use rtio_mgt::drtio;
+    
+    pub struct RemoteBuffer {
+        pub total_byte_count: u64,
+        pub sent_bytes: u32,
+        pub overflow_occurred: bool,
+        pub data: Vec<u8>
+    }
 
+    pub fn get_data(io: &Io, aux_mutex: &Mutex, ddma_mutex: &Mutex,
+        routing_table: &drtio_routing::RoutingTable,
+        up_destinations: &Urc<RefCell<[bool; drtio_routing::DEST_COUNT]>>) -> RemoteBuffer {
+            // gets data from satellites and returns consolidated data
+            let mut remote_data: Vec<u8> = Vec::new();
+            let mut remote_overflow = false;
+            let mut remote_sent_bytes = 0;
+            let mut remote_total_bytes = 0;
+
+            let data_vec = match drtio::analyzer_query(io, aux_mutex, ddma_mutex, routing_table, up_destinations) {
+                Ok(data_vec) => data_vec,
+                Err(e) => { error!("error retrieving remote analyzer data: {}", e); Vec::new() }
+            };
+            for data in data_vec {
+                remote_total_bytes += data.total_byte_count;
+                remote_sent_bytes += data.sent_bytes;
+                remote_overflow |= data.overflow_occurred;
+                remote_data.extend(data.data);
+            }
+
+            RemoteBuffer {
+                total_byte_count: remote_total_bytes,
+                sent_bytes: remote_sent_bytes,
+                overflow_occurred: remote_overflow,
+                data: remote_data
+            }
+        }
+}   
+
+
+
+fn worker(stream: &mut TcpStream, _io: &Io, _aux_mutex: &Mutex, _ddma_mutex: &Mutex,
+    _routing_table: &drtio_routing::RoutingTable,
+    _up_destinations: &Urc<RefCell<[bool; drtio_routing::DEST_COUNT]>>
+) -> Result<(), IoError<SchedError>> {
+    let local_data = unsafe { &BUFFER.data[..] };
+    let local_overflow_occurred = unsafe { csr::rtio_analyzer::message_encoder_overflow_read() != 0 };
+    let local_total_byte_count = unsafe { csr::rtio_analyzer::dma_byte_count_read() };
+
+    let wraparound = local_total_byte_count >= BUFFER_SIZE as u64;
+    let local_sent_bytes = if wraparound { BUFFER_SIZE as u32 } else { local_total_byte_count as u32 };
+    let pointer = (local_total_byte_count % BUFFER_SIZE as u64) as usize;
+
+    #[cfg(has_drtio)]
+    let remote = remote_analyzer::get_data(
+        _io, _aux_mutex, _ddma_mutex, _routing_table, _up_destinations);
+    #[cfg(has_drtio)]
     let header = Header {
-        total_byte_count: total_byte_count,
-        sent_bytes: if wraparound { BUFFER_SIZE as u32 } else { total_byte_count as u32 },
-        overflow_occurred: overflow_occurred,
+        total_byte_count: local_total_byte_count + remote.total_byte_count,
+        sent_bytes: local_sent_bytes + remote.sent_bytes,
+        overflow_occurred: local_overflow_occurred | remote.overflow_occurred,
+        log_channel: csr::CONFIG_RTIO_LOG_CHANNEL as u8,
+        dds_onehot_sel: true 
+    };
+
+    #[cfg(not(has_drtio))]
+    let header = Header {
+        total_byte_count: local_total_byte_count,
+        sent_bytes: local_sent_bytes,
+        overflow_occurred: local_overflow_occurred,
         log_channel: csr::CONFIG_RTIO_LOG_CHANNEL as u8,
         dds_onehot_sel: true  // kept for backward compatibility of analyzer dumps
     };
@@ -54,16 +119,20 @@ fn worker(stream: &mut TcpStream) -> Result<(), IoError<SchedError>> {
     stream.write_all("e".as_bytes())?;
     header.write_to(stream)?;
     if wraparound {
-        stream.write_all(&data[pointer..])?;
-        stream.write_all(&data[..pointer])?;
+        stream.write_all(&local_data[pointer..])?;
+        stream.write_all(&local_data[..pointer])?;
     } else {
-        stream.write_all(&data[..pointer])?;
+        stream.write_all(&local_data[..pointer])?;
     }
+    #[cfg(has_drtio)]
+    stream.write_all(&remote.data)?;
 
     Ok(())
 }
 
-pub fn thread(io: Io) {
+pub fn thread(io: Io, aux_mutex: &Mutex, ddma_mutex: &Mutex,
+    routing_table: &Urc<RefCell<drtio_routing::RoutingTable>>,
+    up_destinations: &Urc<RefCell<[bool; drtio_routing::DEST_COUNT]>>) {
     let listener = TcpListener::new(&io, 65535);
     listener.listen(1382).expect("analyzer: cannot listen");
 
@@ -75,7 +144,8 @@ pub fn thread(io: Io) {
 
         disarm();
 
-        match worker(&mut stream) {
+        let routing_table = routing_table.borrow();
+        match worker(&mut stream, &io, aux_mutex, ddma_mutex, &routing_table, up_destinations) {
             Ok(())   => (),
             Err(err) => error!("analyzer aborted: {}", err)
         }

--- a/artiq/firmware/runtime/main.rs
+++ b/artiq/firmware/runtime/main.rs
@@ -214,7 +214,7 @@ fn startup() {
         let drtio_routing_table = drtio_routing_table.clone();
         let up_destinations = up_destinations.clone();
         let ddma_mutex = ddma_mutex.clone();
-        io.spawn(4096, move |io| { analyzer::thread(io, &aux_mutex, &ddma_mutex, &drtio_routing_table, &up_destinations) });
+        io.spawn(8192, move |io| { analyzer::thread(io, &aux_mutex, &ddma_mutex, &drtio_routing_table, &up_destinations) });
     }
 
     #[cfg(has_grabber)]

--- a/artiq/firmware/runtime/main.rs
+++ b/artiq/firmware/runtime/main.rs
@@ -209,7 +209,13 @@ fn startup() {
         io.spawn(4096, move |io| { moninj::thread(io, &aux_mutex, &ddma_mutex, &drtio_routing_table) });
     }
     #[cfg(has_rtio_analyzer)]
-    io.spawn(4096, analyzer::thread);
+    {
+        let aux_mutex = aux_mutex.clone();
+        let drtio_routing_table = drtio_routing_table.clone();
+        let up_destinations = up_destinations.clone();
+        let ddma_mutex = ddma_mutex.clone();
+        io.spawn(4096, move |io| { analyzer::thread(io, &aux_mutex, &ddma_mutex, &drtio_routing_table, &up_destinations) });
+    }
 
     #[cfg(has_grabber)]
     io.spawn(4096, grabber_thread);

--- a/artiq/firmware/runtime/rtio_mgt.rs
+++ b/artiq/firmware/runtime/rtio_mgt.rs
@@ -19,6 +19,8 @@ pub mod drtio {
     use drtioaux;
     use proto_artiq::drtioaux_proto::DMA_TRACE_MAX_SIZE;
     use rtio_dma::remote_dma;
+    #[cfg(has_rtio_analyzer)]
+    use analyzer::remote_analyzer::RemoteBuffer;
 
     pub fn startup(io: &Io, aux_mutex: &Mutex,
             routing_table: &Urc<RefCell<drtio_routing::RoutingTable>>,
@@ -402,6 +404,59 @@ pub mod drtio {
             Ok(_) => return Err("received unexpected aux packet during DMA playback"),
             Err(_) => return Err("aux error on DMA playback")
         }
+    }
+
+    #[cfg(has_rtio_analyzer)]
+    fn analyzer_get_data(io: &Io, aux_mutex: &Mutex, ddma_mutex: &Mutex,
+        routing_table: &drtio_routing::RoutingTable, destination: u8
+    ) -> Result<RemoteBuffer, &'static str> {
+        let linkno = routing_table.0[destination as usize][0] - 1;
+        let reply = aux_transact(io, aux_mutex, ddma_mutex, linkno, &drtioaux::Packet::AnalyzerRequest {
+            destination: destination });
+        let (sent, total, overflow) = match reply {
+            Ok(drtioaux::Packet::AnalyzerHeader { 
+                sent_bytes, total_byte_count, overflow_occurred }
+            ) => (sent_bytes, total_byte_count, overflow_occurred),
+            Ok(_) => return Err("received unexpected aux packet during remote analyzer data request"),
+            Err(_) => return Err("aux error on remote analyzer request")
+        };
+
+        let mut remote_data: Vec<u8> = Vec::new();
+        if sent > 0 {
+            let mut last_packet = false;
+            while !last_packet {
+                let reply = recv_aux_timeout(io, linkno, 200);
+                match reply {
+                    Ok(drtioaux::Packet::AnalyzerData { last, length, data }) => { 
+                        last_packet = last;
+                        remote_data.extend(&data[0..length as usize]);
+                    },
+                    Ok(_) => return Err("received unexpected aux packet during remote analyzer data request"),
+                    Err(_) => return Err("aux error on remote analyzer request")
+                }
+            }
+        }
+
+        Ok(RemoteBuffer {
+            sent_bytes: sent,
+            total_byte_count: total,
+            overflow_occurred: overflow,
+            data: remote_data
+        })
+    }
+
+    #[cfg(has_rtio_analyzer)]
+    pub fn analyzer_query(io: &Io, aux_mutex: &Mutex, ddma_mutex: &Mutex,
+        routing_table: &drtio_routing::RoutingTable,
+        up_destinations: &Urc<RefCell<[bool; drtio_routing::DEST_COUNT]>>
+    ) -> Result<Vec<RemoteBuffer>, &'static str> {
+        let mut remote_buffers: Vec<RemoteBuffer> = Vec::new();
+        for i in 0..drtio_routing::DEST_COUNT as u8 {
+            if destination_up(up_destinations, i) {
+                remote_buffers.push(analyzer_get_data(io, aux_mutex, ddma_mutex, routing_table, i)?);
+            }
+        }
+        Ok(remote_buffers)
     }
 
 }

--- a/artiq/firmware/satman/Cargo.toml
+++ b/artiq/firmware/satman/Cargo.toml
@@ -18,3 +18,4 @@ board_misoc = { path = "../libboard_misoc", features = ["uart_console", "log"] }
 board_artiq = { path = "../libboard_artiq" }
 alloc_list = { path = "../liballoc_list" }
 riscv = { version = "0.6.0", features = ["inline-asm"] }
+proto_artiq = { path = "../libproto_artiq", features = ["log", "alloc"] }

--- a/artiq/firmware/satman/analyzer.rs
+++ b/artiq/firmware/satman/analyzer.rs
@@ -1,5 +1,4 @@
 use board_misoc::{csr, cache};
-use board_artiq::drtioaux;
 use proto_artiq::drtioaux_proto::ANALYZER_MAX_SIZE;
 
 const BUFFER_SIZE: usize = 512 * 1024;
@@ -13,7 +12,7 @@ static mut BUFFER: Buffer = Buffer {
     data: [0; BUFFER_SIZE]
 };
 
-pub fn arm() {
+fn arm() {
     unsafe {
         let base_addr = &mut BUFFER.data[0] as *mut _ as usize;
         let last_addr = &mut BUFFER.data[BUFFER_SIZE - 1] as *mut _ as usize;
@@ -25,7 +24,7 @@ pub fn arm() {
     }
 }
 
-pub fn disarm() {
+fn disarm() {
     unsafe {
         csr::rtio_analyzer::enable_write(0);
         while csr::rtio_analyzer::busy_read() != 0 {}
@@ -34,38 +33,109 @@ pub fn disarm() {
     }
 }
 
-pub fn send() -> Result<(), drtioaux::Error<!>> {
-    let data = unsafe { &BUFFER.data[..] };
-    let overflow_occurred = unsafe { csr::rtio_analyzer::message_encoder_overflow_read() != 0 };
-    let total_byte_count = unsafe { csr::rtio_analyzer::dma_byte_count_read() };
-    let pointer = (total_byte_count % BUFFER_SIZE as u64) as usize;
-    let wraparound = total_byte_count >= BUFFER_SIZE as u64;
-    let sent_bytes = if wraparound { BUFFER_SIZE } else { total_byte_count as usize };
+pub struct Analyzer {
+    // necessary for keeping track of sent data
+    sent_bytes: usize,
+    data_iter: usize
+}
 
-    drtioaux::send(0, &drtioaux::Packet::AnalyzerHeader {
-        total_byte_count: total_byte_count,
-        sent_bytes: sent_bytes as u32,
-        overflow_occurred: overflow_occurred,
-    })?;
+pub struct Header {
+    pub total_byte_count: u64,
+    pub sent_bytes: u32,
+    pub overflow: bool
+}
 
-    let mut i = if wraparound { pointer } else { 0 };
-    while i < sent_bytes {
-        let mut data_slice: [u8; ANALYZER_MAX_SIZE] = [0; ANALYZER_MAX_SIZE];
-        let len: usize = if i + ANALYZER_MAX_SIZE < sent_bytes { ANALYZER_MAX_SIZE } else { sent_bytes - i } as usize;
-        let last = i + len == sent_bytes;
+pub struct AnalyzerSliceMeta {
+    pub len: u16,
+    pub last: bool
+}
+
+impl Analyzer {
+    pub fn new() -> Analyzer {
+        // create and arm new Analyzer
+        arm();
+        Analyzer {
+            sent_bytes: 0,
+            data_iter: 0
+        }
+    }
+
+    pub fn get_header(&mut self) -> Header {
+        disarm();
+
+        let overflow = unsafe { csr::rtio_analyzer::message_encoder_overflow_read() != 0 };
+        let total_byte_count = unsafe { csr::rtio_analyzer::dma_byte_count_read() };
+        let wraparound = total_byte_count >= BUFFER_SIZE as u64;
+        self.sent_bytes = if wraparound { BUFFER_SIZE } else { total_byte_count as usize };
+        self.data_iter = if wraparound { (total_byte_count % BUFFER_SIZE as u64) as usize } else { 0 };
+    
+        Header {
+            total_byte_count: total_byte_count,
+            sent_bytes: self.sent_bytes as u32,
+            overflow: overflow
+        }
+    }
+
+    pub fn get_data(&mut self, data_slice: &mut [u8; ANALYZER_MAX_SIZE]) -> AnalyzerSliceMeta {
+        let data = unsafe { &BUFFER.data[..] };
+        let i = self.data_iter;
+        let len = if i + ANALYZER_MAX_SIZE < self.sent_bytes { ANALYZER_MAX_SIZE } else { self.sent_bytes - i };
+        let last = i + len == self.sent_bytes;
         if i + len >= BUFFER_SIZE {
             data_slice[..len].clone_from_slice(&data[i..BUFFER_SIZE]);
             data_slice[..len].clone_from_slice(&data[..(i+len) % BUFFER_SIZE]);
         } else {
             data_slice[..len].clone_from_slice(&data[i..i+len]);
         }
-        i += len;
-        drtioaux::send(0, &drtioaux::Packet::AnalyzerData {
-            last: last,
-            length: len as u16,
-            data: data_slice,
-        })?;
-    }
+        self.data_iter += len;
 
-    Ok(())
+        if last {
+            arm();
+        }
+        
+        AnalyzerSliceMeta {
+            len: len as u16,
+            last: last
+        }
+    }
 }
+
+
+// pub fn send() -> Result<(), drtioaux::Error<!>> {
+//     let data = unsafe { &BUFFER.data[..] };
+//     let overflow_occurred = unsafe { csr::rtio_analyzer::message_encoder_overflow_read() != 0 };
+//     let total_byte_count = unsafe { csr::rtio_analyzer::dma_byte_count_read() };
+//     let pointer = (total_byte_count % BUFFER_SIZE as u64) as usize;
+//     let wraparound = total_byte_count >= BUFFER_SIZE as u64;
+//     let sent_bytes = if wraparound { BUFFER_SIZE } else { total_byte_count as usize };
+
+//     drtioaux::send(0, &drtioaux::Packet::AnalyzerHeader {
+//         total_byte_count: total_byte_count,
+//         sent_bytes: sent_bytes as u32,
+//         overflow_occurred: overflow_occurred,
+//     })?;
+
+//     info!("header sent, total bytes: {}; sent: {}, overflow: {}", total_byte_count, sent_bytes, overflow_occurred);
+
+//     let mut i = if wraparound { pointer } else { 0 };
+//     while i < sent_bytes {
+//         let mut data_slice: [u8; ANALYZER_MAX_SIZE] = [0; ANALYZER_MAX_SIZE];
+//         let len: usize = if i + ANALYZER_MAX_SIZE < sent_bytes { ANALYZER_MAX_SIZE } else { sent_bytes - i } as usize;
+//         let last = i + len == sent_bytes;
+//         if i + len >= BUFFER_SIZE {
+//             data_slice[..len].clone_from_slice(&data[i..BUFFER_SIZE]);
+//             data_slice[..len].clone_from_slice(&data[..(i+len) % BUFFER_SIZE]);
+//         } else {
+//             data_slice[..len].clone_from_slice(&data[i..i+len]);
+//         }
+//         i += len;
+//         drtioaux::send(0, &drtioaux::Packet::AnalyzerData {
+//             last: last,
+//             length: len as u16,
+//             data: data_slice,
+//         })?;
+//         //info!("sent data, last: {}, length: {}", last, len);
+//     }
+
+//     Ok(())
+// }

--- a/artiq/firmware/satman/analyzer.rs
+++ b/artiq/firmware/satman/analyzer.rs
@@ -1,0 +1,71 @@
+use board_misoc::{csr, cache};
+use board_artiq::drtioaux;
+use proto_artiq::drtioaux_proto::ANALYZER_MAX_SIZE;
+
+const BUFFER_SIZE: usize = 512 * 1024;
+
+#[repr(align(64))]
+struct Buffer {
+    data: [u8; BUFFER_SIZE],
+}
+
+static mut BUFFER: Buffer = Buffer {
+    data: [0; BUFFER_SIZE]
+};
+
+pub fn arm() {
+    unsafe {
+        let base_addr = &mut BUFFER.data[0] as *mut _ as usize;
+        let last_addr = &mut BUFFER.data[BUFFER_SIZE - 1] as *mut _ as usize;
+        csr::rtio_analyzer::message_encoder_overflow_reset_write(1);
+        csr::rtio_analyzer::dma_base_address_write(base_addr as u64);
+        csr::rtio_analyzer::dma_last_address_write(last_addr as u64);
+        csr::rtio_analyzer::dma_reset_write(1);
+        csr::rtio_analyzer::enable_write(1);
+    }
+}
+
+pub fn disarm() {
+    unsafe {
+        csr::rtio_analyzer::enable_write(0);
+        while csr::rtio_analyzer::busy_read() != 0 {}
+        cache::flush_cpu_dcache();
+        cache::flush_l2_cache();
+    }
+}
+
+pub fn send() -> Result<(), drtioaux::Error<!>> {
+    let data = unsafe { &BUFFER.data[..] };
+    let overflow_occurred = unsafe { csr::rtio_analyzer::message_encoder_overflow_read() != 0 };
+    let total_byte_count = unsafe { csr::rtio_analyzer::dma_byte_count_read() };
+    let pointer = (total_byte_count % BUFFER_SIZE as u64) as usize;
+    let wraparound = total_byte_count >= BUFFER_SIZE as u64;
+    let sent_bytes = if wraparound { BUFFER_SIZE } else { total_byte_count as usize };
+
+    drtioaux::send(0, &drtioaux::Packet::AnalyzerHeader {
+        total_byte_count: total_byte_count,
+        sent_bytes: sent_bytes as u32,
+        overflow_occurred: overflow_occurred,
+    })?;
+
+    let mut i = if wraparound { pointer } else { 0 };
+    while i < sent_bytes {
+        let mut data_slice: [u8; ANALYZER_MAX_SIZE] = [0; ANALYZER_MAX_SIZE];
+        let len: usize = if i + ANALYZER_MAX_SIZE < sent_bytes { ANALYZER_MAX_SIZE } else { sent_bytes - i } as usize;
+        let last = i + len == sent_bytes;
+        if i + len >= BUFFER_SIZE {
+            data_slice[..len].clone_from_slice(&data[i..BUFFER_SIZE]);
+            data_slice[..len].clone_from_slice(&data[..(i+len) % BUFFER_SIZE]);
+        } else {
+            data_slice[..len].clone_from_slice(&data[i..i+len]);
+        }
+        i += len;
+        drtioaux::send(0, &drtioaux::Packet::AnalyzerData {
+            last: last,
+            length: len as u16,
+            data: data_slice,
+        })?;
+    }
+
+    Ok(())
+}

--- a/artiq/gateware/targets/kasli.py
+++ b/artiq/gateware/targets/kasli.py
@@ -577,7 +577,7 @@ class SatelliteBase(BaseSoC):
         self.submodules.routing_table = rtio.RoutingTableAccess(self.cri_con)
         self.csr_devices.append("routing_table")
         
-        self.submodules.rtio_analyzer = rtio.Analyzer(self.rtio_tsc, self.rtio_core.cri,
+        self.submodules.rtio_analyzer = rtio.Analyzer(self.rtio_tsc, self.local_io.cri,
                                                 self.get_native_sdram_if(), cpu_dw=self.cpu_dw)
         self.csr_devices.append("rtio_analyzer")
 

--- a/artiq/gateware/targets/kasli.py
+++ b/artiq/gateware/targets/kasli.py
@@ -577,7 +577,7 @@ class SatelliteBase(BaseSoC):
         self.submodules.routing_table = rtio.RoutingTableAccess(self.cri_con)
         self.csr_devices.append("routing_table")
         
-        self.submodules.rtio_analyzer = rtio.Analyzer(self.rtio_tsc, self.cri_con.switch.slave,
+        self.submodules.rtio_analyzer = rtio.Analyzer(self.rtio_tsc, self.rtio_core.cri,
                                                 self.get_native_sdram_if(), cpu_dw=self.cpu_dw)
         self.csr_devices.append("rtio_analyzer")
 

--- a/artiq/gateware/targets/kasli.py
+++ b/artiq/gateware/targets/kasli.py
@@ -360,7 +360,7 @@ class MasterBase(MiniSoC, AMPSoC):
         self.submodules.routing_table = rtio.RoutingTableAccess(self.cri_con)
         self.csr_devices.append("routing_table")
 
-        self.submodules.rtio_analyzer = rtio.Analyzer(self.rtio_tsc, self.cri_con.switch.slave,
+        self.submodules.rtio_analyzer = rtio.Analyzer(self.rtio_tsc, self.rtio_core.cri,
                                                       self.get_native_sdram_if(), cpu_dw=self.cpu_dw)
         self.csr_devices.append("rtio_analyzer")
 
@@ -576,6 +576,10 @@ class SatelliteBase(BaseSoC):
         self.csr_devices.append("cri_con")
         self.submodules.routing_table = rtio.RoutingTableAccess(self.cri_con)
         self.csr_devices.append("routing_table")
+        
+        self.submodules.rtio_analyzer = rtio.Analyzer(self.rtio_tsc, self.cri_con.switch.slave,
+                                                self.get_native_sdram_if(), cpu_dw=self.cpu_dw)
+        self.csr_devices.append("rtio_analyzer")
 
 
 class Master(MasterBase):

--- a/artiq/gateware/targets/kc705.py
+++ b/artiq/gateware/targets/kc705.py
@@ -308,6 +308,10 @@ class _MasterBase(MiniSoC, AMPSoC):
         self.register_kernel_cpu_csrdevice("cri_con")
         self.submodules.routing_table = rtio.RoutingTableAccess(self.cri_con)
         self.csr_devices.append("routing_table")
+        self.submodules.rtio_analyzer = rtio.Analyzer(self.rtio_tsc, self.rtio_core.cri,
+                                                self.get_native_sdram_if(), cpu_dw=self.cpu_dw)
+        self.csr_devices.append("rtio_analyzer")
+
 
 
 class _SatelliteBase(BaseSoC):
@@ -460,6 +464,9 @@ class _SatelliteBase(BaseSoC):
         self.csr_devices.append("cri_con")
         self.submodules.routing_table = rtio.RoutingTableAccess(self.cri_con)
         self.csr_devices.append("routing_table")
+        self.submodules.rtio_analyzer = rtio.Analyzer(self.rtio_tsc, self.rtio_core.cri,
+                                                self.get_native_sdram_if(), cpu_dw=self.cpu_dw)
+        self.csr_devices.append("rtio_analyzer")
 
 
 class _NIST_CLOCK_RTIO:

--- a/artiq/gateware/targets/kc705.py
+++ b/artiq/gateware/targets/kc705.py
@@ -464,7 +464,7 @@ class _SatelliteBase(BaseSoC):
         self.csr_devices.append("cri_con")
         self.submodules.routing_table = rtio.RoutingTableAccess(self.cri_con)
         self.csr_devices.append("routing_table")
-        self.submodules.rtio_analyzer = rtio.Analyzer(self.rtio_tsc, self.rtio_core.cri,
+        self.submodules.rtio_analyzer = rtio.Analyzer(self.rtio_tsc, self.local_io.cri,
                                                 self.get_native_sdram_if(), cpu_dw=self.cpu_dw)
         self.csr_devices.append("rtio_analyzer")
 


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

This PR implements distributed analyzer. That means, in DRTIO systems, RTIO analyzer on master will query any remote destinations if they have any logs to send, and download them if necessary. That also allows using the analyzer when also using DDMA - without it, remote events would not get recorded.

Tested with Kasli 2.0 (master) and 1.1 (satellite), and in standalone for regression.

Tested with the following experiment:

<details> 
<summary>Experiment</summary>

```python
from artiq.experiment import *


class DMAPulses(EnvExperiment):
    def build(self):
        self.setattr_device("core")
        self.setattr_device("core_dma")
        self.setattr_device("ttl4")
        self.setattr_device("ttl12")

    @kernel
    def record(self):
        with self.core_dma.record("pulses", enable_ddma=True):
            for i in range(10):
                self.ttl4.pulse(10*us)
                self.ttl12.pulse(5*us)
                delay(10*us)
            rtio_log("test", 15)

    @kernel
    def run(self):
        self.core.reset()
        self.record()
        pulses_handle = self.core_dma.get_handle("pulses")
        self.core.break_realtime()
        delay(100*ms)
        self.core_dma.playback_handle(pulses_handle)
```
</details>

Notice it's using DDMA, so in normal situation some events would not be recorded. Also, the recorded analyzer trace is long enough that it needs to be broken down and reassembled.

Below ``coreanalyzer`` output from the experiment:
<details>
<summary>Coreanalyzer output</summary>

```
[spaqin@hera:~/m-labs/artiq]$ artiq_coreanalyzer -p
Log channel: 11
DDS one-hot: True
OutputMessage(channel=11, timestamp=250000, rtio_counter=602885626704, address=0, data=1952805748)
OutputMessage(channel=11, timestamp=250000, rtio_counter=602885626816, address=0, data=30)
OutputMessage(channel=11, timestamp=250000, rtio_counter=602885647336, address=0, data=3224861)
OutputMessage(channel=4, timestamp=17782380376, rtio_counter=17682262496, address=0, data=1)
OutputMessage(channel=4, timestamp=17782390376, rtio_counter=17682262560, address=0, data=0)
OutputMessage(channel=4, timestamp=17782405376, rtio_counter=17682262784, address=0, data=1)
OutputMessage(channel=4, timestamp=17782415376, rtio_counter=17682263008, address=0, data=0)
OutputMessage(channel=4, timestamp=17782430376, rtio_counter=17682263696, address=0, data=1)
OutputMessage(channel=4, timestamp=17782440376, rtio_counter=17682264376, address=0, data=0)
OutputMessage(channel=4, timestamp=17782455376, rtio_counter=17682264720, address=0, data=1)
OutputMessage(channel=4, timestamp=17782465376, rtio_counter=17682264944, address=0, data=0)
OutputMessage(channel=4, timestamp=17782480376, rtio_counter=17682265168, address=0, data=1)
OutputMessage(channel=4, timestamp=17782490376, rtio_counter=17682265392, address=0, data=0)
OutputMessage(channel=4, timestamp=17782505376, rtio_counter=17682265616, address=0, data=1)
OutputMessage(channel=4, timestamp=17782515376, rtio_counter=17682265840, address=0, data=0)
OutputMessage(channel=4, timestamp=17782530376, rtio_counter=17682266064, address=0, data=1)
OutputMessage(channel=4, timestamp=17782540376, rtio_counter=17682266288, address=0, data=0)
OutputMessage(channel=4, timestamp=17782555376, rtio_counter=17682266512, address=0, data=1)
OutputMessage(channel=4, timestamp=17782565376, rtio_counter=17682266736, address=0, data=0)
OutputMessage(channel=4, timestamp=17782580376, rtio_counter=17682266960, address=0, data=1)
OutputMessage(channel=4, timestamp=17782590376, rtio_counter=17682267184, address=0, data=0)
OutputMessage(channel=4, timestamp=17782605376, rtio_counter=17682267408, address=0, data=1)
OutputMessage(channel=4, timestamp=17782615376, rtio_counter=17682267632, address=0, data=0)
StoppedMessage(rtio_counter=23230647368)
OutputMessage(channel=65540, timestamp=17782390376, rtio_counter=17683078656, address=0, data=1)
OutputMessage(channel=65540, timestamp=17782395376, rtio_counter=17683078816, address=0, data=0)
OutputMessage(channel=65540, timestamp=17782415376, rtio_counter=17683079104, address=0, data=1)
OutputMessage(channel=65540, timestamp=17782420376, rtio_counter=17683079256, address=0, data=0)
OutputMessage(channel=65540, timestamp=17782440376, rtio_counter=17683079448, address=0, data=1)
OutputMessage(channel=65540, timestamp=17782445376, rtio_counter=17683079544, address=0, data=0)
OutputMessage(channel=65540, timestamp=17782465376, rtio_counter=17683079640, address=0, data=1)
OutputMessage(channel=65540, timestamp=17782470376, rtio_counter=17683079736, address=0, data=0)
OutputMessage(channel=65540, timestamp=17782490376, rtio_counter=17683079832, address=0, data=1)
OutputMessage(channel=65540, timestamp=17782495376, rtio_counter=17683079928, address=0, data=0)
OutputMessage(channel=65540, timestamp=17782515376, rtio_counter=17683080024, address=0, data=1)
OutputMessage(channel=65540, timestamp=17782520376, rtio_counter=17683080120, address=0, data=0)
OutputMessage(channel=65540, timestamp=17782540376, rtio_counter=17683080216, address=0, data=1)
OutputMessage(channel=65540, timestamp=17782545376, rtio_counter=17683080776, address=0, data=0)
OutputMessage(channel=65540, timestamp=17782565376, rtio_counter=17683080936, address=0, data=1)
OutputMessage(channel=65540, timestamp=17782570376, rtio_counter=17683081032, address=0, data=0)
OutputMessage(channel=65540, timestamp=17782590376, rtio_counter=17683081192, address=0, data=1)
OutputMessage(channel=65540, timestamp=17782595376, rtio_counter=17683081352, address=0, data=0)
OutputMessage(channel=65540, timestamp=17782615376, rtio_counter=17683081448, address=0, data=1)
OutputMessage(channel=65540, timestamp=17782620376, rtio_counter=17683081544, address=0, data=0)
StoppedMessage(rtio_counter=23236463176)
```

Note two stopped messages, for both master and satellite. Not sure if that's okay - I'm thinking of trimming that out off satellites and disarming master analyzer core after retrieving remote data first, if that's better.
</details>

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
