### PR TITLE
Bootloader: Remove kusddrphy support for SDRAM Initialization

### DIFF
--- a/artiq/firmware/libboard_misoc/sdram.rs
+++ b/artiq/firmware/libboard_misoc/sdram.rs
@@ -8,9 +8,6 @@ mod ddr {
                     DFII_COMMAND_WRDATA, DFII_COMMAND_RDDATA};
     use sdram_phy::{DFII_NPHASES, DFII_PIX_DATA_SIZE, DFII_PIX_WRDATA_ADDR, DFII_PIX_RDDATA_ADDR};
 
-    #[cfg(kusddrphy)]
-    const DDRPHY_MAX_DELAY: u16 = 512;
-    #[cfg(not(kusddrphy))]
     const DDRPHY_MAX_DELAY: u16 = 32;
 
     const DQS_SIGNAL_COUNT: usize = DFII_PIX_DATA_SIZE / 2;
@@ -35,17 +32,12 @@ mod ddr {
 
     #[cfg(ddrphy_wlevel)]
     unsafe fn write_level_scan(logger: &mut Option<&mut dyn fmt::Write>) {
-        #[cfg(kusddrphy)]
-        log!(logger, "DQS initial delay: {} taps\n", ddrphy::wdly_dqs_taps_read());
         log!(logger, "Write leveling scan:\n");
 
         enable_write_leveling(true);
         spin_cycles(100);
 
-        #[cfg(not(kusddrphy))]
         let ddrphy_max_delay : u16 = DDRPHY_MAX_DELAY;
-        #[cfg(kusddrphy)]
-        let ddrphy_max_delay : u16 = DDRPHY_MAX_DELAY - ddrphy::wdly_dqs_taps_read();
 
         for n in 0..DQS_SIGNAL_COUNT {
             let dq_addr = dfii::PI0_RDDATA_ADDR
@@ -57,10 +49,6 @@ mod ddr {
 
             ddrphy::wdly_dq_rst_write(1);
             ddrphy::wdly_dqs_rst_write(1);
-            #[cfg(kusddrphy)]
-            for _ in 0..ddrphy::wdly_dqs_taps_read() {
-                ddrphy::wdly_dqs_inc_write(1);
-            }
 
             let mut dq;
             for _ in 0..ddrphy_max_delay {
@@ -88,17 +76,12 @@ mod ddr {
     unsafe fn write_level(logger: &mut Option<&mut dyn fmt::Write>,
                           delay: &mut [u16; DQS_SIGNAL_COUNT],
                           high_skew: &mut [bool; DQS_SIGNAL_COUNT]) -> bool {
-        #[cfg(kusddrphy)]
-        log!(logger, "DQS initial delay: {} taps\n", ddrphy::wdly_dqs_taps_read());
         log!(logger, "Write leveling: ");
 
         enable_write_leveling(true);
         spin_cycles(100);
 
-        #[cfg(not(kusddrphy))]
         let ddrphy_max_delay : u16 = DDRPHY_MAX_DELAY;
-        #[cfg(kusddrphy)]
-        let ddrphy_max_delay : u16 = DDRPHY_MAX_DELAY - ddrphy::wdly_dqs_taps_read();
 
         let mut failed = false;
         for n in 0..DQS_SIGNAL_COUNT {
@@ -112,10 +95,6 @@ mod ddr {
 
             ddrphy::wdly_dq_rst_write(1);
             ddrphy::wdly_dqs_rst_write(1);
-            #[cfg(kusddrphy)]
-            for _ in 0..ddrphy::wdly_dqs_taps_read() {
-                ddrphy::wdly_dqs_inc_write(1);
-            }
             ddrphy::wlevel_strobe_write(1);
             spin_cycles(10);
 
@@ -146,11 +125,6 @@ mod ddr {
                     dq = ptr::read_volatile(dq_addr);
                 }
 
-                // Get a bit further into the 0 zone
-                #[cfg(kusddrphy)]
-                for _ in 0..32 {
-                    incr_delay();
-                }
             }
 
             while dq == 0 {
@@ -191,9 +165,6 @@ mod ddr {
                 if delay[n] > threshold {
                     ddrphy::dly_sel_write(1 << n);
 
-                    #[cfg(kusddrphy)]
-                    ddrphy::rdly_dq_bitslip_write(1);
-                    #[cfg(not(kusddrphy))]
                     for _ in 0..3 {
                         ddrphy::rdly_dq_bitslip_write(1);
                     }
@@ -451,13 +422,9 @@ pub unsafe fn init(mut _logger: Option<&mut dyn fmt::Write>) -> bool {
 
     #[cfg(has_ddrphy)]
     {
-        #[cfg(kusddrphy)]
-        csr::ddrphy::en_vtc_write(0);
         if !ddr::level(&mut _logger) {
             return false
         }
-        #[cfg(kusddrphy)]
-        csr::ddrphy::en_vtc_write(1);
     }
 
     csr::dfii::control_write(sdram_phy::DFII_CONTROL_SEL);


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
This PR removes support for kusddrphy on sdram.rs as it is no longer support on ARTIQ.
(Note: kusddrphy is the DDR_PHY for Kintex 7 Series FPGA. See kusddrphy.py in [misoc](https://github.com/m-labs/misoc))

kusddrphy cfg flag and its related code are deleted in this PR.

## Testing Methodology
### Pass Requirement
Functions in sdram.rs are called by the bootloader to set up the DDR PHY in order to load the firmware onto SDRAM correctly. Therefore, successful startup of firmware indicates that the DDR PHY is initialized and functions correctly.

This can be observed through the UART Debug Output.

### Test Setup
Platform: Kasli
Commit: master 72a5231493599455f50b25d44e101d74e98762d0
Variant: Master
Result: The firmware is loaded and startup correctly.

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
