### PR TITLE
gateware/targets/kasli: Only set DRTIO_ROLE in *Base classes [nfc]

### DIFF
--- a/artiq/gateware/targets/kasli.py
+++ b/artiq/gateware/targets/kasli.py
@@ -70,6 +70,8 @@ class StandaloneBase(MiniSoC, AMPSoC):
         AMPSoC.__init__(self)
         add_identifier(self, gateware_identifier_str=gateware_identifier_str)
 
+        self.config["DRTIO_ROLE"] = "standalone"
+
         if self.platform.hw_rev == "v2.0":
             self.submodules.error_led = gpio.GPIOOut(Cat(
                 self.platform.request("error_led")))

--- a/artiq/gateware/targets/kasli_generic.py
+++ b/artiq/gateware/targets/kasli_generic.py
@@ -22,7 +22,6 @@ class GenericStandalone(StandaloneBase):
             hw_rev = description["hw_rev"]
         self.class_name_override = description["variant"]
         StandaloneBase.__init__(self, hw_rev=hw_rev, **kwargs)
-        self.config["DRTIO_ROLE"] = description["drtio_role"]
         self.config["RTIO_FREQUENCY"] = "{:.1f}".format(description["rtio_frequency"]/1e6)
         if "ext_ref_frequency" in description:
             self.config["SI5324_EXT_REF"] = None
@@ -78,7 +77,6 @@ class GenericMaster(MasterBase):
             enable_sata=description["enable_sata_drtio"],
             enable_sys5x=has_drtio_over_eem,
             **kwargs)
-        self.config["DRTIO_ROLE"] = description["drtio_role"]
         if "ext_ref_frequency" in description:
             self.config["SI5324_EXT_REF"] = None
             self.config["EXT_REF_FREQUENCY"] = "{:.1f}".format(
@@ -123,7 +121,6 @@ class GenericSatellite(SatelliteBase):
                                rtio_clk_freq=description["rtio_frequency"],
                                enable_sata=description["enable_sata_drtio"],
                                **kwargs)
-        self.config["DRTIO_ROLE"] = description["drtio_role"]
         if hw_rev == "v1.0":
             # EEM clock fan-out from Si5324, not MMCX
             self.comb += self.platform.request("clk_sel").eq(1)


### PR DESCRIPTION
kasli_generic uses the drtio_role setting to select the particular
*Generic class to use anyway.
