### PR TITLE
spi2: update set_config_mu doc

### DIFF
--- a/artiq/coredevice/spi2.py
+++ b/artiq/coredevice/spi2.py
@@ -277,9 +277,8 @@ class NRTSPIMaster:
     def set_config_mu(self, flags=0, length=8, div=6, cs=1):
         """Set the ``config`` register.
 
-        Note that the non-realtime SPI cores are usually clocked by the system
-        clock and not the RTIO clock. In many cases, the SPI configuration is
-        already set by the firmware and you do not need to call this method.
+        In many cases, the SPI configuration is already set by the firmware
+        and you do not need to call this method.
         """
         spi_set_config(self.busno, flags, length, div, cs)
 


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Update ``spi2`` coredevice driver note for ``set_config_mu`` - as RTIO and SYS clock separation is no longer applicable, the mention of it is removed from the note.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.


### Code Changes

- [x] Add and check docstrings and comments

### Documentation Changes

- [x] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
