### PR TITLE
rename ScientificSpinBox precision to sigfigs

### DIFF
--- a/artiq/gui/entries.py
+++ b/artiq/gui/entries.py
@@ -121,7 +121,7 @@ class NumberEntryFloat(ScientificSpinBox):
         procdesc = argument["desc"]
         scale = procdesc["scale"]
         self.setDecimals(procdesc["precision"])
-        self.setPrecision()
+        self.setSigFigs()
         self.setSingleStep(procdesc["step"]/scale)
         self.setRelativeStep()
         if procdesc["min"] is not None:
@@ -160,7 +160,7 @@ class _NoScan(LayoutWidget):
         self.value = ScientificSpinBox()
         disable_scroll_wheel(self.value)
         self.value.setDecimals(procdesc["precision"])
-        self.value.setPrecision()
+        self.value.setSigFigs()
         if procdesc["global_min"] is not None:
             self.value.setMinimum(procdesc["global_min"]/scale)
         else:
@@ -244,10 +244,10 @@ class _RangeScan(LayoutWidget):
         self.addWidget(randomize, 3, 1)
 
         apply_properties(start)
-        start.setPrecision()
+        start.setSigFigs()
         start.setRelativeStep()
         apply_properties(stop)
-        stop.setPrecision()
+        stop.setSigFigs()
         stop.setRelativeStep()
         apply_properties(scanner)
 
@@ -310,7 +310,7 @@ class _CenterScan(LayoutWidget):
         center = ScientificSpinBox()
         disable_scroll_wheel(center)
         apply_properties(center)
-        center.setPrecision()
+        center.setSigFigs()
         center.setRelativeStep()
         center.setValue(state["center"]/scale)
         self.addWidget(center, 0, 1)
@@ -319,7 +319,7 @@ class _CenterScan(LayoutWidget):
         span = ScientificSpinBox()
         disable_scroll_wheel(span)
         apply_properties(span)
-        span.setPrecision()
+        span.setSigFigs()
         span.setRelativeStep()
         span.setMinimum(0)
         span.setValue(state["span"]/scale)
@@ -329,7 +329,7 @@ class _CenterScan(LayoutWidget):
         step = ScientificSpinBox()
         disable_scroll_wheel(step)
         apply_properties(step)
-        step.setPrecision()
+        step.setSigFigs()
         step.setRelativeStep()
         step.setMinimum(0)
         step.setValue(state["step"]/scale)

--- a/artiq/gui/scientific_spinbox.py
+++ b/artiq/gui/scientific_spinbox.py
@@ -20,21 +20,21 @@ class ScientificSpinBox(QtWidgets.QDoubleSpinBox):
         self.setCorrectionMode(self.CorrectToPreviousValue)
         # singleStep: resolution for step, buttons, accelerators
         # decimals: absolute rounding granularity
-        # precision: number of significant digits shown, %g precision
-        self.setPrecision()
+        # sigFigs: number of significant digits shown
+        self.setSigFigs()
         self.setRelativeStep()
         self.setRange(-inf, inf)
         self.setValue(0)
         # self.setKeyboardTracking(False)
 
-    def setPrecision(self, d=None):
+    def setSigFigs(self, d=None):
         if d is None:
             d = self.decimals() + 3
-        self._precision = max(1, int(d))
-        self._fmt = "{{:.{}g}}".format(self._precision)
+        self._sig_figs = max(1, int(d))
+        self._fmt = "{{:.{}g}}".format(self._sig_figs)
 
-    def precision(self):
-        return self._precision
+    def sigFigs(self):
+        return self._sig_figs
 
     def setRelativeStep(self, s=None):
         if s is None:


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Rename `setPrecision` and `precision` in `ScientificSpinBox` to `setSigFigs` and `sigFigs` respectively. Also renames for the entries that call the methods. Done for consistency with #2138.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.
Manual smoke test using `MultiScan` and `ArgumentsDemo` experiments.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
