### PR TITLE
Bootloader: SDRAM patch for EFC

### DIFF
--- a/artiq/firmware/libboard_misoc/sdram.rs
+++ b/artiq/firmware/libboard_misoc/sdram.rs
@@ -246,7 +246,7 @@ mod ddr {
             ddrphy::dly_sel_write(1 << (DQS_SIGNAL_COUNT - n - 1));
 
             ddrphy::rdly_dq_rst_write(1);
-            #[cfg(soc_platform = "kasli")]
+            #[cfg(any(soc_platform = "kasli", soc_platform = "efc"))]
             {
                 for _ in 0..3 {
                     ddrphy::rdly_dq_bitslip_write(1);
@@ -337,7 +337,7 @@ mod ddr {
             let mut max_seen_valid = 0;
 
             ddrphy::rdly_dq_rst_write(1);
-            #[cfg(soc_platform = "kasli")]
+            #[cfg(any(soc_platform = "kasli", soc_platform = "efc"))]
             {
                 for _ in 0..3 {
                     ddrphy::rdly_dq_bitslip_write(1);
@@ -400,7 +400,7 @@ mod ddr {
 
             // Set delay to the middle
             ddrphy::rdly_dq_rst_write(1);
-            #[cfg(soc_platform = "kasli")]
+            #[cfg(any(soc_platform = "kasli", soc_platform = "efc"))]
             {
                 for _ in 0..3 {
                     ddrphy::rdly_dq_bitslip_write(1);


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
This PR includes a patch for the SDRAM initialization on the EFC platform. 

The code is tested on efc hardware. Removal of any modified lines of the cfg flags causes SDRAM fails to initialize and then firmware fails to be loaded. This can be observed in the UART Debug Output.

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
