### PR TITLE
satellites: add kernel cpu

### DIFF
--- a/artiq/build_soc.py
+++ b/artiq/build_soc.py
@@ -59,7 +59,7 @@ def build_artiq_soc(soc, argdict):
     builder.software_packages = []
     builder.add_software_package("bootloader", os.path.join(firmware_dir, "bootloader"))
     is_kasli_v1 = isinstance(soc.platform, kasli.Platform) and soc.platform.hw_rev in ("v1.0", "v1.1")
-    if isinstance(soc, AMPSoC):
+    if not soc.config["GATEWARE_BASE"] == "satellite":
         kernel_cpu_type = "vexriscv" if is_kasli_v1 else "vexriscv-g"
         builder.add_software_package("libm", cpu_type=kernel_cpu_type)
         builder.add_software_package("libprintf", cpu_type=kernel_cpu_type)

--- a/artiq/gateware/amp/soc.py
+++ b/artiq/gateware/amp/soc.py
@@ -36,6 +36,7 @@ class AMPSoC:
             csrs = getattr(self, name).get_csrs()
         csr_bus = wishbone.Interface(data_width=32, adr_width=32-log2_int(self.csr_separation))
         bank = wishbone.CSRBank(csrs, bus=csr_bus)
+        self.config["kernel_has_"+name] = None
         self.submodules += bank
         self.kernel_cpu.add_wb_slave(self.mem_map[name], self.csr_separation*2**bank.decode_bits, bank.bus)
         self.add_csr_region(name,

--- a/artiq/gateware/targets/kasli_generic.py
+++ b/artiq/gateware/targets/kasli_generic.py
@@ -22,7 +22,7 @@ class GenericStandalone(StandaloneBase):
             hw_rev = description["hw_rev"]
         self.class_name_override = description["variant"]
         StandaloneBase.__init__(self, hw_rev=hw_rev, **kwargs)
-
+        self.config["GATEWARE_BASE"] = description["base"]
         self.config["RTIO_FREQUENCY"] = "{:.1f}".format(description["rtio_frequency"]/1e6)
         if "ext_ref_frequency" in description:
             self.config["SI5324_EXT_REF"] = None
@@ -76,6 +76,7 @@ class GenericMaster(MasterBase):
             rtio_clk_freq=description["rtio_frequency"],
             enable_sata=description["enable_sata_drtio"],
             **kwargs)
+        self.config["GATEWARE_BASE"] = description["base"]
         if "ext_ref_frequency" in description:
             self.config["SI5324_EXT_REF"] = None
             self.config["EXT_REF_FREQUENCY"] = "{:.1f}".format(
@@ -113,6 +114,7 @@ class GenericSatellite(SatelliteBase):
                                rtio_clk_freq=description["rtio_frequency"],
                                enable_sata=description["enable_sata_drtio"],
                                **kwargs)
+        self.config["GATEWARE_BASE"] = description["base"]
         if hw_rev == "v1.0":
             # EEM clock fan-out from Si5324, not MMCX
             self.comb += self.platform.request("clk_sel").eq(1)


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

First steps towards:
- satellite subkernel support
- (optional) satellite Ethernet support (config, aux data)
- firmware (runtime + satman) merge to use common (incl. kernel control) features

This is the gateware part of it. Assumes that satellite subkernels will only have RTIO access - no DMA, for one (that's why ``kernel_has_...`` rust-cfg has to be implemented, to differentiate overall features from kernel specific features).

Tested only to compilation of the gateware.

For backwards compatibility and minimum changes in configurations maybe it would be reasonable to be able to choose 
the Eth SFP port?

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
