### PR TITLE
scan: fix deprecated shuffle parameter in python 3.11

### DIFF
--- a/artiq/language/scan.py
+++ b/artiq/language/scan.py
@@ -83,8 +83,7 @@ class RangeScan(ScanObject):
             self.sequence = [i*dx + start for i in range(npoints)]
 
         if randomize:
-            rng = random.Random(seed)
-            random.shuffle(self.sequence, rng.random)
+            random.Random(seed).shuffle(self.sequence)
 
     def __iter__(self):
         return iter(self.sequence)
@@ -120,8 +119,7 @@ class CenterScan(ScanObject):
                              for i in range(n) for sign in [-1, 1]][1:]
 
         if randomize:
-            rng = random.Random(seed)
-            random.shuffle(self.sequence, rng.random)
+            random.Random(seed).shuffle(self.sequence)
 
     def __iter__(self):
         return iter(self.sequence)


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
Fix deprecated optional `random` parameter in `random.shuffle` for python 3.11.

Reference: https://github.com/python/cpython/blob/3.11/Doc/library/random.rst?plain=1#L224

### Related Issue
Closes #2184 
<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Close/update issues.


### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
