### PR TITLE
Upgrade to LLD 14

### DIFF
--- a/artiq/firmware/Cargo.lock
+++ b/artiq/firmware/Cargo.lock
@@ -320,6 +320,7 @@ dependencies = [
  "build_misoc",
  "byteorder",
  "cslice",
+ "dyld",
  "eh",
  "failure",
  "failure_derive",

--- a/artiq/firmware/ksupport/glue.c
+++ b/artiq/firmware/ksupport/glue.c
@@ -17,7 +17,7 @@ void send_to_rtio_log(struct slice data);
 #define KERNELCPU_EXEC_ADDRESS    0x45000000
 #define KERNELCPU_PAYLOAD_ADDRESS 0x45060000
 #define KERNELCPU_LAST_ADDRESS    0x4fffffff
-#define KSUPPORT_HEADER_SIZE      0x80
+#define KSUPPORT_HEADER_SIZE      0x74
 
 FILE *stderr;
 

--- a/artiq/firmware/ksupport/ksupport.ld
+++ b/artiq/firmware/ksupport/ksupport.ld
@@ -35,16 +35,6 @@ SECTIONS
         *(.text .text.*)
     } :text
 
-    /* https://sourceware.org/bugzilla/show_bug.cgi?id=20475 */
-    .got : {
-        PROVIDE(_GLOBAL_OFFSET_TABLE_ = .);
-        *(.got)
-    } :text
-
-    .got.plt : {
-        *(.got.plt)
-    } :text
-
     .rodata :
     {
         *(.rodata .rodata.*)

--- a/artiq/firmware/libproto_artiq/kernel_proto.rs
+++ b/artiq/firmware/libproto_artiq/kernel_proto.rs
@@ -5,7 +5,10 @@ use dyld;
 pub const KERNELCPU_EXEC_ADDRESS:    usize = 0x45000000;
 pub const KERNELCPU_PAYLOAD_ADDRESS: usize = 0x45060000;
 pub const KERNELCPU_LAST_ADDRESS:    usize = 0x4fffffff;
-pub const KSUPPORT_HEADER_SIZE:      usize = 0x80;
+
+// Must match the offset of the first (starting at KERNELCPU_EXEC_ADDRESS)
+// section in ksupport.elf.
+pub const KSUPPORT_HEADER_SIZE: usize = 0x74;
 
 #[derive(Debug)]
 pub enum Message<'a> {

--- a/artiq/firmware/runtime/Cargo.toml
+++ b/artiq/firmware/runtime/Cargo.toml
@@ -19,6 +19,7 @@ byteorder = { version = "1.0", default-features = false }
 cslice = { version = "0.3" }
 log = { version = "0.4", default-features = false }
 managed = { version = "^0.7.1", default-features = false, features = ["alloc", "map"] }
+dyld = { path = "../libdyld" }
 eh = { path = "../libeh" }
 unwind_backtrace = { path = "../libunwind_backtrace" }
 io = { path = "../libio", features = ["byteorder"] }

--- a/artiq/firmware/runtime/kernel.rs
+++ b/artiq/firmware/runtime/kernel.rs
@@ -1,5 +1,5 @@
-use core::ptr;
 use board_misoc::csr;
+use core::{ptr, slice};
 use mailbox;
 use rpc_queue;
 
@@ -13,15 +13,20 @@ pub unsafe fn start() {
 
     stop();
 
-    extern {
+    extern "C" {
         static _binary____ksupport_ksupport_elf_start: u8;
         static _binary____ksupport_ksupport_elf_end: u8;
     }
-    let ksupport_start = &_binary____ksupport_ksupport_elf_start as *const _;
-    let ksupport_end   = &_binary____ksupport_ksupport_elf_end as *const _;
-    ptr::copy_nonoverlapping(ksupport_start,
-                             (KERNELCPU_EXEC_ADDRESS - KSUPPORT_HEADER_SIZE) as *mut u8,
-                             ksupport_end as usize - ksupport_start as usize);
+    let ksupport_elf_start = &_binary____ksupport_ksupport_elf_start as *const u8;
+    let ksupport_elf_end = &_binary____ksupport_ksupport_elf_end as *const u8;
+    let ksupport_elf = slice::from_raw_parts(
+        ksupport_elf_start,
+        ksupport_elf_end as usize - ksupport_elf_start as usize,
+    );
+
+    if let Err(msg) = load_image(&ksupport_elf) {
+        panic!("failed to load kernel CPU image (ksupport.elf): {}", msg);
+    }
 
     csr::kernel_cpu::reset_write(0);
 
@@ -39,6 +44,44 @@ pub unsafe fn stop() {
 
     mailbox::acknowledge();
     rpc_queue::init();
+}
+
+/// Loads the given image for execution on the kernel CPU.
+///
+/// The entire image including the headers is copied into memory for later use by libunwind, but
+/// placed such that the text section ends up at the right location in memory. Currently, we just
+/// hard-code the address range, but at least verify that this matches the ELF program header given
+/// in the image (avoids loading the – non-relocatable – code at the wrong address on toolchain/…
+/// changes).
+unsafe fn load_image(image: &[u8]) -> Result<(), &'static str> {
+    use dyld::elf::*;
+    use dyld::{is_elf_for_current_arch, read_unaligned};
+
+    let ehdr = read_unaligned::<Elf32_Ehdr>(image, 0).map_err(|()| "could not read ELF header")?;
+
+    // The check assumes the two CPUs share the same architecture. This is just to avoid inscrutable
+    // errors; we do not functionally rely on this.
+    if !is_elf_for_current_arch(&ehdr, ET_EXEC) {
+        return Err("not an executable for kernel CPU architecture");
+    }
+
+    // First program header should be the main text/… LOAD (see ksupport.ld).
+    let phdr = read_unaligned::<Elf32_Phdr>(image, ehdr.e_phoff as usize)
+        .map_err(|()| "could not read program header")?;
+    if phdr.p_type != PT_LOAD {
+        return Err("unexpected program header type");
+    }
+    if phdr.p_vaddr + phdr.p_memsz > KERNELCPU_LAST_ADDRESS as u32 {
+        // This is a weak sanity check only; we also need to fit in the stack, etc.
+        return Err("too large for kernel CPU address range");
+    }
+    const TARGET_ADDRESS: u32 = (KERNELCPU_EXEC_ADDRESS - KSUPPORT_HEADER_SIZE) as _;
+    if phdr.p_vaddr - phdr.p_offset != TARGET_ADDRESS {
+        return Err("unexpected load address/offset");
+    }
+
+    ptr::copy_nonoverlapping(image.as_ptr(), TARGET_ADDRESS as *mut u8, image.len());
+    Ok(())
 }
 
 pub fn validate(ptr: usize) -> bool {

--- a/artiq/firmware/runtime/main.rs
+++ b/artiq/firmware/runtime/main.rs
@@ -1,6 +1,7 @@
 #![feature(lang_items, panic_info_message, const_btree_new, iter_advance_by)]
 #![no_std]
 
+extern crate dyld;
 extern crate eh;
 #[macro_use]
 extern crate alloc;

--- a/flake.nix
+++ b/flake.nix
@@ -124,7 +124,7 @@
 
         nativeBuildInputs = [ pkgs.qt5.wrapQtAppsHook ];
         # keep llvm_x and lld_x in sync with llvmlite
-        propagatedBuildInputs = [ pkgs.llvm_11 pkgs.lld_11 sipyco.packages.x86_64-linux.sipyco pythonparser pkgs.qt5.qtsvg artiq-comtools.packages.x86_64-linux.artiq-comtools ]
+        propagatedBuildInputs = [ pkgs.llvm_11 pkgs.lld_14 sipyco.packages.x86_64-linux.sipyco pythonparser pkgs.qt5.qtsvg artiq-comtools.packages.x86_64-linux.artiq-comtools ]
           ++ (with pkgs.python3Packages; [ llvmlite pyqtgraph pygit2 numpy dateutil scipy prettytable pyserial levenshtein h5py pyqt5 qasync tqdm lmdb jsonschema ]);
 
         dontWrapQtApps = true;
@@ -147,10 +147,10 @@
           "--set FONTCONFIG_FILE ${pkgs.fontconfig.out}/etc/fonts/fonts.conf"
         ];
 
-        # FIXME: automatically propagate lld_11 llvm_11 dependencies
+        # FIXME: automatically propagate lld_14 llvm_11 dependencies
         # cacert is required in the check stage only, as certificates are to be
         # obtained from system elsewhere
-        nativeCheckInputs = [ pkgs.lld_11 pkgs.llvm_11 libartiq-support pkgs.lit outputcheck pkgs.cacert ];
+        nativeCheckInputs = [ pkgs.lld_14 pkgs.llvm_11 libartiq-support pkgs.lit outputcheck pkgs.cacert ];
         checkPhase = ''
           python -m unittest discover -v artiq.test
 
@@ -229,7 +229,7 @@
             pkgs.cargo-xbuild
             pkgs.llvmPackages_11.clang-unwrapped
             pkgs.llvm_11
-            pkgs.lld_11
+            pkgs.lld_14
             vivado
             rustPlatform.cargoSetupHook
           ];
@@ -392,7 +392,7 @@
           pkgs.cargo-xbuild
           pkgs.llvmPackages_11.clang-unwrapped
           pkgs.llvm_11
-          pkgs.lld_11
+          pkgs.lld_14
           # To manually run compiler tests:
           pkgs.lit
           outputcheck
@@ -420,7 +420,7 @@
           pkgs.cargo-xbuild
           pkgs.llvmPackages_11.clang-unwrapped
           pkgs.llvm_11
-          pkgs.lld_11
+          pkgs.lld_14
           packages.x86_64-linux.vivado
           packages.x86_64-linux.openocd-bscanspi
         ];
@@ -454,7 +454,7 @@
           buildInputs = [
             (pkgs.python3.withPackages(ps: with packages.x86_64-linux; [ artiq ps.paramiko ]))
             pkgs.llvm_11
-            pkgs.lld_11
+            pkgs.lld_14
             pkgs.openssh
             packages.x86_64-linux.openocd-bscanspi  # for the bscanspi bitstreams
           ];


### PR DESCRIPTION
This part of https://github.com/m-labs/artiq/commit/748969c21e71b45654bd3f9896e9f90f9a8dce57 was previously reverted, as a removal of 12 padding bytes between the ELF header and first section (`.vectors`) in ksupport.elf led to the actual code segment to be loaded at the wrong address. This was surprisingly tricky to track down, as the user kernel loader code actually ran (seemingly) fine until the string table required.

The PR also adds a validation check to avoid such issues in the future (see commit message for details).