### PR TITLE
Firmware: AD9117 Add Comment on Checking the Presence of DCLKIO and CLKIN

### DIFF
--- a/artiq/firmware/libboard_artiq/ad9117.rs
+++ b/artiq/firmware/libboard_artiq/ad9117.rs
@@ -51,6 +51,7 @@ pub fn init() -> Result<(), &'static str> {
             debug!("DAC AD9117 Channel {} has incorrect hardware version. VERSION reg: {:02x}", channel, reg);
             return Err("DAC AD9117 hardware version is not equal to 0x0A");
         }
+        // Check for the presence of DCLKIO and CLKIN
         let reg = read(channel, CLKMODE_REG)?;
         if reg >> 4 & 1 != 0 {
             debug!("DAC AD9117 Channel {} retiming fails. CLKMODE reg: {:02x}", channel, reg);


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
This PR adds a line of comment to clarify why retimer is still be checked when RETIMER-CLK is forced to Phase One.

### Related PR
PR: #2195 

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :scroll: Docs |


### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
