### PR TITLE
remove trailing decimal separator in short_format

### DIFF
--- a/artiq/tools.py
+++ b/artiq/tools.py
@@ -72,6 +72,7 @@ def short_format(v, metadata={}):
         v_t = np.divide(v, scale)
         v_str = np.format_float_positional(v_t, 
                                            precision=precision,
+                                           trim='-',
                                            unique=True)
         v_str += " " + unit if unit else ""
         return v_str
@@ -84,6 +85,7 @@ def short_format(v, metadata={}):
         v_str = np.array2string(v_t,
                                 max_line_width=1000,
                                 precision=precision,
+                                trim='-',
                                 suppress_small=True,
                                 separator=', ',
                                 threshold=4,


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Currently, when a dataset with no decimal digits is displayed, a trailing `.` decimal separator is displayed.

This implies that all the digits on the right of the point are significant (including trailing zeros). However at the moment
we do not have a notion of significant figures associated with datasets (only decimal precision / number of decimal digits), so this formatting is misleading. For example:

Setting an integer value of `4000` with a precision of `1` will display `4000.` which would imply 4 sig. figs. 

This PR proposes to trim the decimal separator when there are no decimal digits displayed. The above example would display `4000` as expected.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
