### PR TITLE
efc firmware: refractor and skip sys_clk_setup

### DIFF
--- a/artiq/firmware/libboard_misoc/io_expander.rs
+++ b/artiq/firmware/libboard_misoc/io_expander.rs
@@ -85,7 +85,7 @@ impl IoExpander {
     pub fn new() -> Result<Self, &'static str> {
         const VIRTUAL_LED_MAPPING: [(u8, u8, u8); 2] = [(0, 0, 5), (1, 0, 6)];
 
-        let mut io_expander = IoExpander {
+        let io_expander = IoExpander {
             busno: 0,
             port: 1,
             address: 0x40,

--- a/artiq/firmware/satman/main.rs
+++ b/artiq/firmware/satman/main.rs
@@ -463,6 +463,7 @@ const SI5324_SETTINGS: si5324::FrequencySettings
     crystal_as_ckin2: true
 };
 
+#[cfg(not(soc_platform = "efc"))]
 fn sysclk_setup() {
     let switched = unsafe {
         csr::crg::switch_done_read()
@@ -529,6 +530,7 @@ pub extern fn main() -> i32 {
         io_expander1.service().unwrap();
     }
 
+    #[cfg(not(soc_platform = "efc"))]
     sysclk_setup();
 
     #[cfg(soc_platform = "efc")]


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
This PR makes efc firmware to be able to compile without error and remove one warning on unnecessary "mut" keyword

1. Add cfg flag to skip sys_clk_setup on efc satman main.rs
- Note: System clock will not be changed during runtime and should have been set before running
2. Remove a mut on io_expander as that "mut" keyword is not necessary

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
