### PR TITLE
set_argument_value in applets

### DIFF
--- a/artiq/frontend/artiq_dashboard.py
+++ b/artiq/frontend/artiq_dashboard.py
@@ -192,6 +192,7 @@ def main():
     d_applets = applets_ccb.AppletsCCBDock(main_window,
                                            sub_clients["datasets"],
                                            rpc_clients["dataset_db"],
+                                           expmgr,
                                            extra_substitutes={
                                                "server": args.server,
                                                "port_notify": args.port_notify,

--- a/artiq/gui/applets.py
+++ b/artiq/gui/applets.py
@@ -21,10 +21,11 @@ logger = logging.getLogger(__name__)
 
 
 class AppletIPCServer(AsyncioParentComm):
-    def __init__(self, dataset_sub, dataset_ctl):
+    def __init__(self, dataset_sub, dataset_ctl, expmgr):
         AsyncioParentComm.__init__(self)
         self.dataset_sub = dataset_sub
         self.dataset_ctl = dataset_ctl
+        self.expmgr = expmgr
         self.datasets = set()
         self.dataset_prefixes = []
 
@@ -83,6 +84,8 @@ class AppletIPCServer(AsyncioParentComm):
                         await self.dataset_ctl.set(obj["key"], obj["value"], metadata=obj["metadata"], persist=obj["persist"])
                     elif action == "update_dataset":
                         await self.dataset_ctl.update(obj["mod"])
+                    elif action == "set_argument_value":
+                        self.expmgr.set_argument_value(obj["expurl"], obj["name"], obj["procdesc"])
                     else:
                         raise ValueError("unknown action in applet message")
                 except:
@@ -108,7 +111,7 @@ class AppletIPCServer(AsyncioParentComm):
 
 
 class _AppletDock(QDockWidgetCloseDetect):
-    def __init__(self, dataset_sub, dataset_ctl, uid, name, spec, extra_substitutes):
+    def __init__(self, dataset_sub, dataset_ctl, expmgr, uid, name, spec, extra_substitutes):
         QDockWidgetCloseDetect.__init__(self, "Applet: " + name)
         self.setObjectName("applet" + str(uid))
 
@@ -118,6 +121,7 @@ class _AppletDock(QDockWidgetCloseDetect):
 
         self.dataset_sub = dataset_sub
         self.dataset_ctl = dataset_ctl
+        self.expmgr = expmgr
         self.applet_name = name
         self.spec = spec
         self.extra_substitutes = extra_substitutes
@@ -136,7 +140,7 @@ class _AppletDock(QDockWidgetCloseDetect):
             return
         self.starting_stopping = True
         try:
-            self.ipc = AppletIPCServer(self.dataset_sub, self.dataset_ctl)
+            self.ipc = AppletIPCServer(self.dataset_sub, self.dataset_ctl, self.expmgr)
             env = os.environ.copy()
             env["PYTHONUNBUFFERED"] = "1"
             env["ARTIQ_APPLET_EMBED"] = self.ipc.get_address()
@@ -333,7 +337,7 @@ class _CompleterDelegate(QtWidgets.QStyledItemDelegate):
 
 
 class AppletsDock(QtWidgets.QDockWidget):
-    def __init__(self, main_window, dataset_sub, dataset_ctl, extra_substitutes={}, *, loop=None):
+    def __init__(self, main_window, dataset_sub, dataset_ctl, expmgr, extra_substitutes={}, *, loop=None):
         """
         :param extra_substitutes: Map of extra ``${strings}`` to substitute in applet
             commands to their respective values.
@@ -346,6 +350,7 @@ class AppletsDock(QtWidgets.QDockWidget):
         self.main_window = main_window
         self.dataset_sub = dataset_sub
         self.dataset_ctl = dataset_ctl
+        self.expmgr = expmgr
         self.extra_substitutes = extra_substitutes
         self.applet_uids = set()
 
@@ -447,7 +452,7 @@ class AppletsDock(QtWidgets.QDockWidget):
             self.table.itemChanged.connect(self.item_changed)
 
     def create(self, item, name, spec):
-        dock = _AppletDock(self.dataset_sub, self.dataset_ctl, item.applet_uid, name, spec, self.extra_substitutes)
+        dock = _AppletDock(self.dataset_sub, self.dataset_ctl, self.expmgr, item.applet_uid, name, spec, self.extra_substitutes)
         self.main_window.addDockWidget(QtCore.Qt.RightDockWidgetArea, dock)
         dock.setFloating(True)
         asyncio.ensure_future(dock.start(), loop=self._loop)


### PR DESCRIPTION
# ARTIQ Pull Request

_WIP_

## Description of Changes

This PR is part of the Applets API extensions project. The purpose of this PR is to allow applets to modify experiment argument values directly. 

Proposed:

In an applet inheriting `SimpleApplet`:
```
self.ctl.set_argument_value(expurl, name, proc)
```
where:
+ `expurl` - the experiment url, i.e. "repo:ArgumentsDemo"
+ `name` - the submission argument name in the argument editor
+ `proc` - an Argument Processor object, i.e. `NumberValue` or `BooleanValue` 

Example:
```
class ExampleApplet(QtWidgets.QWidget):
    def __init__(self, args, ctl):
        QtWidgets.QWidget.__init__(self)
        self.layout = QtWidgets.QVBoxLayout()
        self.setLayout(self.layout)
        self.args = args
        self.ctl = ctl

        # basic usage
        self.ctl.set_argument_value("repo:ArgumentsDemo", "boolean", BooleanValue(True))
        
        self.ctl.set_argument_value("repo:ArgumentsDemo", "string", StringValue("new_string"))

        # alter a Scannable entry
        self.ctl.set_argument_value("repo:ArgumentsDemo", "scan", Scannable(default=RangeScan(200, 300, 49)))

       # alter a EnumerationValue entry
       self.ctl.set_argument_value("repo:ArgumentsDemo", "enum", EnumerationValue(["foo"]))

    def data_changed(self, value, metadata, persist, mods):
        pass
```

Notes:
+ `EnumerationValue` should pass a list of length 1 with the desired string to choose. It must be a string defined in `build()`.
+ Only the "state" of the Entry will be updated. Other parameters passed to the argument processor such as "unit" or "precision" will be ignored. This is because the experiment will use the argument processors defined in the `build()` method, and those processors may store those parameters as member variables.
+ The modification is temporary: when the value is recomputed either individually or as a whole, it will reset to the default specified in the experiments `build()` method.
+ Error will be thrown if experiment is not open, if the name does not correspond to an existing argument, or if there is a type mismatch between the new and old values.

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [ ] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
