### PR TITLE
EFC: Initialize the I/O expander

### DIFF
--- a/artiq/firmware/satman/main.rs
+++ b/artiq/firmware/satman/main.rs
@@ -632,7 +632,8 @@ pub extern fn main() -> i32 {
     #[cfg(soc_platform = "efc")]
     {
         io_expander = board_misoc::io_expander::IoExpander::new().unwrap();
-        
+        io_expander.init().expect("I2C I/O expander initialization failed");
+
         // Enable LEDs
         io_expander.set_oe(0, 1 << 5 | 1 << 6 | 1 << 7).unwrap();
         


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
As titled. Initializing the I/O expander clears the output level to 0, which turns off the error LED (and all other signals controlled by the I/O expander).

### Related Issue
Closes #2205 

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
