### PR TITLE
Update to LLVM 14 and llvmlite 40

### DIFF
--- a/artiq/test/lit/embedding/syscall_arg_attrs.py
+++ b/artiq/test/lit/embedding/syscall_arg_attrs.py
@@ -18,13 +18,13 @@ def entrypoint():
     return_str()
 
 
-# CHECK: declare void @accept_str\({ i8\*, i32 }\* byval\)
+# CHECK: declare void @accept_str\({ i8\*, i32 }\* byval\({ i8\*, i32 }\)\)
 @syscall
 def accept_str(name: TStr) -> TNone:
     pass
 
 
-# CHECK: declare void @return_str\({ i8\*, i32 }\* sret\)
+# CHECK: declare void @return_str\({ i8\*, i32 }\* sret\({ i8\*, i32 }\)\)
 @syscall
 def return_str() -> TStr:
     pass

--- a/artiq/test/lit/embedding/syscall_flags.py
+++ b/artiq/test/lit/embedding/syscall_flags.py
@@ -15,7 +15,7 @@ def foo() -> TNone:
 
 # sret nowrite functions shouldn't be marked inaccessiblememonly.
 # CHECK-L: ; Function Attrs: nounwind
-# CHECK-NEXT-L: declare void @bar({ i32, i64 }* sret)
+# CHECK-NEXT-L: declare void @bar({ i32, i64 }* sret({ i32, i64 }))
 @syscall(flags={"nounwind", "nowrite"})
 def bar() -> TTuple([TInt32, TInt64]):
     pass

--- a/flake.nix
+++ b/flake.nix
@@ -111,6 +111,34 @@
         '';
       };
 
+      llvmlite-new = pkgs.python3Packages.buildPythonPackage rec {
+          pname = "llvmlite";
+          version = "0.40.0";
+          src = pkgs.fetchFromGitHub {
+              owner = "numba";
+              repo = "llvmlite";
+              rev = "f2aa9a7f127d3fcbc2a8e60373ebff2f567ae640";
+              sha256 = "sha256-NxDb/cuKKESn3xC6UFun7J70ZK7jgL430ghGa2pwtEk=";
+            };
+          patches = [
+             (pkgs.fetchurl {
+               url = "https://github.com/numba/llvmlite/pull/950.patch";
+               sha256 = "sha256-Yet5Z2Lw946EI/rjLHkn+isJe6FeuXvM9b3nOppWaKc=";
+             })
+           ];
+          nativeBuildInputs = [ pkgs.llvm_14 ];
+          # Disable static linking
+          # https://github.com/numba/llvmlite/issues/93
+          postPatch = ''
+            substituteInPlace ffi/Makefile.linux --replace "-static-libstdc++" ""
+            substituteInPlace llvmlite/tests/test_binding.py --replace "test_linux" "nope"
+          '';
+          # Set directory containing llvm-config binary
+          preConfigure = ''
+            export LLVM_CONFIG=${pkgs.llvm_14.dev}/bin/llvm-config
+          '';
+      };
+
       artiq-upstream = pkgs.python3Packages.buildPythonPackage rec {
         pname = "artiq";
         version = artiqVersion;
@@ -124,8 +152,8 @@
 
         nativeBuildInputs = [ pkgs.qt5.wrapQtAppsHook ];
         # keep llvm_x and lld_x in sync with llvmlite
-        propagatedBuildInputs = [ pkgs.llvm_11 pkgs.lld_11 sipyco.packages.x86_64-linux.sipyco pythonparser artiq-comtools.packages.x86_64-linux.artiq-comtools ]
-          ++ (with pkgs.python3Packages; [ llvmlite pyqtgraph pygit2 numpy dateutil scipy prettytable pyserial levenshtein h5py pyqt5 qasync tqdm lmdb jsonschema ]);
+        propagatedBuildInputs = [ pkgs.llvm_14 pkgs.lld_14 sipyco.packages.x86_64-linux.sipyco pythonparser artiq-comtools.packages.x86_64-linux.artiq-comtools llvmlite-new ]
+          ++ (with pkgs.python3Packages; [ pyqtgraph pygit2 numpy dateutil scipy prettytable pyserial levenshtein h5py pyqt5 qasync tqdm lmdb jsonschema ]);
 
         dontWrapQtApps = true;
         postFixup = ''
@@ -147,10 +175,10 @@
           "--set FONTCONFIG_FILE ${pkgs.fontconfig.out}/etc/fonts/fonts.conf"
         ];
 
-        # FIXME: automatically propagate lld_11 llvm_11 dependencies
+        # FIXME: automatically propagate lld_14 llvm_14 dependencies
         # cacert is required in the check stage only, as certificates are to be
         # obtained from system elsewhere
-        nativeCheckInputs = [ pkgs.lld_11 pkgs.llvm_11 libartiq-support pkgs.lit outputcheck pkgs.cacert ];
+        nativeCheckInputs = [ pkgs.lld_14 pkgs.llvm_14 libartiq-support pkgs.lit outputcheck pkgs.cacert ];
         checkPhase = ''
           python -m unittest discover -v artiq.test
 
@@ -227,9 +255,9 @@
             (pkgs.python3.withPackages(ps: [ migen misoc (artiq.withExperimentalFeatures experimentalFeatures) ]))
             rust
             pkgs.cargo-xbuild
-            pkgs.llvmPackages_11.clang-unwrapped
-            pkgs.llvm_11
-            pkgs.lld_11
+            pkgs.llvmPackages_14.clang-unwrapped
+            pkgs.llvm_14
+            pkgs.lld_14
             vivado
             rustPlatform.cargoSetupHook
           ];
@@ -390,9 +418,9 @@
           (pkgs.python3.withPackages(ps: with packages.x86_64-linux; [ migen misoc ps.paramiko microscope ] ++ artiq.propagatedBuildInputs ))
           rust
           pkgs.cargo-xbuild
-          pkgs.llvmPackages_11.clang-unwrapped
-          pkgs.llvm_11
-          pkgs.lld_11
+          pkgs.llvmPackages_14.clang-unwrapped
+          pkgs.llvm_14
+          pkgs.lld_14
           # To manually run compiler tests:
           pkgs.lit
           outputcheck
@@ -419,8 +447,8 @@
           rust
           pkgs.cargo-xbuild
           pkgs.llvmPackages_11.clang-unwrapped
-          pkgs.llvm_11
-          pkgs.lld_11
+          pkgs.llvm_14
+          pkgs.lld_14
           packages.x86_64-linux.vivado
           packages.x86_64-linux.openocd-bscanspi
         ];
@@ -453,8 +481,8 @@
 
           buildInputs = [
             (pkgs.python3.withPackages(ps: with packages.x86_64-linux; [ artiq ps.paramiko ]))
-            pkgs.llvm_11
-            pkgs.lld_11
+            pkgs.llvm_14
+            pkgs.lld_14
             pkgs.openssh
             packages.x86_64-linux.openocd-bscanspi  # for the bscanspi bitstreams
           ];


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Update to LLVM 14 and llvmlite 40 with applied patch from https://github.com/numba/llvmlite/pull/950 . 

### Related Issue

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
