### PR TITLE
kasli-soc: Fix of System Clock Switch Failure during System Startup

### DIFF
--- a/artiq/gateware/drtio/transceiver/gtx_7series.py
+++ b/artiq/gateware/drtio/transceiver/gtx_7series.py
@@ -74,6 +74,8 @@ class GTX_20X(Module):
                 p_CPLL_REFCLK_DIV=1,
                 p_RXOUT_DIV=2,
                 p_TXOUT_DIV=2,
+                p_CPLL_INIT_CFG=0x00001E,
+                p_CPLL_LOCK_CFG=0x01C0,
                 i_CPLLRESET=cpllreset,
                 i_CPLLPD=cpllreset,
                 o_CPLLLOCK=cplllock,
@@ -320,7 +322,7 @@ class GTX(Module, TransceiverInterface):
 
         # stable_clkin resets after reboot since it's in SYS domain
         # still need to keep clk_enable high after this
-        self.sync.bootstrap += clk_enable.eq(self.stable_clkin.storage | self.gtxs[0].tx_init.done)
+        self.sync.bootstrap += clk_enable.eq(self.stable_clkin.storage | self.gtxs[0].tx_init.cplllock)
 
         # Connect slave i's `rtio_rx` clock to `rtio_rxi` clock
         for i in range(nchannels):

--- a/artiq/gateware/drtio/transceiver/gtx_7series_init.py
+++ b/artiq/gateware/drtio/transceiver/gtx_7series_init.py
@@ -110,9 +110,9 @@ class GTXInit(Module):
 
         startup_fsm.act("INITIAL",
             startup_timer.wait.eq(1),
-            If(startup_timer.done & self.stable_clkin, NextState("RESET_ALL"))
+            If(startup_timer.done & self.stable_clkin, NextState("RESET_PLL"))
         )
-        startup_fsm.act("RESET_ALL",
+        startup_fsm.act("RESET_PLL",
             gtXxreset.eq(1),
             self.cpllreset.eq(1),
             pll_reset_timer.wait.eq(1),
@@ -120,7 +120,12 @@ class GTXInit(Module):
         )
         startup_fsm.act("RELEASE_PLL_RESET",
             gtXxreset.eq(1),
-            If(cplllock, NextState("RELEASE_GTH_RESET"))
+            If(cplllock, NextState("RESET_GTH"))
+        )
+        startup_fsm.act("RESET_GTH",
+            gtXxreset.eq(1),
+            pll_reset_timer.wait.eq(1),
+            If(pll_reset_timer.done, NextState("RELEASE_GTH_RESET"))
         )
         # Release GTX reset and wait for GTX resetdone
         # (from UG476, GTX is reset on falling edge
@@ -229,7 +234,7 @@ class GTXInit(Module):
         startup_fsm.act("READY",
             Xxuserrdy.eq(1),
             self.done.eq(1),
-            If(self.restart, NextState("RESET_ALL"))
+            If(self.restart, NextState("RESET_GTH"))
         )
 
 


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
Fix of system clock switch start up failure

This pull request is derived from #2122. Changes are reviewed and redundant code is removed after testing. The author's explanations on the code in the conversation are verified. Below explains the changes.

### Investigation of the Problem:
The error occurs when the system is switching from the bootstrap clock to an external reference clock generated by Si5324. The Si5324 clock is used by GTX transceiver and also the rest of PL. Here is how the problem occurs:

1. Si5324 is configured by PS and then waits for the lock.

2. After lock is confirmed, PS writes High to "stable_clkin" CSR to start running the GTX Transceiver Initialization Flow. Note that stable_clkin CSR is connected to the enable pin of input clock buffer (IBUFDS_GTE2) driving the PLL of GTX transceiver. The enable pin is controlled by OR(stable_clkin, tx_init.done).

3. Before reaching the end of the GTX Transceiver initialization,  "stable_clkin" CSR is reset to zero. As a result, the GTX input clock buffer is disabled and the initialization procedures of the GTX transceiver cannot be completed.

4. As the reset of stable_clkin happens before the GTX Transceiver has finished initializing, IBUFDS_GTE2 gets disabled indefinitely. Thus, PS detects that the system clock is not switched correctly.

### Explanations to the Changes
1.  IBUFDS_GTE2 enable pin is now driven by OR( stable_clkin, tx_init.cplllock) instead of OR( stable_clking, tx_init.done)

- This allows the input clock buffer to be held enabled even after stable_clkin CSR is reset.

2. Resetting of PLL and GTH are being separated into two state RESET_PLL and RESET_GTH in the Init FSM. 

- Since RX side of GTX Transceiver has a "BruteforceClockAligner" module which keeps restarting itself for clock alignment, due to the previous change, only the GTX Transceiver section should be reset in order to maintain the system clock.

- The reset timing of RESET_GTH state is complied with UG476 "GTX/GTH Transceiver TX Reset in Response to GTTXRESET Pulse" for the BruteforceClockAligner module to be used. As the timing requirement is the same as PLL reset, PLL Timer is reused instead of creating a new timer.

3. CPLL Parameters are added

- For some reasons, only after p_CPLL_INIT_CFG, p_CPLL_LOCK_CFG are changed, the PLL is able to lock the clock. There is no documentation for these two parameters. But, in UG476 states that these two parameters should not be a zero value and should be generated by the wizard.

- These parameters are retrieved from the IBERT example design. Wizard was used to try generating the right parameters without using the example. However, the generated parameters could not get the system clock to switch correctly.

### Test Methodology
A functional test is conducted. The pass requirements are:
- The system clock switches from bootstrap clock to Si5324 clock successfully.
- GTX Transceiver can function correctly.

The program is tested on this combination of commit: artiq 833fd87 and artiq-zynq [ee438105b2](https://git.m-labs.hk/M-Labs/artiq-zynq/commit/ee438105b26555b80b39a3acadaab5c3d9d1dd48) 

On Kasli-Soc Master, Satellite, Demo and Kasli Platform

Kasli: System clock is switched successfully.
Kasli-Soc Demo: System clock is switched successfully.
Kasli-Soc Master: Successful connection of DRTIO to the satellite on all of the SFP connector(SFP0 .. SFP3).
Kasli-Soc Satellite: Successful connection to another satellite device as a repeater.

### Related Issue
It is not possible to switch the system clock when internal termination is enabled on input clock buffer IBUFDS_GTE2 after these two commit on artiq 22e2514 and artiq-zynq  [63594d7e3d](https://git.m-labs.hk/M-Labs/artiq-zynq/commit/63594d7e3d66bff93aa58bf77256a50b6c15ac72). This issue is being reported on the help desk on June 06, 2023

For kasli-soc, system clock switch may fail during system startup on demo, master and satellite version. Whether the system clock switch fails or not is not consistent across the commit history.

For example, for the commit combination: artiq 22e2514 and artiq-zynq  [63594d7e3d](https://git.m-labs.hk/M-Labs/artiq-zynq/commit/63594d7e3d66bff93aa58bf77256a50b6c15ac72), only satellite version fails to switch the system clock. 

However, for the commit combination: artiq 833fd87 and artiq-zynq [ee438105b2](https://git.m-labs.hk/M-Labs/artiq-zynq/commit/ee438105b26555b80b39a3acadaab5c3d9d1dd48) all demo, master and satellite version experience system clock switch failure during startup.

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.