### PR TITLE
Subkernel: fix composite arguments separate tags and data

### DIFF
--- a/artiq/compiler/ir.py
+++ b/artiq/compiler/ir.py
@@ -764,6 +764,23 @@ class GetOptArgFromRemote(GetArgFromRemote):
     def opcode(self):
         return "getoptargfromremote({})".format(repr(self.arg_name))
 
+class SubkernelAwaitArgs(Instruction):
+    """
+    A builtin instruction that takes min and max received messages as operands,
+    and a list of received types.
+
+    :ivar arg_types: (list of types) types of passed arguments (including optional)
+    """
+
+    """
+    :param arg_types: (list of types) types of passed arguments (including optional)
+    """
+
+    def __init__(self, operands, arg_types, name=None):
+        assert isinstance(arg_types, list)
+        self.arg_types = arg_types
+        super().__init__(operands, builtins.TNone(), name)
+
 class GetAttr(Instruction):
     """
     An intruction that loads an attribute from an object,

--- a/artiq/compiler/transforms/artiq_ir_generator.py
+++ b/artiq/compiler/transforms/artiq_ir_generator.py
@@ -2614,8 +2614,9 @@ class ARTIQIRGenerator(algorithm.Visitor):
                 min_args = ir.Constant(len(fn_typ.args)-offset, builtins.TInt8())
                 max_args = ir.Constant(fn_typ.arity()-offset, builtins.TInt8())
 
-                rcvd_count = self.append(ir.Builtin("subkernel_await_args", [min_args, max_args], builtins.TNone()))
-                arg_types = list(fn_typ.args.items())[offset:]
+                arg_types = list(fn_typ.args.items())[offset:] 
+                arg_type_list = [a[1] for a in arg_types] + [a[1] for a in fn_typ.optargs.items()]
+                rcvd_count = self.append(ir.SubkernelAwaitArgs([min_args, max_args], arg_type_list))
                 # obligatory arguments
                 for arg_name, arg_type in arg_types:
                     args[index] = self.append(ir.GetArgFromRemote(arg_name, arg_type,

--- a/artiq/firmware/ksupport/lib.rs
+++ b/artiq/firmware/ksupport/lib.rs
@@ -138,7 +138,7 @@ extern fn rpc_send_async(service: u32, tag: &CSlice<u8>, data: *const *const ())
     rpc_queue::enqueue(|mut slice| {
         let length = {
             let mut writer = Cursor::new(&mut slice[4..]);
-            rpc_proto::send_args(&mut writer, service, tag.as_ref(), data)?;
+            rpc_proto::send_args(&mut writer, service, tag.as_ref(), data, true)?;
             writer.position()
         };
         io::ProtoWrite::write_u32(&mut slice, length as u32)
@@ -499,8 +499,8 @@ extern fn subkernel_send_message(id: u32, count: u8, tag: &CSlice<u8>, data: *co
 }
 
 #[unwind(allowed)]
-extern fn subkernel_await_message(id: u32, timeout: u64, min: u8, max: u8) -> u8 {
-    send(&SubkernelMsgRecvRequest { id: id, timeout: timeout });
+extern fn subkernel_await_message(id: u32, timeout: u64, tags: &CSlice<u8>, min: u8, max: u8) -> u8 {
+    send(&SubkernelMsgRecvRequest { id: id, timeout: timeout, tags: tags.as_ref() });
     recv!(SubkernelMsgRecvReply { status, count } => {
         match status {
             SubkernelStatus::NoError => {

--- a/artiq/firmware/libproto_artiq/kernel_proto.rs
+++ b/artiq/firmware/libproto_artiq/kernel_proto.rs
@@ -108,7 +108,7 @@ pub enum Message<'a> {
     SubkernelAwaitFinishRequest { id: u32, timeout: u64 },
     SubkernelAwaitFinishReply { status: SubkernelStatus },
     SubkernelMsgSend { id: u32, count: u8, tag: &'a [u8], data: *const *const () },
-    SubkernelMsgRecvRequest { id: u32, timeout: u64 },
+    SubkernelMsgRecvRequest { id: u32, timeout: u64, tags: &'a [u8] },
     SubkernelMsgRecvReply { status: SubkernelStatus, count: u8 },
 
     Log(fmt::Arguments<'a>),

--- a/artiq/firmware/runtime/kernel.rs
+++ b/artiq/firmware/runtime/kernel.rs
@@ -307,8 +307,7 @@ pub mod subkernel {
 
     pub struct Message {
         from_id: u32,
-        pub tag_count: u8,
-        pub tag: u8,
+        pub count: u8,
         pub data: Vec<u8>
     }
 
@@ -334,9 +333,8 @@ pub mod subkernel {
             None => unsafe {
                 CURRENT_MESSAGES.insert(id, Message {
                     from_id: id,
-                    tag_count: data[0],
-                    tag: data[1],
-                    data: data[2..length].to_vec()
+                    count: data[0],
+                    data: data[1..length].to_vec()
                 });
             }
         };
@@ -404,7 +402,7 @@ pub mod subkernel {
         let destination = unsafe { SUBKERNELS.get(&id).unwrap().destination };
 
         // reuse rpc code for sending arbitrary data
-        rpc::send_args(&mut writer, 0, tag, message)?;
+        rpc::send_args(&mut writer, 0, tag, message, false)?;
         // skip service tag, but overwrite first byte with tag count
         let data = &mut writer.into_inner()[3..];
         data[0] = count;

--- a/artiq/test/lit/embedding/subkernel_return.py
+++ b/artiq/test/lit/embedding/subkernel_return.py
@@ -9,13 +9,13 @@ def entrypoint():
     # CHECK: call void @subkernel_load_run\(i32 1, i1 true\), !dbg !.
     # CHECK-NOT: call void @subkernel_send_message\(.*\), !dbg !.
     returning()
-    # CHECK: call i8 @subkernel_await_message\(i32 1, i64 10000, i8 1, i8 1\), !dbg !.
+    # CHECK: call i8 @subkernel_await_message\(i32 1, i64 10000, { i8\*, i32 }\* nonnull .*, i8 1, i8 1\), !dbg !.
     # CHECK: call void @subkernel_await_finish\(i32 1, i64 10000\), !dbg !.
     subkernel_await(returning)
 
 # CHECK-L: declare void @subkernel_load_run(i32, i1) local_unnamed_addr
 # CHECK-NOT-L: declare void @subkernel_send_message(i32, i8, { i8*, i32 }*, i8**) local_unnamed_addr
-# CHECK-L: declare i8 @subkernel_await_message(i32, i64, i8, i8) local_unnamed_addr
+# CHECK-L: declare i8 @subkernel_await_message(i32, i64, { i8*, i32 }*, i8, i8) local_unnamed_addr
 # CHECK-L: declare void @subkernel_await_finish(i32, i64) local_unnamed_addr
 @subkernel(destination=1)
 def returning() -> TInt32:

--- a/artiq/test/lit/embedding/subkernel_return_none.py
+++ b/artiq/test/lit/embedding/subkernel_return_none.py
@@ -10,13 +10,13 @@ def entrypoint():
     # CHECK-NOT: call void @subkernel_send_message\(.*\), !dbg !.
     returning_none()
     # CHECK: call void @subkernel_await_finish\(i32 1, i64 10000\), !dbg !.
-    # CHECK-NOT: call void @subkernel_await_message\(i32 1, i64 10000\), !dbg !.
+    # CHECK-NOT: call i8 @subkernel_await_message\(i32 1, i64 10000\, .*\), !dbg !.
     subkernel_await(returning_none)
 
 # CHECK-L: declare void @subkernel_load_run(i32, i1) local_unnamed_addr
 # CHECK-NOT-L: declare void @subkernel_send_message(i32, { i8*, i32 }*, i8**) local_unnamed_addr
 # CHECK-L: declare void @subkernel_await_finish(i32, i64) local_unnamed_addr
-# CHECK-NOT-L: declare void @subkernel_await_message(i32, i64) local_unnamed_addr
+# CHECK-NOT-L: declare i8 @subkernel_await_message(i32, i64, { i8*, i32 }*, i8, i8) local_unnamed_addr
 @subkernel(destination=1)
 def returning_none() -> TNone:
     pass


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Currently, trying to pass a composite argument such as tuple, array, range and list would cause a panic.

This is because RPC code that was reused for subkernel purpose is asymmetrical - what was sent by the firmware is not what the firmware could receive - sent data has tags, but when receiving, the tags should be provided by the kernel. Instead, trying to get it to work quickly, I took the first byte of the RPC data as tag - which works for simple types, but not for composite, which require more information.

So this PR fixes that by:
- providing arg awaiting and return functions with proper tags in compiler,
- providing an option not to add tags to data by the RPC sender (switch between PC RPC and subkernel modes, basically).
- keeping track of non-consumed tags by the RPC recv function, so multiple messages can be sent.

Basically separating tags and data. Of course that also means a little bit of data sent less, although I wouldn't even try to call it a performance benefit...

Tested with the following script, on top of sanity checks with simple types and optional arguments:
<details>

```python
from artiq.experiment import *
import numpy

class Subkernel(EnvExperiment):
    def build(self):
        self.setattr_device("core")
        self.setattr_device("led1")
        self.setattr_device("led0")
        self.setattr_device("led2")
    
    @subkernel(destination=1)
    def list_args(self, a: TList(TStr), b: TList(TStr)) -> TInt32:
        print(a[0])
        print(a[1])
        print(b[0])
        return len(a) + len(b)

    @subkernel(destination=1)
    def tuple_args(self, a: TTuple([TStr, TInt32]), b: TTuple([TFloat, TBool, TInt32])) -> TInt32:
        print(a[0])
        print(a[1])
        print(b[0])
        if b[1]:
            total = a[1] + int(b[0] * b[2])
        else:
            total = a[1] - int(b[0] / b[2])
        return total

    @subkernel(destination=1)
    def array_args(self, a: TArray(TInt32, 2)) -> TInt32:
        return len(a)

    @subkernel(destination=1)
    def range_args(self, a: TRange32) -> TInt32:
        c = 0
        print(a)
        for i in a:
            print(i)
            c = c + 2 * i
        return c

    @kernel
    def run(self):
        subkernel_preload(self.list_args)
        self.core.reset()
        self.core.break_realtime()
        delay(1000*ms)
        self.list_args(["ala", "ma", "kota"], ["kot", "ma", "ale"])
        
        val = subkernel_await(self.list_args)
        print(val)

        self.tuple_args(("test pls ignore", 2137), (10.0, True, 2))
        val = subkernel_await(self.tuple_args)
        print(val)
        self.tuple_args(("test pls ignore", 2137), (10.0, False, 5))
        val = subkernel_await(self.tuple_args)
        print(val)
        self.array_args(numpy.array([[1, 2], [3, 4]]))
        val = subkernel_await(self.array_args)
        print(val)
        self.range_args(range(10))
        val = subkernel_await(self.range_args)
        print(val)
```

Note: ``print()`` on subkernel prints to the local logger, it's not sent back to the master.
</details>
## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
