### PR TITLE
gui/experiments: cast Qt timestamp to int preventing float type error

### DIFF
--- a/artiq/dashboard/experiments.py
+++ b/artiq/dashboard/experiments.py
@@ -268,7 +268,7 @@ class _ExperimentDock(QtWidgets.QMdiSubWindow):
             datetime.setDate(QtCore.QDate.currentDate())
         else:
             datetime.setDateTime(QtCore.QDateTime.fromMSecsSinceEpoch(
-                scheduling["due_date"]*1000))
+                int(scheduling["due_date"]*1000)))
         datetime_en.setChecked(scheduling["due_date"] is not None)
 
         def update_datetime(dt):


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
Casted the Qt UTC timestamp to `int` when using the to `QDateTime.fromMSecsSinceEpoch` to prevent the typing error, due to other functions converting it to `float`.

Sample error message:
```
Traceback (most recent call last):
  File "/nix/store/8qnzzl4zysdzz616yi96gmzcbnzhragm-python3-3.10.11-env/lib/python3.10/site-packages/artiq/dashboard/explorer.py", line 288, in expname_action
    action("repo:" + expname)
  File "/nix/store/8qnzzl4zysdzz616yi96gmzcbnzhragm-python3-3.10.11-env/lib/python3.10/site-packages/artiq/dashboard/experiments.py", line 725, in open_experiment
    dock = _ExperimentDock(self, expurl)
  File "/nix/store/8qnzzl4zysdzz616yi96gmzcbnzhragm-python3-3.10.11-env/lib/python3.10/site-packages/artiq/dashboard/experiments.py", line 282, in __init__
    datetime.setDateTime(QtCore.QDateTime.fromMSecsSinceEpoch(
TypeError: arguments did not match any overloaded call:
  fromMSecsSinceEpoch(msecs: int): argument 1 has unexpected type 'float'
  fromMSecsSinceEpoch(msecs: int, spec: Qt.TimeSpec, offsetSeconds: int = 0): argument 1 has unexpected type 'float'
  fromMSecsSinceEpoch(msecs: int, timeZone: QTimeZone): argument 1 has unexpected type 'float'
```


<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps to Reproduce
1. Open an experiment from the dashboard.
2. Edit the Due date.
3. Close the experiment.
4. Try to open again.

If the bug doesn't occur after editing the Due date, try to click on Submit before closing the experiment, or try from another experiment.

## Additional Information
Errors likely stem from using `/` to divide timestamps by 1000: it yields a `float` in Python3, unlike an `int` in Python2.
```
        def update_datetime(dt):
            scheduling["due_date"] = dt.toMSecsSinceEpoch()/1000
            datetime_en.setChecked(True)
        datetime.dateTimeChanged.connect(update_datetime)

        def update_datetime_en(checked):
            if checked:
                due_date = datetime.dateTime().toMSecsSinceEpoch()/1000
```
This is proven from the following log test results:
```
After update_datetime, scheduling['due_date']: 1691942400.0, Type: <class 'float'>
After update_datetime_en, scheduling['due_date']: 1691942400.0, Type: <class 'float'>
```

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.

### Git Logistics
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
