### PR TITLE
fix RangeScan SpinBox size layouts

### DIFF
--- a/artiq/gui/entries.py
+++ b/artiq/gui/entries.py
@@ -222,9 +222,6 @@ class _RangeScan(LayoutWidget):
 
         start = ScientificSpinBox()
         start.setStyleSheet("QDoubleSpinBox {color:blue}")
-        start.setMinimumSize(110, 0)
-        start.setSizePolicy(QtWidgets.QSizePolicy(
-            QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed))
         disable_scroll_wheel(start)
         self.addWidget(start, 0, 1)
 
@@ -236,12 +233,14 @@ class _RangeScan(LayoutWidget):
 
         stop = ScientificSpinBox()
         stop.setStyleSheet("QDoubleSpinBox {color:red}")
-        stop.setMinimumSize(110, 0)
         disable_scroll_wheel(stop)
         self.addWidget(stop, 2, 1)
 
         randomize = QtWidgets.QCheckBox("Randomize")
         self.addWidget(randomize, 3, 1)
+
+        self.layout.setColumnStretch(0, 4)
+        self.layout.setColumnStretch(1, 1)
 
         apply_properties(start)
         start.setSigFigs()


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Current behavior:
+ Fixed minimum size of 110 used for SpinBox items in `RangeScan` entry.
+ Inconsistent size policy only used for top entry in column of 3, this leads to issues when **making the entries available in applets.**
+ In some fonts / stylesheets, the minimum size hides parts of the number, making it harder to edit.
+ Not a policy used elsewhere for SpinBox items.

Proposed fix:
+ Remove fixed size policy.
+ Set a 4:1 width ratio between the range display and the spin box items using `setColumnStretch`.  

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
