### PR TITLE
gt_drtio: rename drtio_transceiver to gt_drtio

### DIFF
--- a/artiq/firmware/runtime/rtio_clocking.rs
+++ b/artiq/firmware/runtime/rtio_clocking.rs
@@ -259,14 +259,14 @@ pub fn init() {
             unsafe {
                 // clock switch and reboot will begin after TX is initialized
                 // and TX will be initialized after this
-                csr::drtio_transceiver::stable_clkin_write(1);
+                csr::gt_drtio::stable_clkin_write(1);
             }
             loop {}
         }
         else {
             // enable TX after the reboot, with stable clock
             unsafe {
-                csr::drtio_transceiver::txenable_write(0xffffffffu32 as _);
+                csr::gt_drtio::txenable_write(0xffffffffu32 as _);
             }
         }
     }

--- a/artiq/firmware/satman/main.rs
+++ b/artiq/firmware/satman/main.rs
@@ -479,7 +479,7 @@ fn sysclk_setup() {
         // delay for clean UART log, wait until UART FIFO is empty
         clock::spin_us(1300);
         unsafe {
-            csr::drtio_transceiver::stable_clkin_write(1);
+            csr::gt_drtio::stable_clkin_write(1);
         }
         loop {}
     }
@@ -553,7 +553,7 @@ pub extern fn main() -> i32 {
 
     #[cfg(not(has_drtio_eem))]
     unsafe {
-        csr::drtio_transceiver::txenable_write(0xffffffffu32 as _);
+        csr::gt_drtio::txenable_write(0xffffffffu32 as _);
     }
 
     init_rtio_crg();

--- a/artiq/gateware/eem.py
+++ b/artiq/gateware/eem.py
@@ -30,7 +30,7 @@ class _EEM:
         target.platform.add_extension(cls.io(eem, *args, **kwargs))
         if is_drtio_over_eem:
             print("{} (EEM{}) starting at DRTIO channel 0x{:06x}"
-                .format(name, eem, (len(target.drtio_transceiver.channels) + len(target.eem_drtio_channels) + 1) << 16))
+                .format(name, eem, (len(target.gt_drtio.channels) + len(target.eem_drtio_channels) + 1) << 16))
         else:
             print("{} (EEM{}) starting at RTIO channel 0x{:06x}"
                 .format(name, eem, len(target.rtio_channels)))

--- a/artiq/gateware/targets/kasli_generic.py
+++ b/artiq/gateware/targets/kasli_generic.py
@@ -108,7 +108,7 @@ class GenericMaster(MasterBase):
             self.add_csr_group("grabber", self.grabber_csr_group)
             for grabber in self.grabber_csr_group:
                 self.platform.add_false_path_constraints(
-                    self.drtio_transceiver.gtps[0].txoutclk, getattr(self, grabber).deserializer.cd_cl.clk)
+                    self.gt_drtio.gtps[0].txoutclk, getattr(self, grabber).deserializer.cd_cl.clk)
 
 
 class GenericSatellite(SatelliteBase):
@@ -142,7 +142,7 @@ class GenericSatellite(SatelliteBase):
             self.add_csr_group("grabber", self.grabber_csr_group)
             for grabber in self.grabber_csr_group:
                 self.platform.add_false_path_constraints(
-                    self.drtio_transceiver.gtps[0].txoutclk, getattr(self, grabber).deserializer.cd_cl.clk)
+                    self.gt_drtio.gtps[0].txoutclk, getattr(self, grabber).deserializer.cd_cl.clk)
 
 
 def main():


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
This PR renames drtio_transceiver to gt_drtio throughout the artiq codebase. Both gateware and firmware (CSR name) are affected. See related PR section.

Connections can be established on the following configurations. That version of Kasli-soc has the name change already applied.
Kasli Master -> Kasli-soc Satellite
Kasli Satellite <- Kasli-soc Master

### Related PR
artiq-zynq: To be added


<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.