### PR TITLE
Generate coredevice entries for Shuttler

### DIFF
--- a/artiq/coredevice/coredevice_generic.schema.json
+++ b/artiq/coredevice/coredevice_generic.schema.json
@@ -628,6 +628,10 @@
                             },
                             "minItems": 1,
                             "maxItems": 2
+                        },
+                        "drtio_destination": {
+                            "type": "integer",
+                            "default": 4
                         }
                     },
                     "required": ["ports"]

--- a/artiq/frontend/artiq_ddb_template.py
+++ b/artiq/frontend/artiq_ddb_template.py
@@ -4,7 +4,7 @@ import argparse
 import sys
 import textwrap
 from collections import defaultdict
-from itertools import count
+from itertools import count, filterfalse
 
 from artiq import __version__ as artiq_version
 from artiq.coredevice import jsondesc
@@ -621,12 +621,90 @@ class PeripheralManager:
                 channel=rtio_offset+i)
         return 8
 
+    def process_efc(self, efc_peripheral):
+        efc_name = self.get_name("efc")
+        rtio_offset = efc_peripheral["drtio_destination"] << 16
+        rtio_offset += self.add_board_leds(rtio_offset, board_name=efc_name)
+
+        shuttler_name = self.get_name("shuttler")
+        channel = count(0)
+        self.gen("""
+            device_db["{name}_config"] = {{
+                "type": "local",
+                "module": "artiq.coredevice.shuttler",
+                "class": "Config",
+                "arguments": {{"channel": 0x{channel:06x}}},
+            }}""",
+            name=shuttler_name,
+            channel=rtio_offset + next(channel))
+        self.gen("""
+            device_db["{name}_trigger"] = {{
+                "type": "local",
+                "module": "artiq.coredevice.shuttler",
+                "class": "Trigger",
+                "arguments": {{"channel": 0x{channel:06x}}},
+            }}""",
+            name=shuttler_name,
+            channel=rtio_offset + next(channel))
+        for i in range(16):
+            self.gen("""
+                device_db["{name}_volt{ch}"] = {{
+                    "type": "local",
+                    "module": "artiq.coredevice.shuttler",
+                    "class": "Volt",
+                    "arguments": {{"channel": 0x{channel:06x}}},
+                }}""",
+                name=shuttler_name,
+                ch=i,
+                channel=rtio_offset + next(channel))
+            self.gen("""
+                device_db["{name}_dds{ch}"] = {{
+                    "type": "local",
+                    "module": "artiq.coredevice.shuttler",
+                    "class": "Dds",
+                    "arguments": {{"channel": 0x{channel:06x}}},
+                }}""",
+                name=shuttler_name,
+                ch=i,
+                channel=rtio_offset + next(channel))
+
+        device_class_names = ["Relay", "ADC"]
+        for i, device_name in enumerate(device_class_names):
+            spi_name = "{name}_spi{ch}".format(
+                name=shuttler_name,
+                ch=i)
+            self.gen("""
+                device_db["{spi}"] = {{
+                    "type": "local",
+                    "module": "artiq.coredevice.spi2",
+                    "class": "SPIMaster",
+                    "arguments": {{"channel": 0x{channel:06x}}},
+                }}""",
+                spi=spi_name,
+                channel=rtio_offset + next(channel))
+            self.gen("""
+                device_db["{name}_{device}"] = {{
+                    "type": "local",
+                    "module": "artiq.coredevice.shuttler",
+                    "class": "{dev_class}",
+                    "arguments": {{"spi_device": "{spi}"}},
+                }}""",
+                name=shuttler_name,
+                device=device_name.lower(),
+                dev_class=device_name,
+                spi=spi_name)
+        return 0
+
     def process(self, rtio_offset, peripheral):
         processor = getattr(self, "process_"+str(peripheral["type"]))
         return processor(rtio_offset, peripheral)
 
-    def add_board_leds(self, rtio_offset):
+    def add_board_leds(self, rtio_offset, board_name=None):
         for i in range(2):
+            if board_name is None:
+                led_name = self.get_name("led")
+            else:
+                led_name = self.get_name("{}_led".format(board_name))
             self.gen("""
                 device_db["{name}"] = {{
                     "type": "local",
@@ -634,9 +712,15 @@ class PeripheralManager:
                     "class": "TTLOut",
                     "arguments": {{"channel": 0x{channel:06x}}}
                 }}""",
-                name=self.get_name("led"),
+                name=led_name,
                 channel=rtio_offset+i)
         return 2
+
+
+def split_efcs(peripherals):
+    efc_filter = lambda peripheral: peripheral["type"] == "efc"
+    return filterfalse(efc_filter, peripherals), \
+        list(filter(efc_filter, peripherals))
 
 
 def process(output, primary_description, satellites):
@@ -651,9 +735,11 @@ def process(output, primary_description, satellites):
 
     pm = PeripheralManager(output, primary_description)
 
+    primary_peripherals, efcs = split_efcs(primary_description["peripherals"])
+
     print("# {} peripherals".format(drtio_role), file=output)
     rtio_offset = 0
-    for peripheral in primary_description["peripherals"]:
+    for peripheral in primary_peripherals:
         n_channels = pm.process(rtio_offset, peripheral)
         rtio_offset += n_channels
     if drtio_role == "standalone":
@@ -661,14 +747,20 @@ def process(output, primary_description, satellites):
         rtio_offset += n_channels
 
     for destination, description in satellites:
+        peripherals, satellite_efcs = split_efcs(description["peripherals"])
+        efcs.extend(satellite_efcs)
         if description["drtio_role"] != "satellite":
             raise ValueError("Invalid DRTIO role for satellite at destination {}".format(destination))
 
         print("# DEST#{} peripherals".format(destination), file=output)
         rtio_offset = destination << 16
-        for peripheral in description["peripherals"]:
+        for peripheral in peripherals:
             n_channels = pm.process(rtio_offset, peripheral)
             rtio_offset += n_channels
+    
+    for efc in efcs:
+        print("# DEST#{} peripherals".format(efc["drtio_destination"]), file=output)
+        pm.process_efc(efc)
 
 
 def main():


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
`artiq_ddb_template` now generates Shuttler coredevice entries given an EFC entry in the JSON description file.

EFC peripheral is not processed under the `process` method. Instead, it is filtered from peripherals, and processed as a satellite.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |


### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
