### PR TITLE
Allow using Python types in type annotations

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -25,6 +25,8 @@ Highlights:
   support legacy installations, but may be removed in a future release.
 * Added channel names to RTIO errors.
 * Full Python 3.10 support.
+* Python's built-in types (such as `float`, or `List[...]`) can now be used in type annotations on
+  kernel functions.
 * Distributed DMA is now supported, allowing DMA to be run directly on satellites for corresponding
   RTIO events, increasing bandwidth in scenarios with heavy satellite usage.
 * API extensions have been implemented, enabling applets to directly modify datasets.

--- a/artiq/compiler/embedding.py
+++ b/artiq/compiler/embedding.py
@@ -541,7 +541,7 @@ class StitchingASTTypedRewriter(ASTTypedRewriter):
         node = asttyped.QuotedFunctionDefT(
             typing_env=extractor.typing_env, globals_in_scope=extractor.global_,
             signature_type=types.TVar(), return_type=types.TVar(),
-            name=node.name, args=node.args, returns=node.returns,
+            name=node.name, args=node.args, returns=None,
             body=node.body, decorator_list=node.decorator_list,
             keyword_loc=node.keyword_loc, name_loc=node.name_loc,
             arrow_loc=node.arrow_loc, colon_loc=node.colon_loc, at_locs=node.at_locs,

--- a/artiq/test/lit/embedding/annotation_py.py
+++ b/artiq/test/lit/embedding/annotation_py.py
@@ -1,0 +1,34 @@
+# RUN: env ARTIQ_DUMP_LLVM=%t %python -m artiq.compiler.testbench.embedding +compile %s
+# RUN: OutputCheck %s --file-to-check=%t.ll
+
+from typing import List, Tuple
+
+import numpy as np
+
+from artiq.language.core import *
+from artiq.language.types import *
+
+# CHECK-L: i64 @_Z13testbench.foozz(i64 %ARG.x, { i1, i32 } %ARG.y)
+
+@kernel
+def foo(x: np.int64, y: np.int32 = 1) -> np.int64:
+    print(x + y)
+    return x + y
+
+# CHECK-L: void @_Z13testbench.barzz()
+@kernel
+def bar(x: np.int32) -> None:
+    print(x)
+
+# CHECK-L: @_Z21testbench.unpack_listzz({ i1, i64 }* nocapture writeonly sret({ i1, i64 }) %.1, { i64*, i32 }* %ARG.xs)
+@kernel
+def unpack_list(xs: List[np.int64]) -> Tuple[bool, np.int64]:
+    print(xs)
+    return (len(xs) == 1, xs[0])
+
+@kernel
+def entrypoint():
+    print(foo(0, 2))
+    print(foo(1, 3))
+    bar(3)
+    print(unpack_list([1, 2, 3]))

--- a/artiq/test/lit/embedding/error_specialized_annot.py
+++ b/artiq/test/lit/embedding/error_specialized_annot.py
@@ -4,14 +4,14 @@
 from artiq.experiment import *
 
 class c():
-# CHECK-L: ${LINE:+2}: error: type annotation for argument 'x', '<class 'float'>', is not an ARTIQ type
+# CHECK-L: ${LINE:+2}: error: type annotation for argument 'x', '<class 'list'>', is not an ARTIQ type
     @kernel
-    def hello(self, x: float):
+    def hello(self, x: list):
         pass
 
     @kernel
     def run(self):
-        self.hello(2)
+        self.hello([])
 
 i = c()
 @kernel

--- a/artiq/test/lit/embedding/mixed_tuple.py
+++ b/artiq/test/lit/embedding/mixed_tuple.py
@@ -1,0 +1,16 @@
+# RUN: %python -m artiq.compiler.testbench.embedding %s
+
+from artiq.language.core import *
+from artiq.language.types import *
+
+@kernel
+def consume_tuple(x: TTuple([TInt32, TBool])):
+    print(x)
+
+@kernel
+def return_tuple() -> TTuple([TInt32, TBool]):
+    return (123, False)
+
+@kernel
+def entrypoint():
+    consume_tuple(return_tuple())


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

This change allows using normal Python type annotations (e.g. `List[np.int64]`) inside kernel code. A lot of existing tooling (e.g. external type checkers, language servers) have issues with ARTIQ-style type annotations, so using standard Python annotations makes the developer experience a little better.

 - Most primitive Python types (`bool`, `str`, `float`, `bytes`, `bytearray`) are treated as their equivalent ARTIQ type.
 - `np.int32` and `np.int64` are treated as `TInt32` and `TInt64` respectively. `int` is not converted - it instead errors, and suggests you use an explicit type.
 - `List[_]` and `Tuple[...]` are both supported (as are `list[_]` and `tuple[_]`) on more recent Python versions.

This change relies on the fixes in #2164, hence 1faa0acb8edd0a44f4217ef21bfc9fa7434afc99 also being included here.

I realise that this has the potential to be quite a wide-reaching change, so I've tried to keep this as minimal as is for now. Happy to make any documentation or code changes as required.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how:

  Have included an additional lit test, and confirmed all existing tests pass. I've written a couple of small experiments using this syntax, and checked they compiled and ran.
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

- [ ] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
