### PR TITLE
update configuration of IBUFDS_GTE2

### DIFF
--- a/artiq/gateware/drtio/transceiver/gtx_7series.py
+++ b/artiq/gateware/drtio/transceiver/gtx_7series.py
@@ -288,9 +288,9 @@ class GTX(Module, TransceiverInterface):
             i_I=clock_pads.p,
             i_IB=clock_pads.n,
             o_O=refclk,
-            p_CLKCM_CFG="0b1",
-            p_CLKRCV_TRST="0b1",
-            p_CLKSWING_CFG="0b11"
+            p_CLKCM_CFG="TRUE",
+            p_CLKRCV_TRST="TRUE",
+            p_CLKSWING_CFG=3
         )
 
         channel_interfaces = []

--- a/artiq/gateware/targets/kasli.py
+++ b/artiq/gateware/targets/kasli.py
@@ -87,7 +87,10 @@ class StandaloneBase(MiniSoC, AMPSoC):
             Instance("IBUFDS_GTE2",
                 i_CEB=0,
                 i_I=cdr_clk_out.p, i_IB=cdr_clk_out.n,
-                o_O=cdr_clk), 
+                o_O=cdr_clk,
+                p_CLKCM_CFG="TRUE",
+                p_CLKRCV_TRST="TRUE", 
+                p_CLKSWING_CFG=3), 
             Instance("BUFG", i_I=cdr_clk, o_O=cdr_clk_buf)
         ]
 
@@ -378,7 +381,10 @@ class MasterBase(MiniSoC, AMPSoC):
         self.specials += Instance("IBUFDS_GTE2",
             i_CEB=0,
             i_I=cdr_clk_out.p, i_IB=cdr_clk_out.n,
-            o_O=cdr_clk)
+            o_O=cdr_clk,
+            p_CLKCM_CFG="TRUE",
+            p_CLKRCV_TRST="TRUE", 
+            p_CLKSWING_CFG=3)
         # Note precisely the rules Xilinx made up:
         # refclksel=0b001 GTREFCLK0 selected
         # refclksel=0b010 GTREFCLK1 selected
@@ -440,7 +446,10 @@ class SatelliteBase(BaseSoC):
         self.specials += Instance("IBUFDS_GTE2",
             i_CEB=0,
             i_I=cdr_clk_out.p, i_IB=cdr_clk_out.n,
-            o_O=cdr_clk)
+            o_O=cdr_clk,
+            p_CLKCM_CFG="TRUE",
+            p_CLKRCV_TRST="TRUE", 
+            p_CLKSWING_CFG=3)
         qpll_drtio_settings = QPLLSettings(
             refclksel=0b001,
             fbdiv=4,

--- a/artiq/gateware/targets/kc705.py
+++ b/artiq/gateware/targets/kc705.py
@@ -119,9 +119,9 @@ class _StandaloneBase(MiniSoC, AMPSoC):
                 i_CEB=0,
                 i_I=cdr_clk_out.p, i_IB=cdr_clk_out.n,
                 o_O=cdr_clk,
-                p_CLKCM_CFG=1,
-                p_CLKRCV_TRST=1, 
-                p_CLKSWING_CFG="2'b11"),
+                p_CLKCM_CFG="TRUE",
+                p_CLKRCV_TRST="TRUE", 
+                p_CLKSWING_CFG=3),
             Instance("BUFG", i_I=cdr_clk, o_O=cdr_clk_buf)
         ]
 


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
Input clock is terminated internally with 50 Ohm on each leg and to 4/5 MGTAVCC.

### Related Issue
review buffer params in other uses of IBUFDS_GTE2 #1944 

## Type of Changes
| ✓  | :bug: Bug fix  |
