### PR TITLE
Fix last `except` handler running if no others match on Kasli-SoC

### DIFF
--- a/artiq/compiler/transforms/llvm_ir_generator.py
+++ b/artiq/compiler/transforms/llvm_ir_generator.py
@@ -1376,7 +1376,7 @@ class LLVMIRGenerator:
 
         stack_save_needed = False
         for i, arg in enumerate(insn.arguments()):
-            llarg = self.map(arg)            
+            llarg = self.map(arg)
             if isinstance(llarg.type, (ll.LiteralStructType, ll.IdentifiedStructType)):
                 stack_save_needed = True
                 break
@@ -1909,6 +1909,10 @@ class LLVMIRGenerator:
                 self.add_pred(landingpadbb, self.llbuilder.basic_block)
                 self.llbuilder.branch(target)
             else:
-                self.llbuilder.resume(lllandingpad)
+                llinsn = self.llbuilder.call(
+                    self.llbuiltin("__artiq_resume"), [], name=insn.name
+                )
+                llinsn.attributes.add('noreturn')
+                self.llbuilder.unreachable()
 
         return llexn


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
This changes the compiler to generate a call to `@__artiq_resume` in the `try`/`except` fallthrough block, rather than LLVM's `resume` instruction.

This fixes a block on Kasli-SoC, where the last `except` block is run, if none of the preceding blocks match - see #2108 for further details.

### Related Issue
Closes #2108.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [X] Close/update issues.
- [X] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [ ] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how:
  - With this patch, the experiment in #2108 behaves as expected on both Kasli 1.1 and Kasli-SoC.
  - We've been running this for a little over a month now (with both Kasli-SoC and Kasli 1.1 masters), and not encountered any issues.

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
