### PR TITLE
ad53xx: fix `load()` references in documentation

### DIFF
--- a/artiq/coredevice/ad53xx.py
+++ b/artiq/coredevice/ad53xx.py
@@ -233,7 +233,7 @@ class AD53xx:
     def write_gain_mu(self, channel, gain=0xffff):
         """Program the gain register for a DAC channel.
 
-        The DAC output is not updated until LDAC is pulsed (see :meth load:).
+        The DAC output is not updated until LDAC is pulsed (see :meth:`load`).
         This method advances the timeline by the duration of one SPI transfer.
 
         :param gain: 16-bit gain register value (default: 0xffff)
@@ -245,7 +245,7 @@ class AD53xx:
     def write_offset_mu(self, channel, offset=0x8000):
         """Program the offset register for a DAC channel.
 
-        The DAC output is not updated until LDAC is pulsed (see :meth load:).
+        The DAC output is not updated until LDAC is pulsed (see :meth:`load`).
         This method advances the timeline by the duration of one SPI transfer.
 
         :param offset: 16-bit offset register value (default: 0x8000)
@@ -258,7 +258,7 @@ class AD53xx:
         """Program the DAC offset voltage for a channel.
 
         An offset of +V can be used to trim out a DAC offset error of -V.
-        The DAC output is not updated until LDAC is pulsed (see :meth load:).
+        The DAC output is not updated until LDAC is pulsed (see :meth:`load`).
         This method advances the timeline by the duration of one SPI transfer.
 
         :param voltage: the offset voltage
@@ -270,7 +270,7 @@ class AD53xx:
     def write_dac_mu(self, channel, value):
         """Program the DAC input register for a channel.
 
-        The DAC output is not updated until LDAC is pulsed (see :meth load:).
+        The DAC output is not updated until LDAC is pulsed (see :meth:`load`).
         This method advances the timeline by the duration of one SPI transfer.
         """
         self.bus.write(
@@ -280,7 +280,7 @@ class AD53xx:
     def write_dac(self, channel, voltage):
         """Program the DAC output voltage for a channel.
 
-        The DAC output is not updated until LDAC is pulsed (see :meth load:).
+        The DAC output is not updated until LDAC is pulsed (see :meth:`load`).
         This method advances the timeline by the duration of one SPI transfer.
         """
         self.write_dac_mu(channel, voltage_to_mu(voltage, self.offset_dacs,
@@ -313,7 +313,7 @@ class AD53xx:
 
         If no LDAC device was defined, the LDAC pulse is skipped.
 
-        See :meth load:.
+        See :meth:`load`.
 
         :param values: list of DAC values to program
         :param channels: list of DAC channels to program. If not specified,
@@ -355,7 +355,7 @@ class AD53xx:
         """ Two-point calibration of a DAC channel.
 
         Programs the offset and gain register to trim out DAC errors. Does not
-        take effect until LDAC is pulsed (see :meth load:).
+        take effect until LDAC is pulsed (see :meth:`load`).
 
         Calibration consists of measuring the DAC output voltage for a channel
         with the DAC set to zero-scale (0x0000) and full-scale (0xffff).


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Also should be applied to release-7.

Before:
![image](https://github.com/m-labs/artiq/assets/1278433/7948b5bf-4633-4989-9206-a6ce9fef3fe2)
After:
![image](https://github.com/m-labs/artiq/assets/1278433/5b56c277-f891-42fe-892c-339ed6322e94)

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Documentation Changes

- [x] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
