### PR TITLE
simple: add kwargs to AppletControlRPC

### DIFF
--- a/artiq/applets/simple.py
+++ b/artiq/applets/simple.py
@@ -44,8 +44,8 @@ class AppletControlRPC:
         self.dataset_ctl = dataset_ctl
         self.background_tasks = set()
 
-    def _background(self, coro, *args):
-        task = self.loop.create_task(coro(*args))
+    def _background(self, coro, *args, **kwargs):
+        task = self.loop.create_task(coro(*args, **kwargs))
         self.background_tasks.add(task)
         task.add_done_callback(self.background_tasks.discard)
 


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

`AppletControlRPC` in `artiq.applets.simple.py` was missing kwargs and as such `set-dataset` breaks when called on RPC.

Old implementation:

```
def _background(self, coro, *args):
        task = self.loop.create_task(coro(*args))
        self.background_tasks.add(task)
        task.add_done_callback(self.background_tasks.discard)
```

Proposed:

```
def _background(self, coro, *args, **kwargs):
        task = self.loop.create_task(coro(*args, **kwargs))
        self.background_tasks.add(task)
        task.add_done_callback(self.background_tasks.discard)
```

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.
Quick smoke test to ensure set-dataset works on RPC.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:


### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
