### PR TITLE
Shuttler: Add test case for EEM IOStandard

### DIFF
--- a/artiq/gateware/eem.py
+++ b/artiq/gateware/eem.py
@@ -792,5 +792,7 @@ class Shuttler(_EEM):
 
     @classmethod
     def add_std(cls, target, eem, eem_aux, iostandard=default_iostandard):
+        if iostandard(eem).name != "LVDS_25":
+            raise ValueError("EEM{} does not support LVDS_25 IOStandard".format(eem))
         cls.add_extension(target, eem, is_drtio_over_eem=True, iostandard=iostandard)
         target.eem_drtio_channels.append((target.platform.request("shuttler{}_drtio_rx".format(eem), 0), target.platform.request("shuttler{}_drtio_tx".format(eem), 0)))

--- a/artiq/gateware/eem_7series.py
+++ b/artiq/gateware/eem_7series.py
@@ -141,7 +141,7 @@ def peripheral_shuttler(module, peripheral, **kwargs):
         port, port_aux = peripheral["ports"]
     else:
         raise ValueError("wrong number of ports")
-    eem.Shuttler.add_std(module, port, port_aux)
+    eem.Shuttler.add_std(module, port, port_aux, **kwargs)
 
 peripheral_processors = {
     "dio": peripheral_dio,


### PR DESCRIPTION

<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
This PR add a test case for shuttler before gateware is compiled. Since EFC(Shuttler) EEM port only supports LVDS_25 IOStandard, gateware should not be compiled if the assigned port does not support LVDS_25 IOStandard. For example, Kasli-Soc has EEM ports with LVDS and LVDS_25 IOStandard.

The code is verified on artiq-zynq and artiq repo. 

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
