### PR TITLE
Shuttler: Truncate LSBs instead of MSBs when passing samples to DAC

### DIFF
--- a/artiq/coredevice/shuttler.py
+++ b/artiq/coredevice/shuttler.py
@@ -12,7 +12,7 @@ def shuttler_volt_to_mu(volt):
     """Return the equivalent DAC code. Valid input range is from -10 to
     10 - LSB.
     """
-    return round((1 << 14) * (volt / 20.0)) & 0x3fff
+    return round((1 << 16) * (volt / 20.0)) & 0xffff
 
 
 class Config:
@@ -25,7 +25,7 @@ class Config:
     output data with pre-DAC gain, then adds the offset.
 
     .. note::
-        The DAC code is capped at 0x1fff and 0x2000.
+        The DAC code is capped at 0x7fff and 0x8000.
 
     :param channel: RTIO channel number of this interface.
     :param core_device: Core device name.
@@ -152,8 +152,8 @@ class Volt:
 
             a_3 &= p_3T^3
         
-        :math:`a_0`, :math:`a_1`, :math:`a_2` and :math:`a_3` are 14, 30, 46
-        and 46 bits in width respectively. See :meth:`shuttler_volt_to_mu` for
+        :math:`a_0`, :math:`a_1`, :math:`a_2` and :math:`a_3` are 16, 32, 48
+        and 48 bits in width respectively. See :meth:`shuttler_volt_to_mu` for
         machine unit conversion.
 
         Note: The waveform is not updated to the Shuttler Core until
@@ -238,8 +238,8 @@ class Dds:
 
             c_2 &= r_2T^2
         
-        :math:`b_0`, :math:`b_1`, :math:`b_2` and :math:`b_3` are 14, 30, 46
-        and 46 bits in width respectively. See :meth:`shuttler_volt_to_mu` for
+        :math:`b_0`, :math:`b_1`, :math:`b_2` and :math:`b_3` are 16, 32, 48
+        and 48 bits in width respectively. See :meth:`shuttler_volt_to_mu` for
         machine unit conversion. :math:`c_0`, :math:`c_1` and :math:`c_2` are
         16, 32 and 32 bits in width respectively.
 

--- a/artiq/examples/kasli_shuttler/repository/shuttler.py
+++ b/artiq/examples/kasli_shuttler/repository/shuttler.py
@@ -26,15 +26,15 @@ def shuttler_volt_amp_mu(volt):
 
 @portable
 def shuttler_volt_damp_mu(volt_per_us):
-    return round(float(2) ** 30 * (volt_per_us / 20) / DAC_Fs_MHZ)
+    return round(float(2) ** 32 * (volt_per_us / 20) / DAC_Fs_MHZ)
 
 @portable
 def shuttler_volt_ddamp_mu(volt_per_us_square):
-    return round(float(2) ** 46 * (volt_per_us_square / 20) * 2 / (DAC_Fs_MHZ ** 2))
+    return round(float(2) ** 48 * (volt_per_us_square / 20) * 2 / (DAC_Fs_MHZ ** 2))
 
 @portable
 def shuttler_volt_dddamp_mu(volt_per_us_cube):
-    return round(float(2) ** 46 * (volt_per_us_cube / 20) * 6 / (DAC_Fs_MHZ ** 3))
+    return round(float(2) ** 48 * (volt_per_us_cube / 20) * 6 / (DAC_Fs_MHZ ** 3))
 
 @portable
 def shuttler_dds_amp_mu(volt):


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
After pre-DAC gain & offset adjustment, Shuttler truncates the 16-bits pre-DAC voltage sample down to 14-bits wide. Previously, the 2 MSBs are truncated. This PR truncates the 2 LSBs instead.

Documentations & helper functions are adjusted to reflect the change.

### Related Issue
[Comments in PR 2193](https://github.com/m-labs/artiq/pull/2193#discussion_r1323641963)
@linuswck @dhslichter 

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :scroll: Docs |

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
