### PR TITLE
Associate unit, scale and ndecimals with datasets

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -39,10 +39,11 @@ Highlights:
   new = lmdb.open("dataset_db.mdb", subdir=False, map_size=2**30)
   with new.begin(write=True) as txn:
     for key, value in old.items():
-      txn.put(key.encode(), pyon.encode(value).encode())
+      txn.put(key.encode(), pyon.encode((value, {})).encode())
   new.close()
 
-
+* Metadata such as units and precision can now be associated with a dataset. 
+  The ``(value, {})`` is needed to enable metadata in persistent datasets.
 
 ARTIQ-7
 -------

--- a/artiq/dashboard/datasets.py
+++ b/artiq/dashboard/datasets.py
@@ -100,7 +100,7 @@ class Model(DictSyncTreeSepModel):
         if column == 1:
             return "Y" if v[0] else "N"
         elif column == 2:
-            return short_format(v[1])
+            return short_format(v[1], v[2])
         else:
             raise ValueError
 

--- a/artiq/language/environment.py
+++ b/artiq/language/environment.py
@@ -337,13 +337,18 @@ class HasEnvironment:
         self.kernel_invariants = kernel_invariants | {key}
 
     @rpc(flags={"async"})
-    def set_dataset(self, key, value,
+    def set_dataset(self, key, value, *,
+                    unit=None, scale=None, precision=None,
                     broadcast=False, persist=False, archive=True):
         """Sets the contents and handling modes of a dataset.
 
         Datasets must be scalars (``bool``, ``int``, ``float`` or NumPy scalar)
         or NumPy arrays.
 
+        :param unit: A string representing the unit of the value.
+        :param scale: A numerical scaling factor by which the displayed value is
+            multiplied when referenced in the experiment.
+        :param precision: The precision a UI should use.
         :param broadcast: the data is sent in real-time to the master, which
             dispatches it.
         :param persist: the master should store the data on-disk. Implies
@@ -351,7 +356,14 @@ class HasEnvironment:
         :param archive: the data is saved into the local storage of the current
             run (archived as a HDF5 file).
         """
-        self.__dataset_mgr.set(key, value, broadcast, persist, archive)
+        metadata = {}
+        if unit is not None:
+            metadata["unit"] = unit
+        if scale is not None:
+            metadata["scale"] = scale
+        if precision is not None:
+            metadata["precision"] = precision
+        self.__dataset_mgr.set(key, value, metadata, broadcast, persist, archive)
 
     @rpc(flags={"async"})
     def mutate_dataset(self, key, index, value):

--- a/artiq/language/environment.py
+++ b/artiq/language/environment.py
@@ -417,6 +417,29 @@ class HasEnvironment:
             else:
                 return default
 
+    def get_dataset_metadata(self, key, default=NoDefault):
+        """Returns the metadata of a dataset.
+         
+        Returns dictionary with items describing the dataset, including the units, 
+        scale and precision. 
+
+        This function is used to get additional information for displaying the dataset.
+
+        Returns a dictionary which may contain zero or more of the items:
+        
+        'unit' - Physical unit associated with dataset.
+        'scale' - A numerical scaling factor associated with the unit by which the displayed value is
+            multiplied when referenced in the experiment.
+        'precision' - The precision a UI should use when displaying the dataset.
+        """
+        try:
+            return self.__dataset_mgr.get_metadata(key)
+        except KeyError:
+            if default is NoDefault:
+                raise
+            else:
+                return default
+
     def setattr_dataset(self, key, default=NoDefault, archive=True):
         """Sets the contents of a dataset as attribute. The names of the
         dataset and of the attribute are the same."""

--- a/artiq/test/test_scheduler.py
+++ b/artiq/test/test_scheduler.py
@@ -288,7 +288,7 @@ class SchedulerCase(unittest.TestCase):
             self.assertEqual(
                 mod,
                 {"action": "setitem", "key": "termination_ok",
-                 "value": (False, True), "path": []})
+                 "value": (False, True, {}), "path": []})
             termination_ok = True
         handlers = {
             "update_dataset": check_termination


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Added additional optional parameters in set_dataset function: unit, precision, scale. See Testing for examples.

Refactored `short_format` to improve formatting of units in dashboard with metadata provided.

If archive=True, units, precision and scale will be saved as hdf5 attributes:
```
DATASET "test_array" {
         DATATYPE  H5T_IEEE_F64LE
         DATASPACE  SIMPLE { ( 5 ) / ( 5 ) }
         DATA {
         (0): 1.234, 1.234, 1.234, 1.234, 1.234
         }
         ATTRIBUTE "precision" {
            DATATYPE  H5T_STD_I64LE
            DATASPACE  SCALAR
            DATA {
            (0): 1
            }
         }
         ATTRIBUTE "unit" {
            DATATYPE  H5T_STRING {
               STRSIZE H5T_VARIABLE;
               STRPAD H5T_STR_NULLTERM;
               CSET H5T_CSET_UTF8;
               CTYPE H5T_C_S1;
            }
            DATASPACE  SCALAR
            DATA {
            (0): "V"
            }
         }
      }
```

Added: 
`get_dataset_metadata` returns a dictionary that may contain the units, scale and dataset.
By default returns `{}`. 

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Testing

#### Automatic Tests

Additional unit tests added to `test_datasets.py`

#### Manual Testing

- [x] Smoke test dashboard
- [x] Smoke test browser 
- [x] Set dataset in client
- [ ] Show datasets in client (BROKEN -> fixed in later PR)
- [x] set dataset in dashboard
- [x] set persistent dataset in dashboard 
- [ ] edit dataset in dashboard (BROKEN -> fixed in later PR)
- [x] test with multiple dashboards
- [x] Tested data types with following script

```
class TestExperiment(EnvExperiment):
    """Test Experiment"""
    def run(self):
        self.set_dataset("test_mutate", 
                         np.asarray([1,2,3,4]),
                         unit="kV",
                         precision=4,
                         broadcast=True, 
                         archive=True)

        self.mutate_dataset("test_mutate", 0, 4)
        
        self.set_dataset("test_int", 1, broadcast=True, archive=True, unit="V", precision=0)
        self.set_dataset("test_float", 1.2345, broadcast=True, archive=True, unit="V", precision=3)
        self.set_dataset("test_float_no_prec", 1.2345, broadcast=True, archive=True, unit="V")
        self.set_dataset("test_array", np.array([1.234, 1.234, 1.234, 1.234, 1.234]), broadcast=True, archive=True, unit="V", precision=1)
        self.set_dataset("test_array_no_prec", np.array([1.234, 1.234, 1.234, 1.234, 1.234]), broadcast=True, archive=True, unit="V")
        self.set_dataset("test_bool", False, broadcast=True, archive=True)
        self.set_dataset("test_list", [1,2,3,4], broadcast=True, archive=True, unit="V", precision=0) # not supporting units etc
        self.set_dataset("test_dict", {'k':3}, broadcast=True, archive=True, unit="V", precision=0) # no support

        self.set_dataset("test_override_scale", 1234.567, broadcast=True, archive=True, unit="kV", scale=1e6)
            
        print(self.get_dataset("test_mutate"))
        print(self.get_dataset_metadata("test_mutate"))
```    
output:

![testing-results](https://github.com/m-labs/artiq/assets/24266430/a8be2923-ebbb-445f-af41-dfb1dfdbf125)
ebase).

![testing-log](https://github.com/m-labs/artiq/assets/24266430/bdc5757d-b06c-475e-99be-35aa6f1fec85)


### Documentation Changes

Added docstrings for `get_dataset_metadata` and `set_dataset`.

Updated release notes migration script to make persistent database compatible with metadata.

### Git Logistics

- [x] Split your contribution into logically separate change
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:

4 additional PRs depend on this branch expanding the feature in:

- browser support
- applet support
- client support
- GUI dashboard create/edit dataset refactor

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.

