### PR TITLE
kasli-soc: System Clock Switch Failure Fix (Backport to Release 7)

### DIFF
--- a/artiq/gateware/drtio/transceiver/gtx_7series_init.py
+++ b/artiq/gateware/drtio/transceiver/gtx_7series_init.py
@@ -108,9 +108,9 @@ class GTXInit(Module):
 
         startup_fsm.act("INITIAL",
             startup_timer.wait.eq(1),
-            If(startup_timer.done, NextState("RESET_ALL"))
+            If(startup_timer.done, NextState("RESET_PLL"))
         )
-        startup_fsm.act("RESET_ALL",
+        startup_fsm.act("RESET_PLL",
             gtXxreset.eq(1),
             self.cpllreset.eq(1),
             pll_reset_timer.wait.eq(1),
@@ -118,7 +118,12 @@ class GTXInit(Module):
         )
         startup_fsm.act("RELEASE_PLL_RESET",
             gtXxreset.eq(1),
-            If(cplllock, NextState("RELEASE_GTX_RESET"))
+            If(cplllock, NextState("RESET_GTX"))
+        )
+        startup_fsm.act("RESET_GTX",
+            gtXxreset.eq(1),
+            pll_reset_timer.wait.eq(1),
+            If(pll_reset_timer.done, NextState("RELEASE_GTX_RESET"))
         )
         # Release GTX reset and wait for GTX resetdone
         # (from UG476, GTX is reset on falling edge
@@ -227,7 +232,7 @@ class GTXInit(Module):
         startup_fsm.act("READY",
             Xxuserrdy.eq(1),
             self.done.eq(1),
-            If(self.restart, NextState("RESET_ALL"))
+            If(self.restart, NextState("RESET_GTX"))
         )
 
 


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Problem Description
The changes on the IBUFDS_GTE2 parameters on d6704d30e9380272064b49c1111a29eb1b6afa45 combine with artiq-zynq commit [832a861477](https://git.m-labs.hk/M-Labs/artiq-zynq/commit/832a861477fc00fdc7a11842fdc9fe76aa660fc7) cause the master not being able to establish connection with satellite but with the rest of the system functioning correctly. This issue is related to PR #2128.

## Description of Changes
The changes in PR #2128 are backported to fix the problem. For detailed explanations of the changes, please refers to PR #2128. Please note that current build of gateware does not switch the clock source at the startup of operations unlike PR #2128.

Below shows the summary of code modified.
- CPLL Parameters are added. 
- CEB signal of IBUFDS_GTE2 is asserted by NOT(OR(stable_clkin, GTX CPLL Locked))
- Modify the GTX Init FSM so that the PLL Reset and GTX Reset are done in two seperated state.
- Restart of GTX module now only resets GTX transceiver.

### Test Methodology
A functional test is conducted. The pass requirement is:
- GTX Transceiver can function correctly

The code is tested on artiq-zynq commit [832a861477](https://git.m-labs.hk/M-Labs/artiq-zynq/commit/832a861477fc00fdc7a11842fdc9fe76aa660fc7) 

Kasli-Soc Master: 
- Successfully connect with satellite. Master can ping the satellite

Kasli-Soc Satellite: 
- Successfully establish uplink with satellite and calibrate its own clock
- Able to fall back to the local oscillator clock when uplink connection is lost

Kasli-Soc Demo:
- Ethernet uplink is established

### Related PR
(Refers to PR #2128)

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.