### PR TITLE
Fix return type annotations being type-checked as expressions

### DIFF
--- a/artiq/compiler/embedding.py
+++ b/artiq/compiler/embedding.py
@@ -541,7 +541,7 @@ class StitchingASTTypedRewriter(ASTTypedRewriter):
         node = asttyped.QuotedFunctionDefT(
             typing_env=extractor.typing_env, globals_in_scope=extractor.global_,
             signature_type=types.TVar(), return_type=types.TVar(),
-            name=node.name, args=node.args, returns=node.returns,
+            name=node.name, args=node.args, returns=None,
             body=node.body, decorator_list=node.decorator_list,
             keyword_loc=node.keyword_loc, name_loc=node.name_loc,
             arrow_loc=node.arrow_loc, colon_loc=node.colon_loc, at_locs=node.at_locs,

--- a/artiq/test/lit/embedding/mixed_tuple.py
+++ b/artiq/test/lit/embedding/mixed_tuple.py
@@ -1,0 +1,16 @@
+# RUN: %python -m artiq.compiler.testbench.embedding %s
+
+from artiq.language.core import *
+from artiq.language.types import *
+
+@kernel
+def consume_tuple(x: TTuple([TInt32, TBool])):
+    print(x)
+
+@kernel
+def return_tuple() -> TTuple([TInt32, TBool]):
+    return (123, False)
+
+@kernel
+def entrypoint():
+    consume_tuple(return_tuple())


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

The type checker/inferer visits every node in an AST tree, including function return annotations. This means for a function definition like

    def f() -> TTuple([TInt32, TBool]):
      ...

We attempt to type check the list `[TInt32, TBool]`, which generates the unification constraint `builtins.TBool ~ builtins.TInt`. This then fails, causing the program to not compile.

We can avoid this by just clearing the return annotation in the embedding stage. The return type isn't actually used anywhere (as it's extracted from the run-time function, rather than the AST), so this is entirely safe. Arguments aren't affected by this, as we already cleared out the annotation (see [`visit_arg` in `embedding.py`](https://github.com/m-labs/artiq/blob/e8818c812c84ad232e5e899fd43df97138d1dea4/artiq/compiler/embedding.py#L522-L525)).

### Related Issue

This resolves the symptoms of #1671. The issues with mixed source buffers may still occur elsewhere - afraid I haven't looked further into the underlying cause.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
