### PR TITLE
[WIP] Support for Shuttler for EEM FMC Satellite

### DIFF
--- a/artiq/coredevice/coredevice_generic.schema.json
+++ b/artiq/coredevice/coredevice_generic.schema.json
@@ -134,7 +134,7 @@
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": ["dio", "dio_spi", "urukul", "novogorny", "sampler", "suservo", "zotino", "grabber", "mirny", "fastino", "phaser", "hvamp"]
+                    "enum": ["dio", "dio_spi", "urukul", "novogorny", "sampler", "suservo", "zotino", "grabber", "mirny", "fastino", "phaser", "hvamp", "efc"]
                 },
                 "board": {
                     "type": "string"
@@ -588,6 +588,28 @@
                             },
                             "minItems": 1,
                             "maxItems": 1
+                        }
+                    },
+                    "required": ["ports"]
+                }
+            }, {
+                "title": "FMCCarrier",
+                "if": {
+                    "properties": {
+                        "type": {
+                            "const": "efc"
+                        }
+                    }
+                },
+                "then": {
+                    "properties": {
+                        "ports": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
                         }
                     },
                     "required": ["ports"]

--- a/artiq/firmware/ksupport/Cargo.toml
+++ b/artiq/firmware/ksupport/Cargo.toml
@@ -17,7 +17,7 @@ cslice = { version = "0.3" }
 eh = { path = "../libeh" }
 io = { path = "../libio", features = ["byteorder"] }
 dyld = { path = "../libdyld" }
-board_misoc = { path = "../libboard_misoc" }
+board_misoc = { path = "../libboard_misoc", features = ["uart_console", "log"] }
 board_artiq = { path = "../libboard_artiq" }
 proto_artiq = { path = "../libproto_artiq" }
 riscv = { version = "0.6.0", features = ["inline-asm"] }

--- a/artiq/firmware/libboard_artiq/drtio_eem.rs
+++ b/artiq/firmware/libboard_artiq/drtio_eem.rs
@@ -1,0 +1,198 @@
+use board_misoc::{csr, ident, clock, uart_logger, i2c, pmp};
+
+
+#[derive(Debug)]
+pub struct SerdesConfig {
+    select_odd: u8,
+    decoder_invert: u8,
+    delay: [u8; 4],
+    bitslip: [u8; 4],
+}
+
+impl SerdesConfig {
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe {
+            core::slice::from_raw_parts(
+                (self as *const SerdesConfig) as *const u8,
+                core::mem::size_of::<SerdesConfig>(),
+            )
+        }
+    }
+}
+
+pub fn align_eem() -> SerdesConfig {
+    let mut delay_confs: [(u8, u8, u8, u8); 4] = Default::default();
+
+    for eem_pair_no in 0..4 {
+        delay_confs[eem_pair_no] = unsafe { align(eem_pair_no) };
+    }
+
+    let mut select_odd = 0;
+    let mut decoder_invert = 0;
+    let mut delay = [0; 4];
+    let mut bitslip = [0; 4];
+    for (eem_pair_no, (select_odd_idx, dly, slip, invert)) in delay_confs.iter().enumerate() {
+        select_odd |= (select_odd_idx << eem_pair_no);
+        delay[eem_pair_no] = *dly;
+        bitslip[eem_pair_no] = *slip;
+        decoder_invert |= (invert << eem_pair_no);
+    }
+
+    SerdesConfig {
+        select_odd,
+        decoder_invert,
+        delay,
+        bitslip,
+    }
+}
+
+fn select_eem_pair(eem_pair_no: usize) {
+    unsafe {
+        csr::eem_transceiver::serdes_bitslip_sel_write(1 << eem_pair_no);
+        csr::eem_transceiver::serdes_dly_cnt_in_sel_write(1 << eem_pair_no);
+        csr::eem_transceiver::serdes_dly_cnt_out_sel_write(1 << eem_pair_no);
+        csr::eem_transceiver::serdes_read_word_write(eem_pair_no as u8);
+    }
+}
+
+fn update_select_odd(eem_pair_no: usize, select_odd: usize) {
+    let mut odd_sel_reg = unsafe { csr::eem_transceiver::serdes_select_odd_read() };
+    // Clear bit
+    odd_sel_reg &= (!(1 << eem_pair_no));
+    // Set bit if applicable
+    unsafe { csr::eem_transceiver::serdes_select_odd_write(odd_sel_reg | (select_odd << eem_pair_no) as u8) };
+}
+
+fn update_invert(eem_pair_no: usize, invert: usize) {
+    let mut invert_reg = unsafe { csr::eem_transceiver::serdes_decoder_dly_read() };
+    // Clear bit
+    invert_reg &= (!(1 << eem_pair_no));
+    // Set bit if applicable
+    unsafe { csr::eem_transceiver::serdes_decoder_dly_write(invert_reg | (invert << eem_pair_no) as u8) };
+}
+
+fn apply_bitslip() {
+    unsafe {
+        csr::eem_transceiver::serdes_bitslip_write(1);
+        csr::eem_transceiver::serdes_bitslip_write(1);
+    }
+}
+
+fn apply_delay(tap: u8) {
+    unsafe {
+        csr::eem_transceiver::serdes_dly_cnt_in_write(tap);
+        // Ensure dly_cnt_in is updated before ld
+        clock::spin_us(100);
+        assert!(tap == csr::eem_transceiver::serdes_dly_cnt_in_read());
+        csr::eem_transceiver::serdes_dly_ld_write(1);
+    }
+}
+
+pub fn write_config(config: &SerdesConfig) {
+    unsafe {
+        csr::eem_transceiver::serdes_decoder_dly_write(config.decoder_invert as u8);
+        csr::eem_transceiver::serdes_select_odd_write(config.select_odd as u8);
+    }
+
+    for eem_pair_no in 0..4 {
+        select_eem_pair(eem_pair_no);
+        apply_delay(config.delay[eem_pair_no]);
+
+        for _ in 0..config.bitslip[eem_pair_no] {
+            apply_bitslip();
+        }
+    }
+}
+
+unsafe fn align(eem_pair_no: usize) -> (u8, u8, u8, u8) {
+    let mut table: [[bool; 32]; 20] = [[false; 32]; 20];
+
+    select_eem_pair(eem_pair_no);
+    clock::spin_us(1);
+
+    let scan = |table: &mut[[bool; 32]]| {
+        for slip in 0..5 {
+            for delay in 0..32 {
+                apply_delay(delay);
+                clock::spin_us(1);
+
+                for odd_select in 0..2 {
+                    update_select_odd(eem_pair_no, odd_select);
+                    clock::spin_us(100);
+
+                    table[(slip * 2 + odd_select) as usize][delay as usize] = true;
+                    for _ in 0..512 {
+                        let aligned = csr::eem_transceiver::serdes_aligned_read();
+                        table[(slip * 2 + odd_select) as usize][delay as usize] &= (aligned == 1);
+                    }
+                }
+            }
+
+            apply_bitslip();
+            clock::spin_us(100);
+        }
+    };
+
+    update_invert(eem_pair_no, 0);
+    clock::spin_us(100);
+    scan(&mut table[..10]);
+    update_invert(eem_pair_no, 1);
+    clock::spin_us(100);
+    scan(&mut table[10..]);
+
+    print!("                       ");
+    for i in 0..32 {
+        print!("{}", i % 10);
+    }
+    println!("");
+
+    for (idx, dly_row) in table.iter().enumerate() {
+        let slip = (idx % 10) / 2;
+        let select_odd = idx % 2;
+        print!("Slip {:#02}, SELECT_ODD {}: ", slip, select_odd);
+        for &hit_status in dly_row {
+            if hit_status {
+                print!("*");
+            } else {
+                print!(" ");
+            }
+        }
+        println!("");
+    }
+
+    get_delay(&table)
+}
+
+// Find the appropriate delay configuration, in (select_odd, delay_tap, bitslip, flip_order)
+fn get_delay(table: &[[bool; 32]]) -> (u8, u8, u8, u8) {
+    // Figure out the longest chain of hits within some bitslip & select_odd
+    let mut max = 0;
+    let mut slip = 0;
+    let mut tap = 0;
+    for (curr_idx, dly_row) in table.iter().enumerate() {
+        let mut curr_len = 0;
+        let mut first_hit = 0;
+        let mut curr_mid = 0;
+
+        for (dly_tap, dly_stat) in dly_row.iter().enumerate() {
+            if *dly_stat {
+                // Beginning of a chain of hits
+                if curr_len == 0 {
+                    first_hit = dly_tap;
+                }
+                curr_len += 1;
+                curr_mid = (dly_tap + first_hit) / 2;
+            } else {
+                curr_len = 0;
+            }
+
+            if curr_len > max {
+                max = curr_len;
+                slip = curr_idx;
+                tap = curr_mid;
+            }
+        }
+    }
+
+    (slip as u8 % 2, tap as u8, (slip as u8 % 10) / 2, slip as u8 / 10)
+}

--- a/artiq/firmware/libboard_artiq/drtio_eem.rs
+++ b/artiq/firmware/libboard_artiq/drtio_eem.rs
@@ -48,9 +48,9 @@ pub fn align_eem() -> SerdesConfig {
 
 fn select_eem_pair(eem_pair_no: usize) {
     unsafe {
-        csr::eem_transceiver::serdes_bitslip_sel_write(1 << eem_pair_no);
-        csr::eem_transceiver::serdes_dly_cnt_in_sel_write(1 << eem_pair_no);
-        csr::eem_transceiver::serdes_dly_cnt_out_sel_write(1 << eem_pair_no);
+        csr::eem_transceiver::serdes_bitslip_sel_write(eem_pair_no as u8);
+        csr::eem_transceiver::serdes_dly_cnt_in_sel_write(eem_pair_no as u8);
+        csr::eem_transceiver::serdes_dly_cnt_out_sel_write(eem_pair_no as u8);
         csr::eem_transceiver::serdes_read_word_write(eem_pair_no as u8);
     }
 }

--- a/artiq/firmware/libboard_artiq/drtio_eem.rs
+++ b/artiq/firmware/libboard_artiq/drtio_eem.rs
@@ -48,10 +48,7 @@ pub fn align_eem() -> SerdesConfig {
 
 fn select_eem_pair(eem_pair_no: usize) {
     unsafe {
-        csr::eem_transceiver::serdes_bitslip_sel_write(eem_pair_no as u8);
-        csr::eem_transceiver::serdes_dly_cnt_in_sel_write(eem_pair_no as u8);
-        csr::eem_transceiver::serdes_dly_cnt_out_sel_write(eem_pair_no as u8);
-        csr::eem_transceiver::serdes_read_word_write(eem_pair_no as u8);
+        csr::eem_transceiver::serdes_eem_sel_write(eem_pair_no as u8);
     }
 }
 

--- a/artiq/firmware/libboard_artiq/lib.rs
+++ b/artiq/firmware/libboard_artiq/lib.rs
@@ -29,3 +29,6 @@ pub mod grabber;
 #[cfg(has_drtio)]
 pub mod drtioaux;
 pub mod drtio_routing;
+
+#[cfg(has_drtio_eem)]
+pub mod drtio_eem;

--- a/artiq/firmware/libboard_artiq/lib.rs
+++ b/artiq/firmware/libboard_artiq/lib.rs
@@ -10,6 +10,7 @@ extern crate crc;
 #[macro_use]
 extern crate log;
 extern crate io;
+#[macro_use]
 extern crate board_misoc;
 extern crate proto_artiq;
 

--- a/artiq/firmware/libboard_misoc/io_expander.rs
+++ b/artiq/firmware/libboard_misoc/io_expander.rs
@@ -187,6 +187,7 @@ impl IoExpander {
     }
 
     pub fn service(&mut self) -> Result<(), &'static str> {
+        #[cfg(soc_platform = "kasli")]
         for (led, port, bit) in self.virtual_led_mapping.iter() {
             let level = unsafe { (csr::virtual_leds::status_read() >> led) & 1 };
             self.set(*port, *bit, level != 0);

--- a/artiq/firmware/libboard_misoc/io_expander.rs
+++ b/artiq/firmware/libboard_misoc/io_expander.rs
@@ -81,11 +81,55 @@ impl IoExpander {
         Ok(io_expander)
     }
 
+    #[cfg(soc_platform = "efc")]
+    pub fn new() -> Result<Self, &'static str> {
+        // TODO: Actually put VirtualLEDs in gateware
+        const VIRTUAL_LED_MAPPING: [(u8, u8, u8); 3] = [(0, 0, 5), (1, 0, 6), (2, 0, 7)];
+
+        let mut io_expander = IoExpander {
+            busno: 0,
+            port: 1,
+            address: 0x40,
+            virtual_led_mapping: &VIRTUAL_LED_MAPPING,
+            iodir: [0xff; 2],
+            out_current: [0; 2],
+            out_target: [0; 2],
+            registers: Registers {
+                iodira: 0x00,
+                iodirb: 0x01,
+                gpioa: 0x12,
+                gpiob: 0x13,
+            },
+        };
+        if !io_expander.check_ack()? {
+            #[cfg(feature = "log")]
+            log::info!("MCP23017 io expander not found. Checking for PCA9539.");
+            io_expander.address += 0xa8; // translate to PCA9539 addresses (see schematic)
+            io_expander.registers = Registers {
+                iodira: 0x06,
+                iodirb: 0x07,
+                gpioa: 0x02,
+                gpiob: 0x03,
+            };
+            if !io_expander.check_ack()? {
+                return Err("Neither MCP23017 nor PCA9539 io expander found.");
+            };
+        }
+        Ok(io_expander)
+    }
+
     #[cfg(soc_platform = "kasli")]
     fn select(&self) -> Result<(), &'static str> {
         let mask: u16 = 1 << self.port;
         i2c::switch_select(self.busno, 0x70, mask as u8)?;
         i2c::switch_select(self.busno, 0x71, (mask >> 8) as u8)?;
+        Ok(())
+    }
+
+    #[cfg(soc_platform = "efc")]
+    fn select(&self) -> Result<(), &'static str> {
+        let mask: u16 = 1 << self.port;
+        i2c::switch_select(self.busno, 0x70, mask as u8)?;
         Ok(())
     }
 

--- a/artiq/firmware/libboard_misoc/lib.rs
+++ b/artiq/firmware/libboard_misoc/lib.rs
@@ -40,7 +40,7 @@ pub mod ethmac;
 pub mod i2c;
 #[cfg(soc_platform = "kasli")]
 pub mod i2c_eeprom;
-#[cfg(all(soc_platform = "kasli", hw_rev = "v2.0"))]
+#[cfg(any(all(soc_platform = "kasli", hw_rev = "v2.0"), soc_platform = "efc"))]
 pub mod io_expander;
 #[cfg(all(has_ethmac, feature = "smoltcp"))]
 pub mod net_settings;

--- a/artiq/firmware/libboard_misoc/sdram.rs
+++ b/artiq/firmware/libboard_misoc/sdram.rs
@@ -246,7 +246,7 @@ mod ddr {
             ddrphy::dly_sel_write(1 << (DQS_SIGNAL_COUNT - n - 1));
 
             ddrphy::rdly_dq_rst_write(1);
-            #[cfg(soc_platform = "kasli")]
+            #[cfg(any(soc_platform = "kasli", soc_platform = "efc"))]
             {
                 for _ in 0..3 {
                     ddrphy::rdly_dq_bitslip_write(1);
@@ -337,7 +337,7 @@ mod ddr {
             let mut max_seen_valid = 0;
 
             ddrphy::rdly_dq_rst_write(1);
-            #[cfg(soc_platform = "kasli")]
+            #[cfg(any(soc_platform = "kasli", soc_platform = "efc"))]
             {
                 for _ in 0..3 {
                     ddrphy::rdly_dq_bitslip_write(1);
@@ -400,7 +400,7 @@ mod ddr {
 
             // Set delay to the middle
             ddrphy::rdly_dq_rst_write(1);
-            #[cfg(soc_platform = "kasli")]
+            #[cfg(any(soc_platform = "kasli", soc_platform = "efc"))]
             {
                 for _ in 0..3 {
                     ddrphy::rdly_dq_bitslip_write(1);

--- a/artiq/firmware/runtime/Cargo.toml
+++ b/artiq/firmware/runtime/Cargo.toml
@@ -23,7 +23,7 @@ eh = { path = "../libeh" }
 unwind_backtrace = { path = "../libunwind_backtrace" }
 io = { path = "../libio", features = ["byteorder"] }
 alloc_list = { path = "../liballoc_list" }
-board_misoc = { path = "../libboard_misoc", features = ["uart_console", "smoltcp"] }
+board_misoc = { path = "../libboard_misoc", features = ["uart_console", "smoltcp", "log"] }
 logger_artiq = { path = "../liblogger_artiq" }
 board_artiq = { path = "../libboard_artiq" }
 proto_artiq = { path = "../libproto_artiq", features = ["log", "alloc"] }

--- a/artiq/firmware/runtime/rtio_clocking.rs
+++ b/artiq/firmware/runtime/rtio_clocking.rs
@@ -279,4 +279,13 @@ pub fn init() {
             error!("RTIO clock failed");
         }
     }
+
+    info!("Using internal RTIO clock");
+    unsafe {
+        csr::serdes_crg::pll_reset_write(0);
+    }
+    clock::spin_us(150);
+    if unsafe { csr::serdes_crg::pll_locked_read() == 0 } {
+        error!("EEM clock failed");
+    }
 }

--- a/artiq/firmware/satman/main.rs
+++ b/artiq/firmware/satman/main.rs
@@ -488,14 +488,14 @@ fn sysclk_setup() {
 #[cfg(soc_platform = "efc")]
 fn sysclk_setup() -> board_misoc::io_expander::IoExpander {
     let mut io_expander = board_misoc::io_expander::IoExpander::new().unwrap();
-
+    /* 
     // Skip intialization if it had reset
     if (unsafe { csr::crg::had_clk_switch_read() } != 0) {
         io_expander.set(0, 3, false);
         io_expander.set(0, 2, true);
         return io_expander;
     }
-
+    */
     io_expander.init().expect("I2C I/O expander #0 initialization failed");
 
     // Latch in the logic signal before enabling
@@ -503,18 +503,23 @@ fn sysclk_setup() -> board_misoc::io_expander::IoExpander {
     io_expander.set(0, 2, true);
     io_expander.service().unwrap();
     println!("Serviced I/O expander.");
-
+    /* 
     // Changing output direction of the I/O expander
     // will immediately update clock source, which may trigger reboot
     // So, notify the gateware a clock switch request in advance
     unsafe {
         csr::crg::switched_clk_write(1);
     }
-    io_expander.set_oe(0, 1 << 2 | 1 << 3);
+    */
+    println!("Enable clock switch now");
+    //io_expander.set_oe(0, 1 << 2 | 1 << 3);
+    println!("Finish enabling");
 
-    loop {}
+    return io_expander;
+//temp disable infinite loop
+    //loop {}
 
-    unreachable!()
+    //unreachable!()
 }
 
 
@@ -570,9 +575,11 @@ pub extern fn main() -> i32 {
 
     #[cfg(soc_platform = "efc")]
     {
+        println!("Enabling power for fmc card");
         // Do whatever we need the IO expander to do here
         // The CLK_SELs must be output to keep MMCX
-        io_expander.set_oe(0, 1 << 2 | 1 << 3 | 1 << 5 | 1 << 6 | 1 << 7).unwrap();
+        //io_expander.set_oe(0, 1 << 2 | 1 << 3 | 1 << 5 | 1 << 6 | 1 << 7).unwrap();
+        io_expander.set_oe(0, 1 << 5 | 1 << 6 | 1 << 7).unwrap();
         io_expander.set_oe(1, 1 << 0 | 1 << 1).unwrap();
 
         io_expander.set(0, 5, true);
@@ -582,6 +589,10 @@ pub extern fn main() -> i32 {
         io_expander.set(1, 1, true);
 
         io_expander.service().unwrap();
+        println!("Finishing enabling power for fmc card");
+        loop {}
+        unreachable!()
+
     }
 
     #[cfg(not(soc_platform = "efc"))]

--- a/artiq/firmware/satman/main.rs
+++ b/artiq/firmware/satman/main.rs
@@ -582,11 +582,12 @@ pub extern fn main() -> i32 {
         // Do whatever we need the IO expander to do here
         // The CLK_SELs must be output to keep MMCX
         io_expander.set_oe(0, 1 << 2 | 1 << 3 | 1 << 5 | 1 << 6 | 1 << 7).unwrap();
-        io_expander.set_oe(1, 1 << 1).unwrap();
+        io_expander.set_oe(1, 1 << 0 | 1 << 1).unwrap();
 
         io_expander.set(0, 5, true);
         io_expander.set(0, 6, true);
         io_expander.set(0, 7, true);
+        io_expander.set(1, 0, true);
         io_expander.set(1, 1, true);
 
         io_expander.service().unwrap();

--- a/artiq/firmware/satman/main.rs
+++ b/artiq/firmware/satman/main.rs
@@ -592,6 +592,7 @@ pub extern fn main() -> i32 {
         io_expander.service().unwrap();
     }
 
+    #[cfg(not(soc_platform = "efc"))]
     unsafe {
         csr::drtio_transceiver::txenable_write(0xffffffffu32 as _);
     }

--- a/artiq/frontend/artiq_ddb_template.py
+++ b/artiq/frontend/artiq_ddb_template.py
@@ -620,6 +620,8 @@ class PeripheralManager:
         return 8
 
     def process(self, rtio_offset, peripheral):
+        if peripheral["type"] == "efc":
+            return 0
         processor = getattr(self, "process_"+str(peripheral["type"]))
         return processor(rtio_offset, peripheral)
 

--- a/artiq/frontend/artiq_flash.py
+++ b/artiq/frontend/artiq_flash.py
@@ -59,7 +59,7 @@ Prerequisites:
                         help="SSH host to jump through")
     parser.add_argument("-t", "--target", default="kasli",
                         help="target board, default: %(default)s, one of: "
-                             "kasli kc705")
+                             "kasli kc705 efc")
     parser.add_argument("-I", "--preinit-command", default=[], action="append",
                         help="add a pre-initialization OpenOCD command. "
                              "Useful for selecting a board when several are connected.")
@@ -215,10 +215,16 @@ class ProgrammerXC7(Programmer):
         Programmer.__init__(self, client, preinit_script)
         self._proxy = proxy
 
-        add_commands(self._board_script,
-            "source {boardfile}",
-            boardfile=self._transfer_script("board/{}.cfg".format(board)))
-        self.add_flash_bank("spi0", "xc7", index=0)
+        if board != "efc":
+            add_commands(self._board_script,
+                "source {boardfile}",
+                boardfile=self._transfer_script("board/{}.cfg".format(board)))
+            self.add_flash_bank("spi0", "xc7", index=0)
+        else:
+            add_commands(self._board_script,
+                "source efc.cfg"
+            )
+            self.add_flash_bank("spi0", "xc7", index=0)
 
         add_commands(self._script, "xadc_report xc7.tap")
 
@@ -237,6 +243,13 @@ def main():
     config = {
         "kasli": {
             "programmer":   partial(ProgrammerXC7, board="kasli", proxy="bscan_spi_xc7a100t.bit"),
+            "gateware":     ("spi0", 0x000000),
+            "bootloader":   ("spi0", 0x400000),
+            "storage":      ("spi0", 0x440000),
+            "firmware":     ("spi0", 0x450000),
+        },
+        "efc": {
+            "programmer":   partial(ProgrammerXC7, board="efc", proxy="bscan_spi_xc7a100t.bit"),
             "gateware":     ("spi0", 0x000000),
             "bootloader":   ("spi0", 0x400000),
             "storage":      ("spi0", 0x440000),

--- a/artiq/gateware/drtio/core.py
+++ b/artiq/gateware/drtio/core.py
@@ -27,11 +27,11 @@ class ChannelInterface:
 
 
 class TransceiverInterface(AutoCSR):
-    def __init__(self, channel_interfaces):
+    def __init__(self, channel_interfaces, start_idx=0):
         self.stable_clkin = CSRStorage()
         self.txenable = CSRStorage(len(channel_interfaces))
         for i in range(len(channel_interfaces)):
-            name = "rtio_rx" + str(i)
+            name = "rtio_rx" + str(i + start_idx)
             setattr(self.clock_domains, "cd_"+name, ClockDomain(name=name))
         self.channels = channel_interfaces
 

--- a/artiq/gateware/drtio/transceiver/eem_serdes.py
+++ b/artiq/gateware/drtio/transceiver/eem_serdes.py
@@ -277,29 +277,29 @@ class SerdesSingle(Module, AutoCSR):
         self.submodules.tx_serdes = TXSerdes()
 
         # CSR for delay & bitslip
-        self.bitslip_sel = CSRStorage(4)
+        self.bitslip_sel = CSRStorage(2)
         self.bitslip = CSR()
 
         for i in range(4):
             self.specials += MultiReg(
-                self.bitslip_sel.storage[i] & self.bitslip.re,
+                (self.bitslip_sel.storage == i) & self.bitslip.re,
                 self.rx_serdes.bitslip[i], "eem_sys")
         
-        self.dly_cnt_in_sel = CSRStorage(4)
+        self.dly_cnt_in_sel = CSRStorage(2)
         self.dly_cnt_in = CSRStorage(5)
         self.dly_ld = CSR()
 
         for i in range(4):
             self.comb += [
                 self.rx_serdes.cnt_in[i].eq(self.dly_cnt_in.storage),
-                self.rx_serdes.ld[i].eq(self.dly_cnt_in_sel.storage[i] & self.dly_ld.re),
+                self.rx_serdes.ld[i].eq((self.dly_cnt_in_sel.storage == i) & self.dly_ld.re),
             ]
         
-        self.dly_cnt_out_sel = CSRStorage(4)
+        self.dly_cnt_out_sel = CSRStorage(2)
         self.dly_cnt_out = CSRStatus(5)
 
         self.comb += Case(self.dly_cnt_out_sel.storage, {
-            (1 << idx): self.dly_cnt_out.status.eq(self.rx_serdes.cnt_out[idx]) for idx in range(4)
+            idx: self.dly_cnt_out.status.eq(self.rx_serdes.cnt_out[idx]) for idx in range(4)
         })
         
         # CSR for global decoding phase

--- a/artiq/gateware/drtio/transceiver/eem_serdes.py
+++ b/artiq/gateware/drtio/transceiver/eem_serdes.py
@@ -1,0 +1,485 @@
+from migen import *
+from migen.genlib.cdc import MultiReg
+from migen.genlib.io import DifferentialInput, DifferentialOutput
+from migen.genlib.fifo import AsyncFIFO
+from misoc.cores import gpio
+from misoc.interconnect.csr import *
+from misoc.cores.code_8b10b import SingleEncoder, Decoder
+from artiq.gateware.drtio.core import TransceiverInterface, ChannelInterface
+
+
+class RXPhy(Module):
+    def __init__(self, i_pads):
+        self.o = [Signal() for _ in range(4)]
+
+        for i in range(4):
+            self.specials += Instance("IBUFDS",
+                i_I=i_pads[i].p,
+                i_IB=i_pads[i].n,
+                o_O=self.o[i],
+            )
+
+
+class TXPhy(Module):
+    def __init__(self, o_pads):
+        self.i = [Signal() for _ in range(4)]
+        self.t = [Signal() for _ in range(4)]
+
+        for i in range(4):
+            self.specials += Instance("OBUFTDS",
+                i_I=self.i[i],
+                o_O=o_pads[i].p,
+                o_OB=o_pads[i].n,
+                # Always chain the 3-states input to serializer
+                # Vivado will complain otherwise
+                i_T=self.t[i],
+            )
+
+
+class RXSerdes(Module):
+    def __init__(self):
+        self.rxdata = [ Signal(10) for _ in range(4) ]
+        self.ser_in_no_dly = [ Signal() for _ in range(4) ]
+        self.ld = [ Signal() for _ in range(4) ]
+        self.cnt_in = [ Signal(5) for _ in range(4) ]
+        self.cnt_out = [ Signal(5) for _ in range(4) ]
+        self.bitslip = [ Signal() for _ in range(4) ]
+
+        ser_in = [ Signal() for _ in range(4) ]
+        shifts = [ Signal(2) for _ in range(4) ]
+
+        for i in range(4):
+            self.specials += [
+                # Master deserializer
+                Instance("ISERDESE2",
+                    p_DATA_RATE="DDR",
+                    p_DATA_WIDTH=10,
+                    p_INTERFACE_TYPE="NETWORKING",
+                    p_NUM_CE=1,
+                    p_SERDES_MODE="MASTER",
+                    p_IOBDELAY="IFD",
+                    o_Q1=self.rxdata[i][9],
+                    o_Q2=self.rxdata[i][8],
+                    o_Q3=self.rxdata[i][7],
+                    o_Q4=self.rxdata[i][6],
+                    o_Q5=self.rxdata[i][5],
+                    o_Q6=self.rxdata[i][4],
+                    o_Q7=self.rxdata[i][3],
+                    o_Q8=self.rxdata[i][2],
+                    o_SHIFTOUT1=shifts[i][0],
+                    o_SHIFTOUT2=shifts[i][1],
+                    i_DDLY=ser_in[i],
+                    i_BITSLIP=self.bitslip[i],
+                    i_CLK=ClockSignal("eem_sys5x"),
+                    i_CLKB=~ClockSignal("eem_sys5x"),
+                    i_CE1=1,
+                    i_RST=ResetSignal("eem_sys"),
+                    i_CLKDIV=ClockSignal("eem_sys")),
+                
+                # Slave deserializer
+                Instance("ISERDESE2",
+                    p_DATA_RATE="DDR",
+                    p_DATA_WIDTH=10,
+                    p_INTERFACE_TYPE="NETWORKING",
+                    p_NUM_CE=1,
+                    p_SERDES_MODE="SLAVE",
+                    p_IOBDELAY="IFD",
+                    o_Q3=self.rxdata[i][1],
+                    o_Q4=self.rxdata[i][0],
+                    i_BITSLIP=self.bitslip[i],
+                    i_CLK=ClockSignal("eem_sys5x"),
+                    i_CLKB=~ClockSignal("eem_sys5x"),
+                    i_CE1=1,
+                    i_RST=ResetSignal("eem_sys"),
+                    i_CLKDIV=ClockSignal("eem_sys"),
+                    i_SHIFTIN1=shifts[i][0],
+                    i_SHIFTIN2=shifts[i][1]),
+
+                # Tunable delay
+                Instance("IDELAYE2",
+                    p_DELAY_SRC="IDATAIN",
+                    p_SIGNAL_PATTERN="DATA",
+                    p_CINVCTRL_SEL="FALSE",
+                    p_HIGH_PERFORMANCE_MODE="TRUE",
+                    # REFCLK refers to the clock source of IDELAYCTRL
+                    p_REFCLK_FREQUENCY=200.0,
+                    p_PIPE_SEL="FALSE",
+                    p_IDELAY_TYPE="VAR_LOAD",
+                    p_IDELAY_VALUE=0,
+
+                    i_C=ClockSignal(),
+                    i_LD=self.ld[i],
+                    i_CE=0,
+                    i_LDPIPEEN=0,
+                    i_INC=1,            # Always increment
+
+                    # Set the optimal delay tap via the aligner
+                    i_CNTVALUEIN=self.cnt_in[i],
+                    # Allow the aligner to check the tap value
+                    o_CNTVALUEOUT=self.cnt_out[i],
+
+                    i_IDATAIN=self.ser_in_no_dly[i],
+                    o_DATAOUT=ser_in[i]
+                ),
+
+                # IDELAYCTRL is with the clocking
+            ]
+
+
+class TXSerdes(Module):
+    def __init__(self):
+        self.txdata = [ Signal(5) for _ in range(4) ]
+        self.ser_out = [ Signal() for _ in range(4) ]
+        self.t_out = [ Signal() for _ in range(4) ]
+
+        # TX SERDES
+        for i in range(4):
+            self.specials += Instance("OSERDESE2",
+                p_DATA_RATE_OQ="SDR", p_DATA_RATE_TQ="BUF",
+                p_DATA_WIDTH=5, p_TRISTATE_WIDTH=1,
+                p_INIT_OQ=0b00000,
+                o_OQ=self.ser_out[i],
+                o_TQ=self.t_out[i],
+                i_RST=ResetSignal("eem_sys"),
+                i_CLK=ClockSignal("eem_sys5x"),
+                i_CLKDIV=ClockSignal("eem_sys"),
+                i_D1=self.txdata[i][0],
+                i_D2=self.txdata[i][1],
+                i_D3=self.txdata[i][2],
+                i_D4=self.txdata[i][3],
+                i_D5=self.txdata[i][4],
+                i_TCE=1, i_OCE=1,
+                i_T1=0)
+
+
+class MultiEncoder(Module):
+    def __init__(self):
+        WORDS = 2
+        # Keep the link layer interface identical to standard encoders
+        self.d = [Signal(8) for _ in range(WORDS)]
+        self.k = [Signal() for _ in range(WORDS)]
+
+        # Alignment control: Keep sending K.28.5
+        self.align = Signal()
+
+        # Output interface is simplified because we have custom physical layer
+        self.output = [Signal(10) for _ in range(WORDS)]
+
+        # Phase of the encoder
+        # Alternate crossbar between encoder and SERDES every cycle
+        self.phase = Signal()
+
+        # Intermediate registers for output and disparity
+        # More significant bits are buffered due to channel geometry
+        # Disparity bit is delayed. The same encoder is shared by 2 SERDES
+        output_bufs = [Signal(5) for _ in range(WORDS)]
+        disp_bufs = [Signal() for _ in range(WORDS)]
+
+        encoders = [SingleEncoder() for _ in range(WORDS)]
+        self.submodules += encoders
+
+        for d, k, output, output_buf, disp_buf, encoder in \
+                zip(self.d, self.k, self.output, output_bufs, disp_bufs, encoders):
+            self.comb += [
+                If(self.align,
+                    encoder.d.eq(0xBC),
+                    encoder.k.eq(1),
+                ).Else(
+                    encoder.d.eq(d),
+                    encoder.k.eq(k),
+                ),
+
+                # Implementing switching crossbar
+                If(self.phase,
+                    output.eq(Cat(encoder.output[0:5], output_buf))
+                ).Else(
+                    output.eq(Cat(output_buf, encoder.output[0:5]))
+                ),
+            ]
+            # Handle intermediate registers
+            self.sync.eem_sys += [
+                disp_buf.eq(encoder.disp_out),
+                encoder.disp_in.eq(disp_buf),
+                output_buf.eq(encoder.output[5:10]),
+            ]
+
+
+# Unlike the usual 8b10b decoder, it needs to know which SERDES to decode
+class CrossbarDecoder(Module):
+    def __init__(self):
+        self.raw_input = [ Signal(5) for _ in range(2) ]
+        self.d = Signal(8)
+        self.k = Signal()
+
+        # Notifier signal when group alignmnet is completed
+        self.delay = Signal(2)
+        self.phase = Signal()
+
+        # Optional extra stage for both lanes
+        self.delay_buf = [ Signal(5) for _ in range(2) ]
+        self.sync.eem_sys += [
+            self.delay_buf[idx].eq(self.raw_input[idx]) for idx in range(2)
+        ]
+
+        # Intermediate register for input
+        buffer = Signal(5)
+
+        self.submodules.decoder = Decoder()
+
+        # Update phase & synchronous elements
+        self.sync.eem_sys += [
+            If(~self.phase,
+                If(~self.delay[0],
+                    buffer.eq(self.raw_input[0]),
+                ).Else(
+                    buffer.eq(self.delay_buf[0]),
+                )
+            ).Else(
+                If(~self.delay[1],
+                    buffer.eq(self.raw_input[1]),
+                ).Else(
+                    buffer.eq(self.delay_buf[1]),
+                )
+            )
+        ]
+        
+        # Send appropriate input to decoder
+        self.comb += [
+            If(self.phase,
+                If(~self.delay[0],
+                    self.decoder.input.eq(Cat(buffer, self.raw_input[0])),
+                ).Else(
+                    self.decoder.input.eq(Cat(buffer, self.delay_buf[0])),
+                )
+            ).Else(
+                If(~self.delay[1],
+                    self.decoder.input.eq(Cat(buffer, self.raw_input[1])),
+                ).Else(
+                    self.decoder.input.eq(Cat(buffer, self.delay_buf[1])),
+                )
+            ),
+        ]
+
+        self.comb += [
+            self.d.eq(self.decoder.d),
+            self.k.eq(self.decoder.k),
+        ]
+
+
+class SerdesSingle(Module, AutoCSR):
+    def __init__(self, i_pads, o_pads, debug=False):
+        # Modules for the IOB
+        self.submodules.rx_phy = RXPhy(i_pads)
+        self.submodules.tx_phy = TXPhy(o_pads)
+
+        # Serdes Module
+        self.submodules.rx_serdes = RXSerdes()
+        self.submodules.tx_serdes = TXSerdes()
+
+        # CSR for delay & bitslip
+        self.bitslip_sel = CSRStorage(4)
+        self.bitslip = CSR()
+
+        for i in range(4):
+            self.specials += MultiReg(
+                self.bitslip_sel.storage[i] & self.bitslip.re,
+                self.rx_serdes.bitslip[i], "eem_sys")
+        
+        self.dly_cnt_in_sel = CSRStorage(4)
+        self.dly_cnt_in = CSRStorage(5)
+        self.dly_ld = CSR()
+
+        for i in range(4):
+            self.comb += [
+                self.rx_serdes.cnt_in[i].eq(self.dly_cnt_in.storage),
+                self.rx_serdes.ld[i].eq(self.dly_cnt_in_sel.storage[i] & self.dly_ld.re),
+            ]
+        
+        self.dly_cnt_out_sel = CSRStorage(4)
+        self.dly_cnt_out = CSRStatus(5)
+
+        self.comb += Case(self.dly_cnt_out_sel.storage, {
+            (1 << idx): self.dly_cnt_out.status.eq(self.rx_serdes.cnt_out[idx]) for idx in range(4)
+        })
+        
+        # CSR for global decoding phase
+        # This is to determine if this cycle should decode SERDES 0 or 1
+        self.decoder_dly = CSRStorage(4)
+        dec_dly_cdc = Signal(4)
+        self.specials += MultiReg(self.decoder_dly.storage, dec_dly_cdc, "eem_sys")
+
+        # Encoder/Decodfer interfaces
+        self.submodules.encoder = MultiEncoder()
+        self.submodules.decoders = decoders = Array(CrossbarDecoder() for _ in range(2))
+
+        # Wire up the IOB to serdes modules
+        for i in range(4):
+            self.comb += [
+                self.tx_phy.i[i].eq(self.tx_serdes.ser_out[i]),
+                self.tx_phy.t[i].eq(self.tx_serdes.t_out[i]),
+
+                self.rx_serdes.ser_in_no_dly[i].eq(self.rx_phy.o[i]),
+            ]
+        
+        # Control decoders phase
+        self.comb += [
+            decoders[0].delay.eq(dec_dly_cdc[:2]),
+            decoders[1].delay.eq(dec_dly_cdc[2:]),
+        ]
+        
+        # Route encoded symbols to TXSerdes
+        self.comb += [
+            self.tx_serdes.txdata[0].eq(self.encoder.output[0][:5]),
+            self.tx_serdes.txdata[1].eq(self.encoder.output[0][5:]),
+            self.tx_serdes.txdata[2].eq(self.encoder.output[1][:5]),
+            self.tx_serdes.txdata[3].eq(self.encoder.output[1][5:]),
+        ]
+
+        # Truncate RX, controllable via CSR
+        self.select_odd = CSRStorage(4)
+        select_odd_cdc = Signal(4)
+        self.specials += MultiReg(self.select_odd.storage, select_odd_cdc, "eem_sys")
+
+        decimated_rxdata = [ Signal(5) for _ in range(4) ]
+        for i in range(4):
+            self.comb += decimated_rxdata[i].eq(Mux(select_odd_cdc[i],
+                self.rx_serdes.rxdata[i][1::2], self.rx_serdes.rxdata[i][0::2]))
+        
+        # Route RXSerdes to decoder
+        self.comb += [
+            decoders[i//2].raw_input[i%2].eq(decimated_rxdata[i]) for i in range(4)
+        ]
+
+        # Always send out K.28.5 if not aligned
+        self.send_align = CSRStorage(reset=1)
+        self.specials += MultiReg(self.send_align.storage, self.encoder.align, "eem_sys")
+
+        # Alternate phase
+        phase = Signal()
+        # Assign to encoder and decoder
+        self.comb += [
+            self.encoder.phase.eq(phase),
+            self.decoders[0].phase.eq(phase),
+            self.decoders[1].phase.eq(phase),
+        ]
+
+        # Phase increment & reset mechanism
+        # Reset to 0 when externally triggered
+        self.phase_rst = Signal()
+        self.sync.eem_sys += If(self.phase_rst,
+            phase.eq(0),
+        ).Else(
+            phase.eq(~phase)
+        )
+        self.phase_out = Signal()
+        self.comb += self.phase_out.eq(phase)
+
+        # Interleave data/ctrl update
+        self.read_word = CSRStorage(2)
+        self.aligned = CSRStatus()
+
+        rx_d = Signal(8)
+        rx_k = Signal()
+
+        rx_d_prev = Signal(8)
+        rx_k_prev = Signal()
+
+        read_word_cdc = Signal(2)
+        self.specials += MultiReg(self.read_word.storage, read_word_cdc)
+
+        self.sync.eem_sys += [
+            If(~phase ^ read_word_cdc[0],
+                rx_d.eq(decoders[read_word_cdc[1]].d),
+                rx_k.eq(decoders[read_word_cdc[1]].k),
+                rx_d_prev.eq(rx_d),
+                rx_k_prev.eq(rx_k),
+            )
+        ]
+
+        found_align_symbol = Signal()
+        self.comb += found_align_symbol.eq(
+            (rx_d == 0xBC) & (rx_d_prev == 0xBC)
+            & (rx_k == 1) & (rx_k_prev == 1))
+        
+        self.specials += MultiReg(found_align_symbol, self.aligned.status)
+
+
+layout = [
+    ("sat_clk_rdy", 2, "satellite"),
+    ("phase_rdy",   3, "master"),
+    ("sat_rst",     4, "master"),
+    ("mst_clk_rdy", 5, "master"),
+    ("align_mst",   6, "satellite"),
+    ("align_sat",   7, "master"),
+]
+
+class EEMSerdes(Module, TransceiverInterface):    
+    def __init__(self, platform, eem, eem_aux, role="master", start_idx=0):
+        self.rx_ready = CSRStorage()
+
+        # Request resources
+        # TODO: Expand to support multiple EFCs
+        i_pads = [
+            platform.request("eem{}_fmc_data_in".format(eem), i) for i in range(4)
+        ]
+        o_pads = [
+            platform.request("eem{}_fmc_data_out".format(eem), i) for i in range(4)
+        ]
+
+        self.submodules.serdes = SerdesSingle(i_pads, o_pads)
+        self.submodules.aux = EEMAux(platform, eem_aux, role=role)
+        
+        # TODO: Move global phase here
+        if role == "master":
+            self.comb += self.aux.phase_in.eq(self.serdes.phase_out)
+        elif role == "satellite":
+            self.comb += self.serdes.phase_rst.eq(self.aux.phase_rst)
+        
+        chan_if = ChannelInterface(self.serdes.encoder, self.serdes.decoders)
+        self.comb += chan_if.rx_ready.eq(self.rx_ready.storage)
+        channel_interfaces = [chan_if]
+
+        TransceiverInterface.__init__(self, channel_interfaces, start_idx=start_idx)
+
+        self.comb += [
+            getattr(self, "cd_rtio_rx" + str(start_idx)).clk.eq(ClockSignal("eem_sys")),
+            getattr(self, "cd_rtio_rx" + str(start_idx)).rst.eq(ResetSignal("eem_sys"))
+        ]
+
+
+class EEMAux(Module, AutoCSR):
+    def __init__(self, platform, eem_aux, role="master"):
+        for name, _, src in layout:
+            if name != "sat_rst":
+                tmp = Signal()
+                pad = platform.request(("eem{}_fmc_"+name).format(eem_aux))
+                if src == role:
+                    self.specials += DifferentialOutput(tmp, pad.p, pad.n)
+                    setattr(self.submodules, name, gpio.GPIOOut(tmp))
+                else:
+                    self.specials += DifferentialInput(pad.p, pad.n, tmp)
+                    setattr(self.submodules, name, gpio.GPIOIn(tmp))
+
+        sat_rst_pad = platform.request("eem{}_fmc_sat_rst".format(eem_aux))
+        sat_rst_tmp = Signal()
+        if role == "master":
+            self.phase_in = Signal()
+            self.sat_phase_rst = CSR()
+            sat_phase_rst_r = Signal()
+            sat_phase_rst_rr = Signal()
+            sat_phase_rst_cdc = Signal()
+
+            self.specials += MultiReg(self.sat_phase_rst.re, sat_phase_rst_r, "eem_sys")
+            self.sync.eem_sys += sat_phase_rst_rr.eq(sat_phase_rst_r)
+            self.comb += sat_phase_rst_cdc.eq(sat_phase_rst_rr | sat_phase_rst_r)
+            gated_pulse = Signal()
+            self.sync.eem_sys += gated_pulse.eq(sat_phase_rst_cdc & self.phase_in)
+            self.specials += DifferentialOutput(gated_pulse, sat_rst_pad.p, sat_rst_pad.n)
+
+        elif role == "satellite":
+            self.phase_rst = Signal()
+            phase_in_raw = Signal()
+            self.specials += DifferentialInput(sat_rst_pad.p, sat_rst_pad.n, phase_in_raw)
+            self.specials += MultiReg(phase_in_raw, self.phase_rst, "eem_sys")
+        else:
+            ValueError("Invalid role type")

--- a/artiq/gateware/eem_7series.py
+++ b/artiq/gateware/eem_7series.py
@@ -134,6 +134,11 @@ def peripheral_hvamp(module, peripheral, **kwargs):
         ttl_simple.Output, **kwargs)
 
 
+def peripheral_efc(module, peripheral, **kwargs):
+    # Skip, EFC was handled during the DRTIO phase
+    pass
+
+
 peripheral_processors = {
     "dio": peripheral_dio,
     "dio_spi": peripheral_dio_spi,
@@ -147,6 +152,7 @@ peripheral_processors = {
     "fastino": peripheral_fastino,
     "phaser": peripheral_phaser,
     "hvamp": peripheral_hvamp,
+    "efc": peripheral_efc,
 }
 
 

--- a/artiq/gateware/fmc.py
+++ b/artiq/gateware/fmc.py
@@ -1,0 +1,213 @@
+from migen import *
+from migen.build.generic_platform import *
+from migen.genlib.io import DifferentialOutput
+
+from artiq.gateware import rtio
+from artiq.gateware.rtio.phy import spi2, ad53xx_monitor, dds, grabber
+from artiq.gateware.suservo import servo, pads as servo_pads
+from artiq.gateware.rtio.phy import servo as rtservo, fastino, phaser
+from artiq.gateware.drtio.transceiver import eem_serdes
+
+
+def _fmc_signal(i):
+    n = "d{}".format(i)
+    if i == 0:
+        n += "_cc"
+    return n
+
+
+def _fmc_pin(fmc, i, pol):
+    return "fmc{}:{}_{}".format(fmc, _fmc_signal(i), pol)
+
+
+def default_iostandard(fmc):
+    return IOStandard("LVDS_25")
+
+
+class _FMC:
+    @classmethod
+    def add_extension(cls, target, fmc, *args, **kwargs):
+        name = cls.__name__
+        target.platform.add_extension(cls.io(fmc, *args, **kwargs))
+        print("{} (FMC{}) starting at RTIO channel 0x{:06x}"
+              .format(name, fmc, len(target.rtio_channels)))
+
+class DIO(_FMC):
+    @staticmethod
+    def io(fmc, iostandard):
+        return [("dio{}".format(fmc), i,
+            Subsignal("p", Pins(_fmc_pin(fmc, i, "p"))),
+            Subsignal("n", Pins(_fmc_pin(fmc, i, "n"))),
+            iostandard(fmc))
+            for i in range(8)]
+
+    @classmethod
+    def add_std(cls, target, fmc, ttl03_cls, ttl47_cls, iostandard=default_iostandard,
+            edge_counter_cls=None):
+        cls.add_extension(target, fmc, iostandard=iostandard)
+
+        phys = []
+        dci = iostandard(fmc).name == "LVDS"
+        for i in range(4):
+            pads = target.platform.request("dio{}".format(fmc), i)
+            phy = ttl03_cls(pads.p, pads.n, dci=dci)
+            phys.append(phy)
+            target.submodules += phy
+            target.rtio_channels.append(rtio.Channel.from_phy(phy))
+        for i in range(4):
+            pads = target.platform.request("dio{}".format(fmc), 4+i)
+            phy = ttl47_cls(pads.p, pads.n, dci=dci)
+            phys.append(phy)
+            target.submodules += phy
+            target.rtio_channels.append(rtio.Channel.from_phy(phy))
+
+        if edge_counter_cls is not None:
+            for phy in phys:
+                state = getattr(phy, "input_state", None)
+                if state is not None:
+                    counter = edge_counter_cls(state)
+                    target.submodules += counter
+                    target.rtio_channels.append(rtio.Channel.from_phy(counter))
+
+
+class DIO_SPI(_FMC):
+    @staticmethod
+    def io(fmc, spi, ttl, iostandard):
+        def spi_subsignals(clk, mosi, miso, cs, pol):
+            signals = [Subsignal("clk", Pins(_fmc_pin(fmc, clk, pol)))]
+            if mosi is not None:
+                signals.append(Subsignal("mosi",
+                                         Pins(_fmc_pin(fmc, mosi, pol))))
+            if miso is not None:
+                signals.append(Subsignal("miso",
+                                         Pins(_fmc_pin(fmc, miso, pol))))
+            if cs:
+                signals.append(Subsignal("cs_n", Pins(
+                    *(_fmc_pin(fmc, pin, pol) for pin in cs))))
+            return signals
+
+        spi = [
+            ("dio{}_spi{}_{}".format(fmc, i, pol), i,
+             *spi_subsignals(clk, mosi, miso, cs, pol),
+             iostandard(fmc))
+            for i, (clk, mosi, miso, cs) in enumerate(spi) for pol in "pn"
+        ]
+        ttl = [
+            ("dio{}".format(fmc), i,
+             Subsignal("p", Pins(_fmc_pin(fmc, pin, "p"))),
+             Subsignal("n", Pins(_fmc_pin(fmc, pin, "n"))),
+             iostandard(fmc))
+            for i, (pin, _, _) in enumerate(ttl)
+        ]
+        return spi + ttl
+
+    @classmethod
+    def add_std(cls, target, fmc, spi, ttl, iostandard=default_iostandard):
+        cls.add_extension(target, fmc, spi, ttl, iostandard=iostandard)
+
+        for i in range(len(spi)):
+            phy = spi2.SPIMaster(
+                target.platform.request("dio{}_spi{}_p".format(fmc, i)),
+                target.platform.request("dio{}_spi{}_n".format(fmc, i))
+            )
+            target.submodules += phy
+            target.rtio_channels.append(
+                rtio.Channel.from_phy(phy, ififo_depth=4))
+
+        dci = iostandard(fmc).name == "LVDS"
+        for i, (_, ttl_cls, edge_counter_cls) in enumerate(ttl):
+            pads = target.platform.request("dio{}".format(fmc), i)
+            phy = ttl_cls(pads.p, pads.n, dci=dci)
+            target.submodules += phy
+            target.rtio_channels.append(rtio.Channel.from_phy(phy))
+
+            if edge_counter_cls is not None:
+                state = getattr(phy, "input_state", None)
+                if state is not None:
+                    counter = edge_counter_cls(state)
+                    target.submodules += counter
+                    target.rtio_channels.append(rtio.Channel.from_phy(counter))
+
+class Shuttler(_FMC):
+    @staticmethod
+    def io(fmc, fmc_aux, iostandard):
+        ios = [
+            ("sampler{}_adc_spi_p".format(fmc), 0,
+                Subsignal("clk", Pins(_fmc_pin(fmc, 0, "p"))),
+                Subsignal("miso", Pins(_fmc_pin(fmc, 1, "p")), Misc("DIFF_TERM=TRUE")),
+                iostandard(fmc),
+            ),
+            ("sampler{}_adc_spi_n".format(fmc), 0,
+                Subsignal("clk", Pins(_fmc_pin(fmc, 0, "n"))),
+                Subsignal("miso", Pins(_fmc_pin(fmc, 1, "n")), Misc("DIFF_TERM=TRUE")),
+                iostandard(fmc),
+            ),
+            ("sampler{}_pgia_spi_p".format(fmc), 0,
+                Subsignal("clk", Pins(_fmc_pin(fmc, 4, "p"))),
+                Subsignal("mosi", Pins(_fmc_pin(fmc, 5, "p"))),
+                Subsignal("miso", Pins(_fmc_pin(fmc, 6, "p")), Misc("DIFF_TERM=TRUE")),
+                Subsignal("cs_n", Pins(_fmc_pin(fmc, 7, "p"))),
+                iostandard(fmc),
+            ),
+            ("sampler{}_pgia_spi_n".format(fmc), 0,
+                Subsignal("clk", Pins(_fmc_pin(fmc, 4, "n"))),
+                Subsignal("mosi", Pins(_fmc_pin(fmc, 5, "n"))),
+                Subsignal("miso", Pins(_fmc_pin(fmc, 6, "n")), Misc("DIFF_TERM=TRUE")),
+                Subsignal("cs_n", Pins(_fmc_pin(fmc, 7, "n"))),
+                iostandard(fmc),
+            ),
+        ] + [
+            ("sampler{}_{}".format(fmc, sig), 0,
+                Subsignal("p", Pins(_fmc_pin(j, i, "p"))),
+                Subsignal("n", Pins(_fmc_pin(j, i, "n"))),
+                iostandard(j)
+            ) for i, j, sig in [
+                (2, fmc, "sdr"),
+                (3, fmc, "cnv")
+            ]
+        ]
+        if fmc_aux is not None:
+            ios += [
+                ("sampler{}_adc_data_p".format(fmc), 0,
+                    Subsignal("clkout", Pins(_fmc_pin(fmc_aux, 0, "p"))),
+                    Subsignal("sdoa", Pins(_fmc_pin(fmc_aux, 1, "p"))),
+                    Subsignal("sdob", Pins(_fmc_pin(fmc_aux, 2, "p"))),
+                    Subsignal("sdoc", Pins(_fmc_pin(fmc_aux, 3, "p"))),
+                    Subsignal("sdod", Pins(_fmc_pin(fmc_aux, 4, "p"))),
+                    Misc("DIFF_TERM=TRUE"),
+                    iostandard(fmc_aux),
+                ),
+                ("sampler{}_adc_data_n".format(fmc), 0,
+                    Subsignal("clkout", Pins(_fmc_pin(fmc_aux, 0, "n"))),
+                    Subsignal("sdoa", Pins(_fmc_pin(fmc_aux, 1, "n"))),
+                    Subsignal("sdob", Pins(_fmc_pin(fmc_aux, 2, "n"))),
+                    Subsignal("sdoc", Pins(_fmc_pin(fmc_aux, 3, "n"))),
+                    Subsignal("sdod", Pins(_fmc_pin(fmc_aux, 4, "n"))),
+                    Misc("DIFF_TERM=TRUE"),
+                    iostandard(fmc_aux),
+                ),
+            ]
+        return ios
+
+    @classmethod
+    def add_std(cls, target, fmc, fmc_aux, ttl_out_cls, iostandard=default_iostandard):
+        cls.add_extension(target, fmc, fmc_aux, iostandard=iostandard)
+
+        phy = spi2.SPIMaster(
+                target.platform.request("sampler{}_adc_spi_p".format(fmc)),
+                target.platform.request("sampler{}_adc_spi_n".format(fmc)))
+        target.submodules += phy
+        target.rtio_channels.append(rtio.Channel.from_phy(phy, ififo_depth=4))
+        phy = spi2.SPIMaster(
+                target.platform.request("sampler{}_pgia_spi_p".format(fmc)),
+                target.platform.request("sampler{}_pgia_spi_n".format(fmc)))
+        target.submodules += phy
+
+        target.rtio_channels.append(rtio.Channel.from_phy(phy, ififo_depth=4))
+        pads = target.platform.request("sampler{}_cnv".format(fmc))
+        phy = ttl_out_cls(pads.p, pads.n)
+        target.submodules += phy
+
+        target.rtio_channels.append(rtio.Channel.from_phy(phy))
+        sdr = target.platform.request("sampler{}_sdr".format(fmc))
+        target.specials += DifferentialOutput(1, sdr.p, sdr.n)

--- a/artiq/gateware/shuttler/io_map.py
+++ b/artiq/gateware/shuttler/io_map.py
@@ -1,0 +1,174 @@
+from copy import copy
+import pprint
+from migen import *
+from migen.build.generic_platform import *
+
+def default_iostandard():
+    return IOStandard("LVDS_25")
+
+def _fmc_pins(fmc, sigs_names):
+    sig_list = sigs_names.split()
+    temp = [("fmc{}:{}".format(fmc, sig)) for sig in sig_list]
+    pins = temp.pop(0)
+    for sig in temp:
+        pins = "{} {}".format(pins, sig)
+    return pins
+
+class shuttler_fmc_ios():
+    @staticmethod
+    def fmc_io_map(fmc, iostandard):
+        ios = []
+
+        signal_dict_template = {"Pins": ""}
+        dac_din_template = {"data": [], "dclkio": []}
+        dac_ctrl_template = {"spi": [], "reset": []}
+        dac_spi_template={"clk": copy(signal_dict_template),
+                        "cs_n": copy(signal_dict_template),
+                        "sdio": copy(signal_dict_template),
+                        "cs_a": copy(signal_dict_template)
+                        }
+
+        dac_din = copy(dac_din_template)
+        dac_ctrl = copy(dac_ctrl_template)
+        for i in range(8):
+            dac_din["data"].append(copy(signal_dict_template))
+            dac_din["dclkio"].append(copy(signal_dict_template))
+        
+        dac_ctrl["spi"] = copy(dac_spi_template)
+        dac_ctrl["reset"] = copy(signal_dict_template)
+        
+        dac_din["data"][0]["Pins"]   = "HA06_N HA06_P HA07_N HA02_N HA07_P HA02_P HA03_N HA03_P HA04_N HA04_P HA05_N HA05_P HA00_CC_N HA01_CC_N"
+        dac_din["dclkio"][0]["Pins"] = "HA00_CC_P"
+
+        dac_din["data"][1]["Pins"]   = "LA09_P LA09_N LA07_N LA08_N LA07_P LA08_P LA05_N LA04_N LA05_P LA06_N LA04_P LA03_N LA03_P LA06_P"
+        dac_din["dclkio"][1]["Pins"] = "LA00_CC_P"
+
+        dac_din["data"][2]["Pins"]   = "HA14_N HA14_P HA12_N HA12_P HA13_N HA10_N HA10_P HA11_N HA11_P HA13_P HA08_N HA08_P HA09_N HA09_P"
+        dac_din["dclkio"][2]["Pins"] = "HA01_CC_P"
+
+        dac_din["data"][3]["Pins"]   = "LA14_N LA15_N LA16_N LA15_P LA14_P LA13_N LA16_P LA13_P LA11_N LA12_N LA11_P LA12_P LA10_N LA10_P"
+        dac_din["dclkio"][3]["Pins"] = "LA01_CC_P"
+
+        dac_din["data"][4]["Pins"]   = "HA22_N HA19_N HA22_P HA21_N HA21_P HA19_P HA18_N HA20_N HA20_P HA18_P HA15_N HA15_P HA16_N HA16_P"
+        dac_din["dclkio"][4]["Pins"] = "HA17_CC_P"
+
+        dac_din["data"][5]["Pins"]   = "LA24_N LA25_N LA24_P LA25_P LA21_N LA21_P LA22_N LA22_P LA23_N LA23_P LA19_N LA19_P LA20_N LA20_P"
+        dac_din["dclkio"][5]["Pins"] = "LA17_CC_P"
+
+        dac_din["data"][6]["Pins"]   = "HB08_N HB08_P HB07_N HB07_P HB04_N HB04_P HB01_N HB05_N HB01_P HB05_P HB02_N HB02_P HB03_N HB03_P"
+        dac_din["dclkio"][6]["Pins"] = "HB00_CC_P"
+
+        dac_din["data"][7]["Pins"]   = "HB13_N HB12_N HB13_P HB12_P HB15_N HB15_P HB11_N HB09_N HB09_P HB14_N HB14_P HB10_N HB10_P HB11_P"
+        dac_din["dclkio"][7]["Pins"] = "HB06_CC_P"
+
+        dac_ctrl["reset"]["Pins"] = "HB16_P"
+        dac_ctrl["spi"]["cs_a"]["Pins"] = "LA31_P HB19_P LA30_P"
+        dac_ctrl["spi"]["clk"]["Pins"] = "HB16_N"
+        dac_ctrl["spi"]["cs_n"]["Pins"] = "LA31_N"
+        dac_ctrl["spi"]["sdio"]["Pins"] = "HB06_CC_N"
+  
+        led = { "led0_g": {"Pins":"HA23_N"},
+            "led0_r": {"Pins":"HA23_P"},
+            "led1_g": {"Pins":"LA32_P"},
+            "led1_r": {"Pins":"HB18_N"}}
+
+        osc = { "osc_sda": {"Pins":"HB20_P"},
+                "osc_scl": {"Pins":"HB21_N"},
+                "osc_en" : {"Pins":"HB20_N"}}
+
+        mmcx_osc_sel_n = {"mmcx_osc_sel_n": {"Pins":"HB17_CC_N"}}
+        
+        ref_clk_sel = {"ref_clk_sel": {"Pins":"LA32_N"}}
+        
+        fmc_clk_m2c2 = {"fmc_clk_m2c2": {"Pins":["LA18_CC_P", "LA18_CC_N"], "diff_term": True, "diff_sig": True}}
+
+        afe = {"ctrl_vadj":[{"channel": 0, 
+                            "Pins": "LA02_P LA02_N LA00_CC_N LA01_CC_N LA17_CC_N LA27_P LA27_N LA26_P"}, 
+                        {"channel": 1, 
+                        "Pins": "LA29_P LA29_N LA28_P LA28_N LA30_N LA33_P HB21_P HB18_P"}],
+            "01_01dir":{"Pins": "LA26_N"},
+            "01_23dir":{"Pins": "HB00_CC_N"},
+            "01_45dir":{"Pins": "HB17_CC_P"},
+            "01_67dir":{"Pins": "HA17_CC_N"},
+            "01_oen":  {"Pins": "HB19_N"}
+        }
+
+        ios += [("shuttler{}_dac_din".format(fmc), i,
+            Subsignal("data", Pins(_fmc_pins(fmc, dac_din["data"][i]["Pins"]))),
+            Subsignal("dclkio", Pins(_fmc_pins(fmc, dac_din["dclkio"][i]["Pins"]))),
+            default_iostandard()
+            )for i in range(8)]
+        
+        # Operate in 3-wire SPI
+        ios += [("shuttler{}_dac_ctrl_spi".format(fmc), 0,
+            Subsignal("clk", Pins(_fmc_pins(fmc, dac_ctrl["spi"]["clk"]["Pins"]))),
+            Subsignal("mosi", Pins(_fmc_pins(fmc, dac_ctrl["spi"]["sdio"]["Pins"]))),
+            Subsignal("cs_n", Pins(_fmc_pins(fmc, dac_ctrl["spi"]["cs_n"]["Pins"]))),
+            default_iostandard()
+            )]
+
+        ios += [("shuttler{}_dac_ctrl".format(fmc), 0,
+            Subsignal("reset", Pins(_fmc_pins(fmc, dac_ctrl["reset"]["Pins"]))),
+            Subsignal("cs_sel", Pins(_fmc_pins(fmc, dac_ctrl["spi"]["cs_a"]["Pins"]))),
+            default_iostandard()
+            )]
+
+        # Temporarily change name to get it compile
+        ios += [("user_led", 0, Pins(_fmc_pins(fmc, led["led0_g"]["Pins"])), IOStandard("LVCMOS25")),
+                ("user_led", 1, Pins(_fmc_pins(fmc, led["led0_r"]["Pins"])), IOStandard("LVCMOS25")),
+                ("user_led", 2, Pins(_fmc_pins(fmc, led["led1_g"]["Pins"])), IOStandard("LVCMOS25")),
+                ("user_led", 3, Pins(_fmc_pins(fmc, led["led1_r"]["Pins"])), IOStandard("LVCMOS25")),
+        ]
+
+        """
+        ios += [("shuttler{}_led".format(fmc), 0,
+            Subsignal("g", Pins(_fmc_pins(fmc, led["led0_g"]["Pins"]))),
+            Subsignal("r", Pins(_fmc_pins(fmc, led["led0_r"]["Pins"]))),
+            default_iostandard()
+            )]
+
+        ios += [("shuttler{}_led".format(fmc), 1,
+            Subsignal("g", Pins(_fmc_pins(fmc, led["led1_g"]["Pins"]))),
+            Subsignal("r", Pins(_fmc_pins(fmc, led["led1_r"]["Pins"]))),
+            default_iostandard()
+            )]
+        """
+        ios += [("shuttler{}_osc".format(fmc), 0,
+            Subsignal("sda", Pins(_fmc_pins(fmc, osc["osc_sda"]["Pins"]))),
+            Subsignal("scl", Pins(_fmc_pins(fmc, osc["osc_scl"]["Pins"]))),
+            Subsignal("en", Pins(_fmc_pins(fmc, osc["osc_en"]["Pins"]))),
+            default_iostandard()
+            )]
+        
+        ios += [("shuttler{}_mmcx_osc_sel_n".format(fmc), 0, 
+            Pins(_fmc_pins(fmc, mmcx_osc_sel_n["mmcx_osc_sel_n"]["Pins"])),
+            default_iostandard()
+            )]
+
+        ios += [("shuttler{}_ref_clk_sel".format(fmc), 0, 
+            Pins(_fmc_pins(fmc, ref_clk_sel["ref_clk_sel"]["Pins"])),
+            default_iostandard()
+            )]
+
+        ios += [("shuttler{}_fmc_clk_m2c2".format(fmc), 0, 
+            Subsignal("p", Pins(_fmc_pins(fmc, fmc_clk_m2c2["fmc_clk_m2c2"]["Pins"][0]))),
+            Subsignal("n", Pins(_fmc_pins(fmc, fmc_clk_m2c2["fmc_clk_m2c2"]["Pins"][1]))),
+            default_iostandard(),
+            Misc("DIFF_TERM=TRUE")
+            )]
+    
+        ios += [("shuttler{}_afe_ctrl_vadj".format(fmc), 0,
+            Pins(_fmc_pins(fmc,afe["ctrl_vadj"][i]["Pins"])),
+            default_iostandard()
+            )for i in range(2)]
+        
+        ios += [("shuttler{}_afe".format(fmc), 0,
+            Subsignal("01_01dir", Pins(_fmc_pins(fmc, afe["01_01dir"]["Pins"]))),
+            Subsignal("01_23dir", Pins(_fmc_pins(fmc, afe["01_23dir"]["Pins"]))),
+            Subsignal("01_45dir", Pins(_fmc_pins(fmc, afe["01_45dir"]["Pins"]))),
+            Subsignal("01_67dir", Pins(_fmc_pins(fmc, afe["01_67dir"]["Pins"]))),
+            Subsignal("01_oen", Pins(_fmc_pins(fmc, afe["01_oen"]["Pins"]))),
+            default_iostandard()
+            )]
+
+        return ios

--- a/artiq/gateware/targets/efc.py
+++ b/artiq/gateware/targets/efc.py
@@ -14,7 +14,8 @@ from misoc.targets.efc import BaseSoC
 from misoc.integration.builder import builder_args, builder_argdict
 
 from artiq.gateware.amp import AMPSoC
-from artiq.gateware import rtio, shuttler
+from artiq.gateware import rtio
+from artiq.gateware.shuttler.core import Shuttler
 from artiq.gateware.rtio.phy import ttl_simple, ttl_serdes_7series, edge_counter
 from artiq.gateware.rtio.xilinx_clocking import fix_serdes_timing_path
 from artiq.gateware import eem
@@ -24,6 +25,7 @@ from artiq.gateware.drtio.rx_synchronizer import XilinxRXSynchronizer
 from artiq.gateware.drtio import *
 from artiq.build_soc import *
 
+from pprint import pp
 
 class SerdesCRG(Module, AutoCSR):
     def __init__(self, platform, main_clk):
@@ -84,7 +86,8 @@ class SatelliteBase(BaseSoC):
         add_identifier(self, gateware_identifier_str=gateware_identifier_str)
 
         platform = self.platform
-        platform.add_extension(shuttler.fmc_adapter_io)
+        #platform.add_extension(Shuttler.io)
+        self.platform.add_extension(Shuttler.io())
 
         eem_data = 1
         eem_aux = 0

--- a/artiq/gateware/targets/efc.py
+++ b/artiq/gateware/targets/efc.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+
+import argparse
+
+from migen import *
+from migen.genlib.resetsync import AsyncResetSynchronizer
+from migen.genlib.cdc import MultiReg
+from migen.genlib.io import DifferentialOutput
+
+from misoc.interconnect.csr import *
+from misoc.cores import gpio
+from misoc.cores.a7_gtp import *
+from misoc.targets.efc import BaseSoC
+from misoc.integration.builder import builder_args, builder_argdict
+
+from artiq.gateware.amp import AMPSoC
+from artiq.gateware import rtio, shuttler
+from artiq.gateware.rtio.phy import ttl_simple, ttl_serdes_7series, edge_counter
+from artiq.gateware.rtio.xilinx_clocking import fix_serdes_timing_path
+from artiq.gateware import eem
+from artiq.gateware.drtio.transceiver import gtp_7series
+from artiq.gateware.drtio.siphaser import SiPhaser7Series
+from artiq.gateware.drtio.rx_synchronizer import XilinxRXSynchronizer
+from artiq.gateware.drtio import *
+from artiq.build_soc import *
+
+from artiq.gateware.drtio.transceiver.eem_serdes import SerdesSingle, EEMSerdes, EEMAux
+from artiq.gateware.drtio.transceiver.eem_helper import generate_pads
+
+
+class SatelliteBase(BaseSoC):
+    mem_map = {
+        "drtioaux": 0x50000000,
+    }
+    mem_map.update(BaseSoC.mem_map)
+
+    def __init__(self, rtio_clk_freq=125e6, enable_sata=False, *, gateware_identifier_str=None, hw_rev="v2.0", **kwargs):
+        if hw_rev in ("v1.0", "v1.1"):
+            cpu_bus_width = 32
+        else:
+            cpu_bus_width = 64
+        BaseSoC.__init__(self,
+                 cpu_type="vexriscv",
+                 cpu_bus_width=cpu_bus_width,
+                 sdram_controller_type="minicon",
+                 l2_size=128*1024,
+                 clk_freq=rtio_clk_freq,
+                 **kwargs)
+        add_identifier(self, gateware_identifier_str=gateware_identifier_str)
+
+        platform = self.platform
+        platform.add_extension(shuttler.fmc_adapter_io)
+
+        eem_serdes = 1
+        eem_aux = 0
+        self.platform.add_extension(eem.FMCCarrier.io(eem_serdes, eem_aux, role="satellite"))
+
+        # Disable SERVMOD, hardwire it to ground to enable EEM
+        servmod = self.platform.request("servmod")
+        self.comb += servmod.eq(0)
+
+        self.submodules.eem_transceiver = EEMSerdes(self.platform, eem_serdes, eem_aux, role="satellite")
+        self.csr_devices.append("eem_transceiver")
+        self.config["HAS_DRTIO_EEM"] = None
+
+        self.platform.add_false_path_constraints(self.crg.cd_sys.clk, self.crg.cd_eem_sys.clk)
+
+        self.submodules.rtio_tsc = rtio.TSC(glbl_fine_ts_width=3)
+
+        drtioaux_csr_group = []
+        drtioaux_memory_group = []
+        drtiorep_csr_group = []
+        self.drtio_cri = []
+        for i in range(len(self.eem_transceiver.channels)):
+            coreaux_name = "drtioaux" + str(i)
+            memory_name = "drtioaux" + str(i) + "_mem"
+            drtioaux_csr_group.append(coreaux_name)
+            drtioaux_memory_group.append(memory_name)
+
+            cdr = ClockDomainsRenamer({"rtio_rx": "rtio_rx" + str(i)})
+
+            if i == 0:
+                self.submodules.rx_synchronizer = cdr(XilinxRXSynchronizer())
+                core = cdr(DRTIOSatellite(
+                    self.rtio_tsc, self.eem_transceiver.channels[i],
+                    self.rx_synchronizer))
+                self.submodules.drtiosat = core
+                self.csr_devices.append("drtiosat")
+            else:
+                corerep_name = "drtiorep" + str(i-1)
+                drtiorep_csr_group.append(corerep_name)
+
+                core = cdr(DRTIORepeater(
+                    self.rtio_tsc, self.eem_transceiver.channels[i]))
+                setattr(self.submodules, corerep_name, core)
+                self.drtio_cri.append(core.cri)
+                self.csr_devices.append(corerep_name)
+
+            coreaux = cdr(DRTIOAuxController(core.link_layer, self.cpu_dw))
+            setattr(self.submodules, coreaux_name, coreaux)
+            self.csr_devices.append(coreaux_name)
+
+            memory_address = self.mem_map["drtioaux"] + 0x800*i
+            self.add_wb_slave(memory_address, 0x800,
+                              coreaux.bus)
+            self.add_memory_region(memory_name, memory_address | self.shadow_base, 0x800)
+        self.config["HAS_DRTIO"] = None
+        self.add_csr_group("drtioaux", drtioaux_csr_group)
+        self.add_memory_group("drtioaux_mem", drtioaux_memory_group)
+        self.add_csr_group("drtiorep", drtiorep_csr_group)
+
+        i2c = self.platform.request("fpga_i2c")
+        self.submodules.i2c = gpio.GPIOTristate([i2c.scl, i2c.sda])
+        self.csr_devices.append("i2c")
+        self.config["I2C_BUS_COUNT"] = 1
+
+        # Enable I2C
+        i2c_reset = self.platform.request("i2c_mux_rst_n")
+        self.comb += i2c_reset.eq(1)
+
+        rtio_clk_period = 1e9/rtio_clk_freq
+        self.config["RTIO_FREQUENCY"] = str(rtio_clk_freq/1e6)
+
+        fix_serdes_timing_path(platform)
+
+    def add_rtio(self, rtio_channels, sed_lanes=8):
+        # Only add MonInj core if there is anything to monitor
+        if any([len(c.probes) for c in rtio_channels]):
+            self.submodules.rtio_moninj = rtio.MonInj(rtio_channels)
+            self.csr_devices.append("rtio_moninj")
+
+        self.submodules.local_io = SyncRTIO(self.rtio_tsc, rtio_channels, lane_count=sed_lanes)
+        self.comb += self.drtiosat.async_errors.eq(self.local_io.async_errors)
+        self.submodules.rtio_dma = rtio.DMA(self.get_native_sdram_if(), self.cpu_dw)
+        self.csr_devices.append("rtio_dma")
+        self.submodules.cri_con = rtio.CRIInterconnectShared(
+            [self.drtiosat.cri, self.rtio_dma.cri],
+            [self.local_io.cri] + self.drtio_cri,
+            enable_routing=True)
+        self.csr_devices.append("cri_con")
+        self.submodules.routing_table = rtio.RoutingTableAccess(self.cri_con)
+        self.csr_devices.append("routing_table")
+
+
+class Satellite(SatelliteBase):
+    def __init__(self, hw_rev=None, **kwargs):
+        if hw_rev is None:
+            hw_rev = "v2.0"
+        SatelliteBase.__init__(self, hw_rev=hw_rev, **kwargs)
+
+        self.rtio_channels = []
+        for i in range(2):
+            print("USER LED at RTIO channel 0x{:06x}".format(len(self.rtio_channels)))
+            phy = ttl_simple.Output(self.platform.request("user_led", i))
+            self.submodules += phy
+            self.rtio_channels.append(rtio.Channel.from_phy(phy))
+        
+        for i in range(2, 4):
+            led = self.platform.request("user_led", i)
+            if i % 2:
+                self.comb += led.eq(1)
+            else:
+                self.comb += led.eq(0)
+
+        self.add_rtio(self.rtio_channels)
+
+
+VARIANTS = {cls.__name__.lower(): cls for cls in [Satellite]}
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="ARTIQ device binary builder for EEM FMC Carrier systems")
+    builder_args(parser)
+    parser.set_defaults(output_dir="artiq_efc")
+    parser.add_argument("-V", "--variant", default="satellite",
+                        help="variant: {} (default: %(default)s)".format(
+                            "/".join(sorted(VARIANTS.keys()))))
+    parser.add_argument("--gateware-identifier-str", default=None,
+                        help="Override ROM identifier")
+    args = parser.parse_args()
+
+    argdict = dict()
+    argdict["gateware_identifier_str"] = args.gateware_identifier_str
+
+    variant = args.variant.lower()
+    try:
+        cls = VARIANTS[variant]
+    except KeyError:
+        raise SystemExit("Invalid variant (-V/--variant)")
+
+    soc = cls(**argdict)
+    build_artiq_soc(soc, builder_argdict(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/artiq/gateware/targets/kasli_generic.py
+++ b/artiq/gateware/targets/kasli_generic.py
@@ -71,10 +71,13 @@ class GenericMaster(MasterBase):
         if hw_rev is None:
             hw_rev = description["hw_rev"]
         self.class_name_override = description["variant"]
+        efc_peripherals = list(filter(lambda peripheral: peripheral["type"] == "efc", description["peripherals"]))
+        efc_port_list = [ peripheral["ports"] for peripheral in efc_peripherals ]
         MasterBase.__init__(self,
             hw_rev=hw_rev,
             rtio_clk_freq=description["rtio_frequency"],
             enable_sata=description["enable_sata_drtio"],
+            efc_port_list=efc_port_list,
             **kwargs)
         if "ext_ref_frequency" in description:
             self.config["SI5324_EXT_REF"] = None

--- a/digilent-hs2.cfg
+++ b/digilent-hs2.cfg
@@ -1,0 +1,8 @@
+adapter driver ftdi
+ftdi device_desc "Digilent USB Device"
+ftdi vid_pid 0x0403 0x6014
+
+ftdi channel 0
+ftdi layout_init 0x00e8 0x00eb
+
+reset_config none

--- a/efc.cfg
+++ b/efc.cfg
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+source [find digilent-hs2.cfg]
+
+ftdi tdo_sample_edge falling
+
+reset_config none
+transport select jtag
+adapter speed 25000
+
+source [find cpld/xilinx-xc7.cfg]
+source [find cpld/jtagspi.cfg]
+source [find fpga/xilinx-xadc.cfg]
+source [find fpga/xilinx-dna.cfg]


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request
This PR intends to add support for the [Shuttler](https://github.com/sinara-hw/Shuttler). This PR is developed based on #2134. 

## Current Status of PR
Work in Progress
- The gateware and firmware can be built and flashed with the flash script and code written on #2134 
- EFC board can startup the power stage of the Shuttler Board.
- UART log can be read on a computer

There are lots of hack around codes to be cleaned up.

(Note our shuttler board has the hardware [modification](https://github.com/sinara-hw/EEM_FMC_Carrier/issues/44) on clock_sel pin on SY58029U to default the clock to the onboard oscillator.)

## Description of Changes
EFC Shuttler Gateware:
- Add io map file for shuttler board

EFC Satellite Firmware: 
- Disable the clock switch logic as the gateware is not developed yet
- Enable the power on the FMC board at startup

## To Do
EFC Shuttler Gateware:
- Add the hardware modules (3-Wire SPI, I2C, OSERDESE2) needed to interface and configure the Shuttler Board
- (More to be added)

EFC Satellite Firmware:
- Write the startup sequence for Shuttler
- Set the DAC to output a waveform as a test for the gateware connection
- (More to be added)


Miscellaneous: 
- Clean up all the hack around code
- Break up this big PR and merge the working code into the master branch
- (To-Do items to be added later down the line)

### Related PR
This PR is derived from #2134 

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [ ] Use correct spelling and grammar.
- [ ] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [ ] Close/update issues.
- [ ] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [ ] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [ ] Test your changes or have someone test them. Mention what was tested and how.
- [ ] Add and check docstrings and comments
- [ ] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

- [ ] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [ ] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [ ] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
