### PR TITLE
compiler: Catch escaping numpy.{array, full, transpose}() results

### DIFF
--- a/artiq/test/lit/escape/error_numpy_array.py
+++ b/artiq/test/lit/escape/error_numpy_array.py
@@ -1,0 +1,15 @@
+# RUN: %python -m artiq.compiler.testbench.embedding +diag %s 2>%t
+# RUN: OutputCheck %s --file-to-check=%t
+
+from artiq.experiment import *
+import numpy as np
+
+@kernel
+def a():
+    # CHECK-L: ${LINE:+2}: error: cannot return an allocated value that does not live forever
+    # CHECK-L: ${LINE:+1}: note: ... to this point
+    return np.array([0, 1])
+
+@kernel
+def entrypoint():
+    a()

--- a/artiq/test/lit/escape/error_numpy_full.py
+++ b/artiq/test/lit/escape/error_numpy_full.py
@@ -1,0 +1,16 @@
+# RUN: %python -m artiq.compiler.testbench.embedding +diag %s 2>%t
+# RUN: OutputCheck %s --file-to-check=%t
+
+from artiq.experiment import *
+import numpy as np
+
+@kernel
+def a():
+    # CHECK-L: ${LINE:+2}: error: cannot return an allocated value that does not live forever
+    # CHECK-L: ${LINE:+1}: note: ... to this point
+    return np.full(10, 42.0)
+
+
+@kernel
+def entrypoint():
+    a()

--- a/artiq/test/lit/escape/error_numpy_transpose.py
+++ b/artiq/test/lit/escape/error_numpy_transpose.py
@@ -1,0 +1,17 @@
+# RUN: %python -m artiq.compiler.testbench.embedding +diag %s 2>%t
+# RUN: OutputCheck %s --file-to-check=%t
+
+from artiq.experiment import *
+import numpy as np
+
+data = np.array([[0, 1], [2, 3]])
+
+@kernel
+def a():
+    # CHECK-L: ${LINE:+2}: error: cannot return an allocated value that does not live forever
+    # CHECK-L: ${LINE:+1}: note: ... to this point
+    return np.transpose(data)
+
+@kernel
+def entrypoint():
+    a()

--- a/doc/manual/compiler.rst
+++ b/doc/manual/compiler.rst
@@ -95,24 +95,6 @@ tracked across function calls (see `#1497 <https://github.com/m-labs/artiq/issue
         def run(self):
             # results in memory corruption
             return func([1, 2, 3])
-or if the return value is obfuscated by an if-statement like here: ::
-
-    class ProblemReturn2(EnvExperiment):
-        def build(self):
-            self.setattr_device("core")
-
-        @kernel
-        def meth(self):
-            # if statement for obfuscation
-            if self.core.get_rtio_counter_mu() % 2:
-                return np.array([1,2,3])
-            else:
-                return np.array([4,5,6])
-
-        @kernel
-        def run(self):
-            # also results in memory corrption
-            return self.meth()
 
 This results in memory corruption at runtime.
 


### PR DESCRIPTION
Function calls in general can still be used to hide escaping
allocations from the compiler (issue #1497), but these calls in
particular always allocate, so we can easily and accurately handle
them.
