### PR TITLE
Kasli-Soc, KC705, ZC706: Fix GTX Clock Path at Initialization

### DIFF
--- a/artiq/gateware/drtio/transceiver/gtx_7series_init.py
+++ b/artiq/gateware/drtio/transceiver/gtx_7series_init.py
@@ -16,7 +16,7 @@ class GTXInit(Module):
         assert mode in ["single", "master", "slave"]
         self.mode = mode
 
-        self.stable_clkin = Signal()
+        self.clk_path_ready = Signal()
 
         self.done = Signal()
         self.restart = Signal()
@@ -110,7 +110,7 @@ class GTXInit(Module):
 
         startup_fsm.act("INITIAL",
             startup_timer.wait.eq(1),
-            If(startup_timer.done & self.stable_clkin, NextState("RESET_PLL"))
+            If(startup_timer.done & self.clk_path_ready, NextState("RESET_PLL"))
         )
         startup_fsm.act("RESET_PLL",
             gtXxreset.eq(1),

--- a/artiq/gateware/targets/kc705.py
+++ b/artiq/gateware/targets/kc705.py
@@ -273,7 +273,8 @@ class _MasterBase(MiniSoC, AMPSoC):
 
         txout_buf = Signal()
         self.specials += Instance("BUFG", i_I=gtx0.txoutclk, o_O=txout_buf)
-        self.crg.configure(txout_buf, clk_sw=gtx0.tx_init.done)
+        self.crg.configure(txout_buf, clk_sw=self.gt_drtio.stable_clkin.storage, ext_async_rst=self.crg.clk_sw_fsm.o_clk_sw & ~gtx0.tx_init.done)
+        self.specials += MultiReg(self.crg.clk_sw_fsm.o_clk_sw & self.crg.mmcm_locked, self.gt_drtio.clk_path_ready, odomain="bootstrap")
 
         self.comb += [
             platform.request("user_sma_clock_p").eq(ClockSignal("rtio_rx0")),
@@ -440,7 +441,8 @@ class _SatelliteBase(BaseSoC, AMPSoC):
 
         txout_buf = Signal()
         self.specials += Instance("BUFG", i_I=gtx0.txoutclk, o_O=txout_buf)
-        self.crg.configure(txout_buf, clk_sw=gtx0.tx_init.done)
+        self.crg.configure(txout_buf, clk_sw=self.gt_drtio.stable_clkin.storage, ext_async_rst=self.crg.clk_sw_fsm.o_clk_sw & ~gtx0.tx_init.done)
+        self.specials += MultiReg(self.crg.clk_sw_fsm.o_clk_sw & self.crg.mmcm_locked, self.gt_drtio.clk_path_ready, odomain="bootstrap")
 
         self.comb += [
             platform.request("user_sma_clock_p").eq(ClockSignal("rtio_rx0")),


### PR DESCRIPTION
# ARTIQ Pull Request
This PR ports the changes from PR #2275 to GTX Transceiver and kc705 platform. Most of the changes made is identical to #2275. 

## Description of Changes
### Change made Specific to Kasli-Soc, ZC706
The following logic is no longer needed to hold this signal high throughout the TX Init for Kasli-soc and zc706
`self.sync.bootstrap += clk_enable.eq(self.stable_clkin.storage | self.gtxs[0].tx_init.cplllock)`

because the logic for  `clk_path_ready` will be driven by `AND(crg.clk_sw_fsm.o_clk_sw, crg.mmcm_locked)`, which does not get affected by the reset signal in PL System Clock Domain.

# Test done on KC705
For tests related to Kasli-soc, ZC706, please read the related [PR](https://git.m-labs.hk/M-Labs/artiq-zynq/pulls/280) in artiq-zynq repo.

The following variants are compiled and tested on hardware, which cover all DRTIO roles.
KC705:
1. nist_clock
2. nist_clock_master
3. nist_clock_satellite

All variants have their system startup and clock switch(if needed) correctly.

### Related PR
Misoc PR: https://github.com/m-labs/misoc/pull/145


## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
