### PR TITLE
Allow indexing tuples in kernel code

### DIFF
--- a/artiq/compiler/transforms/artiq_ir_generator.py
+++ b/artiq/compiler/transforms/artiq_ir_generator.py
@@ -1209,7 +1209,6 @@ class ARTIQIRGenerator(algorithm.Visitor):
                     "cannot assign to a tuple element",
                     {}, node.loc)
                 self.engine.process(diag)
-                return
 
             index = node.slice.value.n
             indexed = self.append(

--- a/artiq/compiler/transforms/inferencer.py
+++ b/artiq/compiler/transforms/inferencer.py
@@ -259,7 +259,31 @@ class Inferencer(algorithm.Visitor):
 
     def visit_SubscriptT(self, node):
         self.generic_visit(node)
-        if isinstance(node.slice, ast.Index):
+
+        if types.is_tuple(node.value.type):
+            if (not isinstance(node.slice, ast.Index) or
+                not isinstance(node.slice.value, ast.Num)):
+                diag = diagnostic.Diagnostic(
+                    "error", "tuples can only be indexed by a constant", {},
+                    node.slice.loc, []
+                )
+                self.engine.process(diag)
+                return
+
+            tuple_type = node.value.type.find()
+            index = node.slice.value.n
+            if index < 0 or index >= len(tuple_type.elts):
+                diag = diagnostic.Diagnostic(
+                    "error",
+                    "index {index} cannot be used to index tuple of size {size}",
+                    {"index": index, "size": len(tuple_type.elts)},
+                    node.slice.loc, []
+                )
+                self.engine.process(diag)
+                return
+
+            self._unify(node.type, tuple_type.elts[index], node.loc, node.value.loc)
+        elif isinstance(node.slice, ast.Index):
             if types.is_tuple(node.slice.value.type):
                 if types.is_var(node.value.type):
                     return

--- a/artiq/compiler/transforms/inferencer.py
+++ b/artiq/compiler/transforms/inferencer.py
@@ -275,7 +275,7 @@ class Inferencer(algorithm.Visitor):
             if index < 0 or index >= len(tuple_type.elts):
                 diag = diagnostic.Diagnostic(
                     "error",
-                    "index {index} cannot be used to index tuple of size {size}",
+                    "index {index} is out of range for tuple of size {size}",
                     {"index": index, "size": len(tuple_type.elts)},
                     node.slice.loc, []
                 )

--- a/artiq/test/lit/embedding/error_tuple_index_assign.py
+++ b/artiq/test/lit/embedding/error_tuple_index_assign.py
@@ -1,0 +1,15 @@
+# RUN: %python -m artiq.compiler.testbench.embedding +diag %s 2>%t
+# RUN: OutputCheck %s --file-to-check=%t
+
+from artiq.language.core import *
+from artiq.language.types import *
+
+@kernel
+def modify(x):
+    # CHECK-L: ${LINE:+1}: error: cannot assign to a tuple element
+    x[0] = 2
+
+@kernel
+def entrypoint():
+    modify((1, "foo", True))
+    modify((2, "bar", False))

--- a/artiq/test/lit/embedding/index_tuple.py
+++ b/artiq/test/lit/embedding/index_tuple.py
@@ -1,0 +1,16 @@
+# RUN: env ARTIQ_DUMP_LLVM=%t %python -m artiq.compiler.testbench.embedding +compile %s
+# RUN: OutputCheck %s --file-to-check=%t.ll
+
+from artiq.language.core import *
+from artiq.language.types import *
+
+# CHECK: void @_Z16testbench.unpackzz\(\{ i32, \{ i8\*, i32 \}, i1 \} %ARG.x\)
+
+@kernel
+def unpack(x):
+    print(x[0])
+
+@kernel
+def entrypoint():
+    unpack((1, "foo", True))
+    unpack((2, "bar", False))

--- a/artiq/test/lit/embedding/index_tuple.py
+++ b/artiq/test/lit/embedding/index_tuple.py
@@ -4,7 +4,7 @@
 from artiq.language.core import *
 from artiq.language.types import *
 
-# CHECK: void @_Z16testbench.unpackzz\(\{ i32, \{ i8\*, i32 \}, i1 \} %ARG.x\)
+# CHECK-L: void @_Z16testbench.unpackzz({ i32, { i8*, i32 }, i1 } %ARG.x)
 
 @kernel
 def unpack(x):

--- a/artiq/test/lit/inferencer/error_tuple_index.py
+++ b/artiq/test/lit/inferencer/error_tuple_index.py
@@ -9,3 +9,6 @@ x[i]
 
 # CHECK-L: ${LINE:+1}: error: tuples can only be indexed by a constant
 x[0:2]
+
+# CHECK-L: ${LINE:+1}: error: index 3 is out of range for tuple of size 3
+x[3]

--- a/artiq/test/lit/inferencer/error_tuple_index.py
+++ b/artiq/test/lit/inferencer/error_tuple_index.py
@@ -1,0 +1,11 @@
+# RUN: %python -m artiq.compiler.testbench.inferencer +diag %s >%t
+# RUN: OutputCheck %s --file-to-check=%t
+
+i = 0
+x = (1, "foo", True)
+
+# CHECK-L: ${LINE:+1}: error: tuples can only be indexed by a constant
+x[i]
+
+# CHECK-L: ${LINE:+1}: error: tuples can only be indexed by a constant
+x[0:2]

--- a/artiq/test/lit/integration/tuple_index.py
+++ b/artiq/test/lit/integration/tuple_index.py
@@ -1,0 +1,22 @@
+# RUN: %python -m artiq.compiler.testbench.jit %s
+# RUN: %python %s
+
+# Basic indexing
+a = (1, "xyz", True)
+
+assert a[0] == 1
+assert a[1] == "xyz"
+assert a[2] == True
+
+# Nested indexing
+b = (a, 2, (3, "abc", a))
+
+assert b[0][0] == 1
+assert b[1] == 2
+assert b[2][2][0] == 1
+
+# Usage on the LHS of an assignment
+c = (1, 2, [1, 2, 3])
+
+c[2][0] = 456
+assert c[2][0] == 456


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
This allows for indexing tuples with a constant integer value (e.g. `x[0]`), rather than having to unpack them (`a, _b, _c = x`).

### Related Issue
There is some discussion of this in #656 as one of the pain points, and we've definitely had to work around it a few times in our own code.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [X] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how

  Have tested the compiled code on a Kasli 1.1 master.
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
