### PR TITLE
Add applet API to modify entries in experiment windows

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -27,7 +27,8 @@ Highlights:
 * Full Python 3.10 support.
 * Distributed DMA is now supported, allowing DMA to be run directly on satellites for corresponding
   RTIO events, increasing bandwidth in scenarios with heavy satellite usage.
-* API extensions have been implemented, enabling applets to directly modify datasets.
+* API extensions have been implemented, enabling applets to directly modify datasets and
+  experiment arguments/entry widget values.
 * Persistent datasets are now stored in a LMDB database for improved performance. PYON databases can
   be converted with the script below.
 
@@ -48,6 +49,8 @@ Breaking changes:
 * ``SimpleApplet`` now calls widget constructors with an additional ``ctl`` parameter for control
   operations, which includes dataset operations. It can be ignored if not needed. For an example usage,
   refer to the ``big_number.py`` applet.
+* The new ``ctl`` parameter in ``SimpleApplet`` now allows modification of current experiment arguments
+  or entry widget values.
 * ``SimpleApplet`` and ``TitleApplet`` now call ``data_changed`` with additional parameters. Wrapped widgets
   should refactor the function signature as seen below:
 ::

--- a/artiq/applets/simple.py
+++ b/artiq/applets/simple.py
@@ -37,6 +37,23 @@ class AppletControlIPC:
         mod = {"action": "append", "path": [key, 1], "x": value}
         self.ipc.update_dataset(mod)
 
+    def set_argument_value(self, expurl, arg_name, arg_value, **kwargs):
+        """Sets the value of a specified argument for a given experiment.
+
+        :param expurl: Experiment URL in the format ``repo:<experiment_name>``.
+        :param arg_name: Name of argument in the experiment.
+        :param arg_value: Value according to the type. Follows the same value
+            format as with the experiment arguments except for the following types:
+            ``EnumerationValue``: A string selecting a choice from the enum.
+            ``Scannable``: A string selecting the scan type to be the default
+            (e.g., ``ExplicitScan``.)
+        :param kwargs: Additional parameters for ``Scannable`` argument type.
+            Should be written in the following format:
+            (e.g., NoScan={"value": <number>, "repetitions": <number>})
+            Omitted entry will not be modified and will use the default value.
+        """
+        self.ipc.set_argument_value(expurl, arg_name, arg_value, **kwargs)
+
 
 class AppletControlRPC:
     def __init__(self, loop, dataset_ctl):
@@ -136,6 +153,13 @@ class AppletIPCClient(AsyncioChildComm):
     def update_dataset(self, mod):
         self.write_pyon({"action": "update_dataset",
                          "mod": mod})
+
+    def set_argument_value(self, expurl, arg_name, arg_value, **kwargs):
+        self.write_pyon({"action": "set_argument_value",
+                         "expurl": expurl,
+                         "arg_name": arg_name,
+                         "arg_value": arg_value,
+                         "kwargs": kwargs})
 
 
 class SimpleApplet:

--- a/artiq/frontend/artiq_dashboard.py
+++ b/artiq/frontend/artiq_dashboard.py
@@ -189,7 +189,7 @@ def main():
                                        rpc_clients["dataset_db"])
     smgr.register(d_datasets)
 
-    d_applets = applets_ccb.AppletsCCBDock(main_window,
+    d_applets = applets_ccb.AppletsCCBDock(main_window, expmgr,
                                            sub_clients["datasets"],
                                            rpc_clients["dataset_db"],
                                            extra_substitutes={

--- a/artiq/gui/entries.py
+++ b/artiq/gui/entries.py
@@ -14,9 +14,10 @@ logger = logging.getLogger(__name__)
 class StringEntry(QtWidgets.QLineEdit):
     def __init__(self, argument):
         QtWidgets.QLineEdit.__init__(self)
-        self.setText(argument["state"])
+        self.argument = argument
+        self.update_state()
         def update(text):
-            argument["state"] = text
+            self.argument["state"] = text
         self.textEdited.connect(update)
 
     @staticmethod
@@ -27,13 +28,18 @@ class StringEntry(QtWidgets.QLineEdit):
     def default_state(procdesc):
         return procdesc.get("default", "")
 
+    def update_state(self):
+        with QtCore.QSignalBlocker(self):
+            self.setText(self.argument["state"])
+
 
 class BooleanEntry(QtWidgets.QCheckBox):
     def __init__(self, argument):
         QtWidgets.QCheckBox.__init__(self)
-        self.setChecked(argument["state"])
+        self.argument = argument
+        self.update_state()
         def update(checked):
-            argument["state"] = bool(checked)
+            self.argument["state"] = bool(checked)
         self.stateChanged.connect(update)
 
     @staticmethod
@@ -44,17 +50,21 @@ class BooleanEntry(QtWidgets.QCheckBox):
     def default_state(procdesc):
         return procdesc.get("default", False)
 
+    def update_state(self):
+        with QtCore.QSignalBlocker(self):
+            self.setChecked(self.argument["state"])
+
 
 class EnumerationEntry(QtWidgets.QComboBox):
     def __init__(self, argument):
         QtWidgets.QComboBox.__init__(self)
         disable_scroll_wheel(self)
-        choices = argument["desc"]["choices"]
-        self.addItems(choices)
-        idx = choices.index(argument["state"])
-        self.setCurrentIndex(idx)
+        self.argument = argument
+        self.choices = argument["desc"]["choices"]
+        self.addItems(self.choices)
+        self.update_state()
         def update(index):
-            argument["state"] = choices[index]
+            self.argument["state"] = self.choices[index]
         self.currentIndexChanged.connect(update)
 
     @staticmethod
@@ -68,11 +78,20 @@ class EnumerationEntry(QtWidgets.QComboBox):
         else:
             return procdesc["choices"][0]
 
+    def update_state(self):
+        with QtCore.QSignalBlocker(self):
+            state = self.argument["state"]
+            if state in self.choices:
+                self.setCurrentIndex(self.choices.index(state))
+            else:
+                raise ValueError("Invalid EnumerationValue value")
+
 
 class NumberEntryInt(QtWidgets.QSpinBox):
     def __init__(self, argument):
         QtWidgets.QSpinBox.__init__(self)
         disable_scroll_wheel(self)
+        self.argument = argument
         procdesc = argument["desc"]
         self.setSingleStep(procdesc["step"])
         if procdesc["min"] is not None:
@@ -86,9 +105,9 @@ class NumberEntryInt(QtWidgets.QSpinBox):
         if procdesc["unit"]:
             self.setSuffix(" " + procdesc["unit"])
 
-        self.setValue(argument["state"])
+        self.update_state()
         def update(value):
-            argument["state"] = value
+            self.argument["state"] = value
         self.valueChanged.connect(update)
 
     @staticmethod
@@ -113,31 +132,36 @@ class NumberEntryInt(QtWidgets.QSpinBox):
                     return procdesc["max"]
             return 0
 
+    def update_state(self):
+        with QtCore.QSignalBlocker(self):
+            self.setValue(self.argument["state"])
+
 
 class NumberEntryFloat(ScientificSpinBox):
     def __init__(self, argument):
         ScientificSpinBox.__init__(self)
         disable_scroll_wheel(self)
+        self.argument = argument
         procdesc = argument["desc"]
-        scale = procdesc["scale"]
+        self.scale = procdesc["scale"]
         self.setDecimals(procdesc["precision"])
         self.setSigFigs()
-        self.setSingleStep(procdesc["step"]/scale)
+        self.setSingleStep(procdesc["step"]/self.scale)
         self.setRelativeStep()
         if procdesc["min"] is not None:
-            self.setMinimum(procdesc["min"]/scale)
+            self.setMinimum(procdesc["min"]/self.scale)
         else:
             self.setMinimum(float("-inf"))
         if procdesc["max"] is not None:
-            self.setMaximum(procdesc["max"]/scale)
+            self.setMaximum(procdesc["max"]/self.scale)
         else:
             self.setMaximum(float("inf"))
         if procdesc["unit"]:
             self.setSuffix(" " + procdesc["unit"])
 
-        self.setValue(argument["state"]/scale)
+        self.update_state()
         def update(value):
-            argument["state"] = value*scale
+            argument["state"] = value*self.scale
         self.valueChanged.connect(update)
 
     @staticmethod
@@ -151,34 +175,37 @@ class NumberEntryFloat(ScientificSpinBox):
         else:
             return 0.0
 
+    def update_state(self):
+        with QtCore.QSignalBlocker(self):
+            self.setValue(self.argument["state"]/self.scale)
+
 
 class _NoScan(LayoutWidget):
     def __init__(self, procdesc, state):
         LayoutWidget.__init__(self)
 
-        scale = procdesc["scale"]
+        self.scale = procdesc["scale"]
         self.value = ScientificSpinBox()
         disable_scroll_wheel(self.value)
         self.value.setDecimals(procdesc["precision"])
         self.value.setSigFigs()
         if procdesc["global_min"] is not None:
-            self.value.setMinimum(procdesc["global_min"]/scale)
+            self.value.setMinimum(procdesc["global_min"]/self.scale)
         else:
             self.value.setMinimum(float("-inf"))
         if procdesc["global_max"] is not None:
-            self.value.setMaximum(procdesc["global_max"]/scale)
+            self.value.setMaximum(procdesc["global_max"]/self.scale)
         else:
             self.value.setMaximum(float("inf"))
-        self.value.setSingleStep(procdesc["global_step"]/scale)
+        self.value.setSingleStep(procdesc["global_step"]/self.scale)
         self.value.setRelativeStep()
         if procdesc["unit"]:
             self.value.setSuffix(" " + procdesc["unit"])
         self.addWidget(QtWidgets.QLabel("Value:"), 0, 0)
         self.addWidget(self.value, 0, 1)
 
-        self.value.setValue(state["value"]/scale)
         def update(value):
-            state["value"] = value*scale
+            state["value"] = value*self.scale
         self.value.valueChanged.connect(update)
 
         self.repetitions = QtWidgets.QSpinBox()
@@ -188,31 +215,35 @@ class _NoScan(LayoutWidget):
         self.addWidget(QtWidgets.QLabel("Repetitions:"), 1, 0)
         self.addWidget(self.repetitions, 1, 1)
 
-        self.repetitions.setValue(state["repetitions"])
-
+        self.update_state(state)
         def update_repetitions(value):
             state["repetitions"] = value
         self.repetitions.valueChanged.connect(update_repetitions)
+
+    def update_state(self, state):
+        with QtCore.QSignalBlocker(self):
+            self.value.setValue(state["value"]/self.scale)
+            self.repetitions.setValue(state["repetitions"])
 
 
 class _RangeScan(LayoutWidget):
     def __init__(self, procdesc, state):
         LayoutWidget.__init__(self)
 
-        scale = procdesc["scale"]
+        self.scale = procdesc["scale"]
 
         def apply_properties(widget):
             widget.setDecimals(procdesc["precision"])
             if procdesc["global_min"] is not None:
-                widget.setMinimum(procdesc["global_min"]/scale)
+                widget.setMinimum(procdesc["global_min"]/self.scale)
             else:
                 widget.setMinimum(float("-inf"))
             if procdesc["global_max"] is not None:
-                widget.setMaximum(procdesc["global_max"]/scale)
+                widget.setMaximum(procdesc["global_max"]/self.scale)
             else:
                 widget.setMaximum(float("inf"))
             if procdesc["global_step"] is not None:
-                widget.setSingleStep(procdesc["global_step"]/scale)
+                widget.setSingleStep(procdesc["global_step"]/self.scale)
             if procdesc["unit"]:
                 widget.setSuffix(" " + procdesc["unit"])
 
@@ -220,142 +251,154 @@ class _RangeScan(LayoutWidget):
         disable_scroll_wheel(scanner)
         self.addWidget(scanner, 0, 0, -1, 1)
 
-        start = ScientificSpinBox()
-        start.setStyleSheet("QDoubleSpinBox {color:blue}")
-        start.setMinimumSize(110, 0)
-        start.setSizePolicy(QtWidgets.QSizePolicy(
+        self.start = ScientificSpinBox()
+        self.start.setStyleSheet("QDoubleSpinBox {color:blue}")
+        self.start.setMinimumSize(110, 0)
+        self.start.setSizePolicy(QtWidgets.QSizePolicy(
             QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed))
-        disable_scroll_wheel(start)
-        self.addWidget(start, 0, 1)
+        disable_scroll_wheel(self.start)
+        self.addWidget(self.start, 0, 1)
 
-        npoints = QtWidgets.QSpinBox()
-        npoints.setMinimum(1)
-        npoints.setMaximum((1 << 31) - 1)
-        disable_scroll_wheel(npoints)
-        self.addWidget(npoints, 1, 1)
+        self.npoints = QtWidgets.QSpinBox()
+        self.npoints.setMinimum(1)
+        self.npoints.setMaximum((1 << 31) - 1)
+        disable_scroll_wheel(self.npoints)
+        self.addWidget(self.npoints, 1, 1)
 
-        stop = ScientificSpinBox()
-        stop.setStyleSheet("QDoubleSpinBox {color:red}")
-        stop.setMinimumSize(110, 0)
-        disable_scroll_wheel(stop)
-        self.addWidget(stop, 2, 1)
+        self.stop = ScientificSpinBox()
+        self.stop.setStyleSheet("QDoubleSpinBox {color:red}")
+        self.stop.setMinimumSize(110, 0)
+        disable_scroll_wheel(self.stop)
+        self.addWidget(self.stop, 2, 1)
 
-        randomize = QtWidgets.QCheckBox("Randomize")
-        self.addWidget(randomize, 3, 1)
+        self.randomize = QtWidgets.QCheckBox("Randomize")
+        self.addWidget(self.randomize, 3, 1)
 
-        apply_properties(start)
-        start.setSigFigs()
-        start.setRelativeStep()
-        apply_properties(stop)
-        stop.setSigFigs()
-        stop.setRelativeStep()
+        apply_properties(self.start)
+        self.start.setSigFigs()
+        self.start.setRelativeStep()
+        apply_properties(self.stop)
+        self.stop.setSigFigs()
+        self.stop.setRelativeStep()
         apply_properties(scanner)
 
+        self.update_state(state)
         def update_start(value):
-            state["start"] = value*scale
+            state["start"] = value*self.scale
             scanner.setStart(value)
-            if start.value() != value:
-                start.setValue(value)
+            if self.start.value() != value:
+                self.start.setValue(value)
 
         def update_stop(value):
-            state["stop"] = value*scale
+            state["stop"] = value*self.scale
             scanner.setStop(value)
-            if stop.value() != value:
-                stop.setValue(value)
+            if self.stop.value() != value:
+                self.stop.setValue(value)
 
         def update_npoints(value):
             state["npoints"] = value
             scanner.setNum(value)
-            if npoints.value() != value:
-                npoints.setValue(value)
+            if self.npoints.value() != value:
+                self.npoints.setValue(value)
 
         def update_randomize(value):
             state["randomize"] = value
-            randomize.setChecked(value)
+            self.randomize.setChecked(value)
 
         scanner.startChanged.connect(update_start)
         scanner.numChanged.connect(update_npoints)
         scanner.stopChanged.connect(update_stop)
-        start.valueChanged.connect(update_start)
-        npoints.valueChanged.connect(update_npoints)
-        stop.valueChanged.connect(update_stop)
-        randomize.stateChanged.connect(update_randomize)
-        scanner.setStart(state["start"]/scale)
+        self.start.valueChanged.connect(update_start)
+        self.npoints.valueChanged.connect(update_npoints)
+        self.stop.valueChanged.connect(update_stop)
+        self.randomize.stateChanged.connect(update_randomize)
+        scanner.setStart(state["start"]/self.scale)
         scanner.setNum(state["npoints"])
-        scanner.setStop(state["stop"]/scale)
-        randomize.setChecked(state["randomize"])
+        scanner.setStop(state["stop"]/self.scale)
+        self.randomize.setChecked(state["randomize"])
+
+    def update_state(self, state):
+        with QtCore.QSignalBlocker(self):
+            self.start.setValue(state["start"]/self.scale)
+            self.npoints.setValue(state["npoints"])
+            self.stop.setValue(state["stop"]/self.scale)
+            self.randomize.setChecked(state["randomize"])
 
 
 class _CenterScan(LayoutWidget):
     def __init__(self, procdesc, state):
         LayoutWidget.__init__(self)
 
-        scale = procdesc["scale"]
+        self.scale = procdesc["scale"]
 
         def apply_properties(widget):
             widget.setDecimals(procdesc["precision"])
             if procdesc["global_min"] is not None:
-                widget.setMinimum(procdesc["global_min"]/scale)
+                widget.setMinimum(procdesc["global_min"]/self.scale)
             else:
                 widget.setMinimum(float("-inf"))
             if procdesc["global_max"] is not None:
-                widget.setMaximum(procdesc["global_max"]/scale)
+                widget.setMaximum(procdesc["global_max"]/self.scale)
             else:
                 widget.setMaximum(float("inf"))
             if procdesc["global_step"] is not None:
-                widget.setSingleStep(procdesc["global_step"]/scale)
+                widget.setSingleStep(procdesc["global_step"]/self.scale)
             if procdesc["unit"]:
                 widget.setSuffix(" " + procdesc["unit"])
 
-        center = ScientificSpinBox()
-        disable_scroll_wheel(center)
-        apply_properties(center)
-        center.setSigFigs()
-        center.setRelativeStep()
-        center.setValue(state["center"]/scale)
-        self.addWidget(center, 0, 1)
+        self.center = ScientificSpinBox()
+        disable_scroll_wheel(self.center)
+        apply_properties(self.center)
+        self.center.setSigFigs()
+        self.center.setRelativeStep()
+        self.addWidget(self.center, 0, 1)
         self.addWidget(QtWidgets.QLabel("Center:"), 0, 0)
 
-        span = ScientificSpinBox()
-        disable_scroll_wheel(span)
-        apply_properties(span)
-        span.setSigFigs()
-        span.setRelativeStep()
-        span.setMinimum(0)
-        span.setValue(state["span"]/scale)
-        self.addWidget(span, 1, 1)
+        self.span = ScientificSpinBox()
+        disable_scroll_wheel(self.span)
+        apply_properties(self.span)
+        self.span.setSigFigs()
+        self.span.setRelativeStep()
+        self.span.setMinimum(0)
+        self.addWidget(self.span, 1, 1)
         self.addWidget(QtWidgets.QLabel("Span:"), 1, 0)
 
-        step = ScientificSpinBox()
-        disable_scroll_wheel(step)
-        apply_properties(step)
-        step.setSigFigs()
-        step.setRelativeStep()
-        step.setMinimum(0)
-        step.setValue(state["step"]/scale)
-        self.addWidget(step, 2, 1)
+        self.step = ScientificSpinBox()
+        disable_scroll_wheel(self.step)
+        apply_properties(self.step)
+        self.step.setSigFigs()
+        self.step.setRelativeStep()
+        self.step.setMinimum(0)
+        self.addWidget(self.step, 2, 1)
         self.addWidget(QtWidgets.QLabel("Step:"), 2, 0)
 
-        randomize = QtWidgets.QCheckBox("Randomize")
-        self.addWidget(randomize, 3, 1)
-        randomize.setChecked(state["randomize"])
+        self.randomize = QtWidgets.QCheckBox("Randomize")
+        self.addWidget(self.randomize, 3, 1)
 
+        self.update_state(state)
         def update_center(value):
-            state["center"] = value*scale
+            state["center"] = value*self.scale
 
         def update_span(value):
-            state["span"] = value*scale
+            state["span"] = value*self.scale
 
         def update_step(value):
-            state["step"] = value*scale
+            state["step"] = value*self.scale
 
         def update_randomize(value):
             state["randomize"] = value
 
-        center.valueChanged.connect(update_center)
-        span.valueChanged.connect(update_span)
-        step.valueChanged.connect(update_step)
-        randomize.stateChanged.connect(update_randomize)
+        self.center.valueChanged.connect(update_center)
+        self.span.valueChanged.connect(update_span)
+        self.step.valueChanged.connect(update_step)
+        self.randomize.stateChanged.connect(update_randomize)
+
+    def update_state(self, state):
+        with QtCore.QSignalBlocker(self):
+            self.center.setValue(state["center"]/self.scale)
+            self.span.setValue(state["span"]/self.scale)
+            self.step.setValue(state["step"]/self.scale)
+            self.randomize.setChecked(state["randomize"])
 
 
 class _ExplicitScan(LayoutWidget):
@@ -370,13 +413,17 @@ class _ExplicitScan(LayoutWidget):
         regexp = "(float)?( +float)* *".replace("float", float_regexp)
         self.value.setValidator(QtGui.QRegExpValidator(QtCore.QRegExp(regexp)))
 
-        self.value.setText(" ".join([str(x) for x in state["sequence"]]))
+        self.update_state(state)
         def update(text):
             if self.value.hasAcceptableInput():
                 state["sequence"] = [float(x) for x in text.split()]
         self.value.textEdited.connect(update)
 
+    def update_state(self, state):
+        with QtCore.QSignalBlocker(self):
+            self.value.setText(" ".join([str(x) for x in state["sequence"]]))
 
+    
 class ScanEntry(LayoutWidget):
     def __init__(self, argument):
         LayoutWidget.__init__(self)
@@ -386,12 +433,12 @@ class ScanEntry(LayoutWidget):
         self.addWidget(self.stack, 1, 0, colspan=4)
 
         procdesc = argument["desc"]
-        state = argument["state"]
+        self.state = argument["state"]
         self.widgets = OrderedDict()
-        self.widgets["NoScan"] = _NoScan(procdesc, state["NoScan"])
-        self.widgets["RangeScan"] = _RangeScan(procdesc, state["RangeScan"])
-        self.widgets["CenterScan"] = _CenterScan(procdesc, state["CenterScan"])
-        self.widgets["ExplicitScan"] = _ExplicitScan(state["ExplicitScan"])
+        self.widgets["NoScan"] = _NoScan(procdesc, self.state["NoScan"])
+        self.widgets["RangeScan"] = _RangeScan(procdesc, self.state["RangeScan"])
+        self.widgets["CenterScan"] = _CenterScan(procdesc, self.state["CenterScan"])
+        self.widgets["ExplicitScan"] = _ExplicitScan(self.state["ExplicitScan"])
         for widget in self.widgets.values():
             self.stack.addWidget(widget)
 
@@ -405,13 +452,17 @@ class ScanEntry(LayoutWidget):
             self.addWidget(b, 0, n)
             scan_type.addButton(b)
             b.toggled.connect(self._scan_type_toggled)
-
-        selected = argument["state"]["selected"]
-        self.radiobuttons[selected].setChecked(True)
+        self.update_state()
 
     def disable(self):
         self.radiobuttons["NoScan"].setChecked(True)
         self.widgets["NoScan"].repetitions.setValue(1)
+
+    def update_state(self):
+        with QtCore.QSignalBlocker(self):
+            for ty in ["NoScan", "RangeScan", "CenterScan", "ExplicitScan"]:
+                self.widgets[ty].update_state(self.state[ty])
+            self.radiobuttons[self.state["selected"]].setChecked(True)
 
     @staticmethod
     def state_to_value(state):


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
Add applet API extension `set_argument_value` to modify current values of entry widgets in the experiment window. Works when a target experiment dock is currently open or closed.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.

#### Testing
- [x] Test `NumberValue` type entry (Int, Float)
- [x] Test `PYONValue` type entry
- [x] Test `BooleanValue` type entry
- [x] Test `EnumerationValue` type entry
- [x] Test `StringValue` type entry
- [x] Test `Scannable` type entry (NoScan, RangeScan, CenterScan, ExplicitScan)
- [x] Test update values when dock is open
- [x] Test update values when dock is close
- [x] Test with the following script targeting `no_hardware/arguments_demo.py`:
```
from PyQt5 import QtWidgets

from artiq.applets.simple import SimpleApplet


class ArgumentModifier(QtWidgets.QLabel):
    def __init__(self, args, ctl):
        QtWidgets.QLabel.__init__(self)
        self.ctl = ctl
        self.modify_argument()

    def modify_argument(self):
        self.ctl.set_argument_value("repo:ArgumentsDemo", "pyon_value", "123")
        self.ctl.set_argument_value("repo:ArgumentsDemo", "number", 123e-6)
        self.ctl.set_argument_value("repo:ArgumentsDemo", "integer", 123)
        self.ctl.set_argument_value("repo:ArgumentsDemo", "string", "Hi")
        self.ctl.set_argument_value("repo:ArgumentsDemo", "boolean", False)
        self.ctl.set_argument_value("repo:ArgumentsDemo", "enum", "quux")
        self.ctl.set_argument_value("repo:ArgumentsDemo", "scan", "ExplicitScan", 
                                    NoScan={"value": 123, "repetitions": 2}, 
                                    RangeScan={"start": 200, "stop": 400, "npoints": 5, "randomize": True},
                                    CenterScan={"center": 0, "span": 200,"step": 5, "randomize": True,},
                                    ExplicitScan={"sequence": [1, 2, 3]})
  
    def data_changed(self, value, metadata, persist, mods):
        pass


def main():
    applet = SimpleApplet(ArgumentModifier)
    applet.run()

if __name__ == "__main__":
    main()
```
Output:
![updated](https://github.com/m-labs/artiq/assets/77672306/d0e2485c-03ab-42cc-96da-e6720eb2dad8)
Click on Recompute all arguments to see default values.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
