### PR TITLE
Construct DRTIO-EEM before finalizing RTIO

### DIFF
--- a/artiq/gateware/targets/kasli.py
+++ b/artiq/gateware/targets/kasli.py
@@ -365,6 +365,8 @@ class MasterBase(MiniSoC, AMPSoC):
         self.csr_devices.append("rtio_analyzer")
 
     def add_eem_drtio(self, eem_drtio_channels):
+        # Must be called before invoking add_rtio() to construct the CRI
+        # interconnect properly
         self.submodules.eem_transceiver = eem_serdes.EEMSerdes(self.platform, eem_drtio_channels)
         self.csr_devices.append("eem_transceiver")
         self.config["HAS_DRTIO_EEM"] = None

--- a/artiq/gateware/targets/kasli_generic.py
+++ b/artiq/gateware/targets/kasli_generic.py
@@ -99,10 +99,12 @@ class GenericMaster(MasterBase):
         self.config["RTIO_LOG_CHANNEL"] = len(self.rtio_channels)
         self.rtio_channels.append(rtio.LogChannel())
 
-        self.add_rtio(self.rtio_channels, sed_lanes=description["sed_lanes"])
         if has_drtio_over_eem:
             self.add_eem_drtio(self.eem_drtio_channels)
         self.add_drtio_cpuif_groups()
+
+        self.add_rtio(self.rtio_channels, sed_lanes=description["sed_lanes"])
+
         if has_grabber:
             self.config["HAS_GRABBER"] = None
             self.add_csr_group("grabber", self.grabber_csr_group)


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
This PR fixes the construction order of DRTIO-EEM modules relative to the (D)RTIO CRI interconnect.

## Test
Kasli can now blink EFC LEDs through DRTIO without triggering `RTIODestinationUnreachable` exception.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
