### PR TITLE
dashboard: Option to close all non-docked applets; make Ctrl-Alt-W default to it

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -28,6 +28,10 @@ Highlights:
 * Distributed DMA is now supported, allowing DMA to be run directly on satellites for corresponding
   RTIO events, increasing bandwidth in scenarios with heavy satellite usage.
 * API extensions have been implemented, enabling applets to directly modify datasets.
+* Dashboard:
+   - The "Close all applets" command (shortcut: Ctrl-Alt-W) now ignores docked applets,
+     making it a convenient way to clean up after exploratory work without destroying a
+     carefully arranged default workspace.
 * Persistent datasets are now stored in a LMDB database for improved performance. PYON databases can
   be converted with the script below.
 

--- a/artiq/gui/applets.py
+++ b/artiq/gui/applets.py
@@ -397,11 +397,12 @@ class AppletsDock(QtWidgets.QDockWidget):
         delete_action.setShortcutContext(QtCore.Qt.WidgetShortcut)
         delete_action.triggered.connect(self.delete)
         self.table.addAction(delete_action)
-        close_all_action = QtWidgets.QAction("Close all applets", self.table)
-        close_all_action.setShortcut("CTRL+ALT+W")
-        close_all_action.setShortcutContext(QtCore.Qt.ApplicationShortcut)
-        close_all_action.triggered.connect(self.close_all)
-        self.table.addAction(close_all_action)
+        close_nondocked_action = QtWidgets.QAction("Close non-docked applets", self.table)
+        close_nondocked_action.setShortcut("CTRL+ALT+W")
+        close_nondocked_action.setShortcutContext(QtCore.Qt.ApplicationShortcut)
+        close_nondocked_action.triggered.connect(self.close_nondocked)
+        self.table.addAction(close_nondocked_action)
+
         new_group_action = QtWidgets.QAction("New group", self.table)
         new_group_action.triggered.connect(partial(self.new_with_parent, self.new_group))
         self.table.addAction(new_group_action)
@@ -674,12 +675,15 @@ class AppletsDock(QtWidgets.QDockWidget):
     def restore_state(self, state):
         self.restore_state_item(state, None)
 
-    def close_all(self):
+    def close_nondocked(self):
         def walk(wi):
             for i in range(wi.childCount()):
                 cwi = wi.child(i)
                 if cwi.ty == "applet":
                     if cwi.checkState(0) == QtCore.Qt.Checked:
+                        if cwi.applet_dock is not None:
+                            if not cwi.applet_dock.isFloating():
+                                continue
                         cwi.setCheckState(0, QtCore.Qt.Unchecked)
                 elif cwi.ty == "group":
                     walk(cwi)


### PR DESCRIPTION
I had introduced this in f11aef74b as a means of quickly cleaning up
after e.g. an exploratory session where a lot of transient applets were
opened from ndscan, or for a dashboard that has been running for a while
with CCBs enabled, but without anybody actually working here.

It turns out that one usually wants the few docked applets, which
necessarily have been manually arranged, to stay open. Hence, this
adds an option to preserve docked applets, and makes the keyboard
shortcut default to this.

Since the "Close all applets" option was specifically introduced as
a convenience for these situations, we might choose to remove it
altogether.
