### PR TITLE
EFC: Start up the power of FMC peripheral

### DIFF
--- a/artiq/firmware/libboard_misoc/lib.rs
+++ b/artiq/firmware/libboard_misoc/lib.rs
@@ -40,7 +40,7 @@ pub mod ethmac;
 pub mod i2c;
 #[cfg(soc_platform = "kasli")]
 pub mod i2c_eeprom;
-#[cfg(all(soc_platform = "kasli", hw_rev = "v2.0"))]
+#[cfg(any(all(soc_platform = "kasli", hw_rev = "v2.0"), soc_platform = "efc"))]
 pub mod io_expander;
 #[cfg(all(has_ethmac, feature = "smoltcp"))]
 pub mod net_settings;

--- a/artiq/firmware/satman/main.rs
+++ b/artiq/firmware/satman/main.rs
@@ -529,6 +529,19 @@ pub extern fn main() -> i32 {
 
     sysclk_setup();
 
+    #[cfg(soc_platform = "efc")]
+    {
+        let mut io_expander = board_misoc::io_expander::IoExpander::new().unwrap();
+        // Enable VADJ and P3V3_FMC
+        io_expander.set_oe(1, 1 << 0 | 1 << 1).unwrap();
+
+        io_expander.set(1, 0, true);
+        io_expander.set(1, 1, true);
+
+        io_expander.service().unwrap();
+    }
+
+    #[cfg(not(soc_platform = "efc"))]
     unsafe {
         csr::drtio_transceiver::txenable_write(0xffffffffu32 as _);
     }


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
This is a patch to startup the VADJ, P3V3_FMC power of the FMC board attached to the EFC Board.
1. efc's io expander method is added
2. Enable VADJ, P3V3_FMC power during initialization in satman main

The code is ported from #2134.

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
