### PR TITLE
fix set_dataset and refactor data_changed in applets

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -48,6 +48,26 @@ Breaking changes:
 * ``SimpleApplet`` now calls widget constructors with an additional ``ctl`` parameter for control
   operations, which includes dataset operations. It can be ignored if not needed. For an example usage,
   refer to the ``big_number.py`` applet.
+* ``SimpleApplet`` and ``TitleApplet`` now call ``data_changed`` with additional parameters. Wrapped widgets
+  should refactor the function signature as seen below:
+::
+
+  # SimpleApplet
+  def data_changed(self, value, metadata, persist, mods)
+  # SimpleApplet (old version)
+  def data_changed(self, data, mods)
+  # TitleApplet
+  def data_changed(self, value, metadata, persist, mods, title)
+  # TitleApplet (old version)
+  def data_changed(self, data, mods, title)
+
+Old syntax should be replaced with the form shown on the right.
+::
+
+  data[key][0] ==> persist[key]
+  data[key][1] ==> value[key]
+  data[key][2] ==> metadata[key]
+
 
 
 ARTIQ-7

--- a/artiq/applets/big_number.py
+++ b/artiq/applets/big_number.py
@@ -61,9 +61,9 @@ class NumberWidget(QtWidgets.QStackedWidget):
     def cancel_edit(self):
         self.setCurrentWidget(self.lcd_widget)
 
-    def data_changed(self, data, mods):
+    def data_changed(self, value, metadata, persist, mods):
         try:
-            n = float(data[self.dataset_name][1])
+            n = float(value[self.dataset_name])
         except (KeyError, ValueError, TypeError):
             n = "---"
         self.lcd_widget.display(n)

--- a/artiq/applets/image.py
+++ b/artiq/applets/image.py
@@ -11,9 +11,9 @@ class Image(pyqtgraph.ImageView):
         pyqtgraph.ImageView.__init__(self)
         self.args = args
 
-    def data_changed(self, data, mods):
+    def data_changed(self, value, metadata, persist, mods):
         try:
-            img = data[self.args.img][1]
+            img = value[self.args.img]
         except KeyError:
             return
         self.setImage(img)

--- a/artiq/applets/plot_hist.py
+++ b/artiq/applets/plot_hist.py
@@ -15,13 +15,13 @@ class HistogramPlot(pyqtgraph.PlotWidget):
         self.timer.setSingleShot(True)
         self.timer.timeout.connect(self.length_warning)
 
-    def data_changed(self, data, mods, title):
+    def data_changed(self, value, metadata, persist, mods, title):
         try:
-            y = data[self.args.y][1]
+            y = value[self.args.y]
             if self.args.x is None:
                 x = None
             else:
-                x = data[self.args.x][1]
+                x = value[self.args.x]
         except KeyError:
             return
         if x is None:

--- a/artiq/applets/plot_xy.py
+++ b/artiq/applets/plot_xy.py
@@ -19,16 +19,16 @@ class XYPlot(pyqtgraph.PlotWidget):
                          'Error bars': False,
                          'Fit values': False}
 
-    def data_changed(self, data, mods, title):
+    def data_changed(self, value, metadata, persist, mods, title):
         try:
-            y = data[self.args.y][1]
+            y = value[self.args.y]
         except KeyError:
             return
-        x = data.get(self.args.x, (False, None))[1]
+        x = value.get(self.args.x, (False, None))
         if x is None:
             x = np.arange(len(y))
-        error = data.get(self.args.error, (False, None))[1]
-        fit = data.get(self.args.fit, (False, None))[1]
+        error = value.get(self.args.error, (False, None))
+        fit = value.get(self.args.fit, (False, None))
 
         if not len(y) or len(y) != len(x):
             self.mismatch['X values'] = True

--- a/artiq/applets/plot_xy_hist.py
+++ b/artiq/applets/plot_xy_hist.py
@@ -124,11 +124,11 @@ class XYHistPlot(QtWidgets.QSplitter):
                 return False
         return True
 
-    def data_changed(self, data, mods):
+    def data_changed(self, value, metadata, persist, mods):
         try:
-            xs = data[self.args.xs][1]
-            histogram_bins = data[self.args.histogram_bins][1]
-            histograms_counts = data[self.args.histograms_counts][1]
+            xs = value[self.args.xs]
+            histogram_bins = value[self.args.histogram_bins]
+            histograms_counts = value[self.args.histograms_counts]
         except KeyError:
             return
         if len(xs) != histograms_counts.shape[0]:

--- a/artiq/applets/progress_bar.py
+++ b/artiq/applets/progress_bar.py
@@ -12,12 +12,12 @@ class ProgressWidget(QtWidgets.QProgressBar):
         self.setMaximum(args.max)
         self.dataset_value = args.value
 
-    def data_changed(self, data, mods):
+    def data_changed(self, value, metadata, persist, mods):
         try:
-            value = round(data[self.dataset_value][1])
+            val = round(value[self.dataset_value])
         except (KeyError, ValueError, TypeError):
-            value = 0
-        self.setValue(value)
+            val = 0
+        self.setValue(val)
 
 
 

--- a/artiq/applets/simple.py
+++ b/artiq/applets/simple.py
@@ -19,8 +19,15 @@ class AppletControlIPC:
     def __init__(self, ipc):
         self.ipc = ipc
 
-    def set_dataset(self, key, value, persist=None):
-        self.ipc.set_dataset(key, value, persist)
+    def set_dataset(self, key, value, unit=None, scale=None, precision=None, persist=None):
+        metadata = {}
+        if unit is not None:
+            metadata["unit"] = unit
+        if scale is not None:
+            metadata["scale"] = scale
+        if precision is not None:
+            metadata["precision"] = precision
+        self.ipc.set_dataset(key, value, metadata, persist)
 
     def mutate_dataset(self, key, index, value):
         mod = {"action": "setitem", "path": [key, 1], "key": index, "value": value}
@@ -112,10 +119,11 @@ class AppletIPCClient(AsyncioChildComm):
         self.mod_cb = mod_cb
         self.listen_task = loop.create_task(self.listen())
 
-    def set_dataset(self, key, value, persist=None):
+    def set_dataset(self, key, value, metadata, persist=None):
         self.write_pyon({"action": "set_dataset",
                          "key": key,
                          "value": value,
+                         "metadata": metadata,
                          "persist": persist})
 
     def update_dataset(self, mod):

--- a/artiq/applets/simple.py
+++ b/artiq/applets/simple.py
@@ -364,4 +364,9 @@ class TitleApplet(SimpleApplet):
                 title = self.args.title
         else:
             title = None
-        self.main_widget.data_changed(data, mod_buffer, title)
+        persist = dict()
+        value = dict()
+        metadata = dict()
+        for k, d in data.items():
+            persist[k], value[k], metadata[k] = d
+        self.main_widget.data_changed(value, metadata, persist, mod_buffer, title)

--- a/artiq/applets/simple.py
+++ b/artiq/applets/simple.py
@@ -270,7 +270,12 @@ class SimpleApplet:
             return False
 
     def emit_data_changed(self, data, mod_buffer):
-        self.main_widget.data_changed(data, mod_buffer)
+        persist = dict()
+        value = dict()
+        metadata = dict()
+        for k, d in data.items():
+            persist[k], value[k], metadata[k] = d
+        self.main_widget.data_changed(value, metadata, persist, mod_buffer)
 
     def flush_mod_buffer(self):
         self.emit_data_changed(self.data, self.mod_buffer)

--- a/artiq/applets/simple.py
+++ b/artiq/applets/simple.py
@@ -49,8 +49,15 @@ class AppletControlRPC:
         self.background_tasks.add(task)
         task.add_done_callback(self.background_tasks.discard)
 
-    def set_dataset(self, key, value, persist=None):
-        self._background(self.dataset_ctl.set, key, value, persist)
+    def set_dataset(self, key, value, unit=None, scale=None, precision=None, persist=None):
+        metadata = {}
+        if unit is not None:
+            metadata["unit"] = unit
+        if scale is not None:
+            metadata["scale"] = scale
+        if precision is not None:
+            metadata["precision"] = precision
+        self._background(self.dataset_ctl.set, key, value, metadata=metadata, persist=persist)
 
     def mutate_dataset(self, key, index, value):
         mod = {"action": "setitem", "path": [key, 1], "key": index, "value": value}

--- a/artiq/gui/applets.py
+++ b/artiq/gui/applets.py
@@ -80,7 +80,7 @@ class AppletIPCServer(AsyncioParentComm):
                                 self.dataset_sub.model.backing_store)
                             self.write_pyon({"action": "mod", "mod": mod})
                     elif action == "set_dataset":
-                        await self.dataset_ctl.set(obj["key"], obj["value"], obj["persist"])
+                        await self.dataset_ctl.set(obj["key"], obj["value"], metadata=obj["metadata"], persist=obj["persist"])
                     elif action == "update_dataset":
                         await self.dataset_ctl.update(obj["mod"])
                     else:


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

1. Refactored `set_dataset` in applets to work with dataset metadata (unit, scale, precision). From #2126. 
2. Altered `data_changed` signature for widgets wrapped by `SimpleApplet` and `TitleApplet` as seen below:
```
  # SimpleApplet
  def data_changed(self, value, metadata, persist, mods)
  # SimpleApplet (old version)
  def data_changed(self, data, mods)
  # TitleApplet
  def data_changed(self, value, metadata, persist, mods, title)
  # TitleApplet (old version)
  def data_changed(self, data, mods, title)
```
Instead of calling `data[key][1]` to get the dataset value, instead call `value[key]`.
More details are provided in the updated release note.
3. Update all template applets with the above change.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :hammer: Refactoring  |


## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
Smoke tested each template applet with behavior as expected.
Smoke tested `set_dataset` with metadata and `mutate_dataset` with behavior as expected.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
