### PR TITLE
browser: fix missing parameter in applets dock from (#2210)

### DIFF
--- a/artiq/frontend/artiq_browser.py
+++ b/artiq/frontend/artiq_browser.py
@@ -81,7 +81,8 @@ class Browser(QtWidgets.QMainWindow):
         self.files.dataset_changed.connect(
             self.experiments.dataset_changed)
 
-        self.applets = applets.AppletsDock(self, dataset_sub, dataset_ctl, loop=loop)
+        self.applets = applets.AppletsDock(self, dataset_sub, dataset_ctl,
+                                           self.experiments, loop=loop)
         smgr.register(self.applets)
         atexit_register_coroutine(self.applets.stop, loop=loop)
 


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
Add the additional parameter `self.experiments` for `AppletsDock` from #2210.
### Error Logs
```shell
artiq_browser
Warning: Ignoring XDG_SESSION_TYPE=wayland on Gnome. Use QT_QPA_PLATFORM=wayland to run on Wayland anyway.
Traceback (most recent call last):
  File "/nix/store/qig0y8ycvai09pk56gsx156nyxr3cd6l-python3.10-artiq-8.8530+b7b8f0e.beta/bin/.artiq_browser-wrapped", line 9, in <module>
    sys.exit(main())
  File "/nix/store/q7qv3ws1zx760x3m48gzk0cvwirqkb67-python3-3.10.12-env/lib/python3.10/site-packages/artiq/frontend/artiq_browser.py", line 154, in main
    browser = Browser(smgr, dataset_sub, dataset_ctl, args.browse_root,
  File "/nix/store/q7qv3ws1zx760x3m48gzk0cvwirqkb67-python3-3.10.12-env/lib/python3.10/site-packages/artiq/frontend/artiq_browser.py", line 84, in __init__
    self.applets = applets.AppletsDock(self, dataset_sub, dataset_ctl, loop=loop)
TypeError: AppletsDock.__init__() missing 1 required positional argument: 'expmgr'
```
<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :hammer: Refactoring  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
