### PR TITLE
eem_7series: pass through kwargs for shuttler

### DIFF
--- a/artiq/gateware/eem_7series.py
+++ b/artiq/gateware/eem_7series.py
@@ -141,7 +141,7 @@ def peripheral_shuttler(module, peripheral, **kwargs):
         port, port_aux = peripheral["ports"]
     else:
         raise ValueError("wrong number of ports")
-    eem.Shuttler.add_std(module, port, port_aux)
+    eem.Shuttler.add_std(module, port, port_aux, **kwargs)
 
 peripheral_processors = {
     "dio": peripheral_dio,


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
For Kasli-Soc, the IOStandard definition does not get pass through. Thus, there is gateware compilation error when shuttler is defined on a LVDS EEM port as the default IOStandard is [LVDS_25](https://github.com/m-labs/artiq/blob/master/artiq/gateware/eem.py#L22-L23).

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
