### PR TITLE
fix CreateEditDialog datatype casting

### DIFF
--- a/artiq/dashboard/datasets.py
+++ b/artiq/dashboard/datasets.py
@@ -78,10 +78,11 @@ class CreateEditDialog(QtWidgets.QDialog):
 
         if metadata is not None:
             scale = scale_from_metadata(metadata)
-            value = pyon.decode(value)
-            t = type(value)
-            if np.issubdtype(t, np.number) or t is np.ndarray:
-                self.value_widget.setText(pyon.encode(value / scale))
+            decoded_value = pyon.decode(value)
+            if scale == 1:
+                self.value_widget.setText(value)
+            else: 
+                self.value_widget.setText(pyon.encode(decoded_value / scale))
             self.unit_widget.setText(metadata.get('unit', ''))
             self.scale_widget.setText(str(metadata.get('scale', '')))
             self.precision_widget.setText(str(metadata.get('precision', '')))
@@ -104,8 +105,9 @@ class CreateEditDialog(QtWidgets.QDialog):
             metadata['precision'] = int(precision)
         scale = scale_from_metadata(metadata)
         value = pyon.decode(value)
-        t = type(value)
-        if np.issubdtype(t, np.number) or t is np.ndarray:
+        t = value.dtype if value is np.ndarray else type(value)
+        is_floating = scale != 1 or np.issubdtype(t, np.floating)
+        if is_floating:
             value = value * scale
         if self.key and self.key != key:
             asyncio.ensure_future(exc_to_warning(rename(self.key, key, value, metadata, persist, self.dataset_ctl)))


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Integer scalars and ndarrays with a scale factor of 1 should remain integers when edited in dashboard. 

### Related Issue

Closes #2174

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Close/update issues.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.
basic manual testing reproducing the bug and observing behavior.
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
