### PR TITLE
Disable Kasli DRTIO-over-EEM OSERDES until clock switch

### DIFF
--- a/artiq/firmware/runtime/rtio_clocking.rs
+++ b/artiq/firmware/runtime/rtio_clocking.rs
@@ -267,6 +267,9 @@ pub fn init() {
             // enable TX after the reboot, with stable clock
             unsafe {
                 csr::gt_drtio::txenable_write(0xffffffffu32 as _);
+
+                #[cfg(has_drtio_eem)]
+                csr::eem_transceiver::txenable_write(0xffffffffu32 as _);
             }
         }
     }

--- a/artiq/gateware/targets/kasli.py
+++ b/artiq/gateware/targets/kasli.py
@@ -365,7 +365,8 @@ class MasterBase(MiniSoC, AMPSoC):
         self.csr_devices.append("rtio_analyzer")
 
     def add_eem_drtio(self, eem_drtio_channels):
-        self.submodules.eem_transceiver = eem_serdes.EEMSerdes(self.platform, eem_drtio_channels)
+        self.submodules.eem_transceiver = eem_serdes.EEMSerdes(
+            self.platform, eem_drtio_channels, gate_tx=True)
         self.csr_devices.append("eem_transceiver")
         self.config["HAS_DRTIO_EEM"] = None
         self.config["EEM_DRTIO_COUNT"] = len(eem_drtio_channels)


### PR DESCRIPTION
# ARTIQ Pull Request

## Description
This PR disables the TX path of DRTIO-over-EEM for Kasli until clock switch is completed, so the OOB reset starts asserted for the EEM FMC Carrier.

Rebooting Kasli causes a log spam on EFC before this patch.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
