### PR TITLE
Fix artiq-manual-pdf dependency

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -292,7 +292,7 @@
         inherit (pkgs.texlive)
           scheme-basic latexmk cmap collection-fontsrecommended fncychap
           titlesec tabulary varwidth framed fancyvrb float wrapfig parskip
-          upquote capt-of needspace etoolbox;
+          upquote capt-of needspace etoolbox booktabs;
       };
     in rec {
       packages.x86_64-linux = rec {


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
New nixpkgs require `booktabs` dependency for sphinx. Current texlive `scheme-basic` does not include it. Adding it to the list make the package build successfully (see test).
```
tlmgr info --list scheme-basic
package:     scheme-basic
category:    Scheme
shortdesc:   basic scheme (plain and latex)
longdesc:    This is the basic TeX Live scheme: it is a small set of files sufficient to typeset plain TeX or LaTeX documents in PostScript or PDF, using the Computer Modern fonts. This scheme corresponds to collection-basic and collection-latex.

depends:
	collection-basic
	collection-latex
```
```
tlmgr info --list collection-basic
package:     collection-basic
depends:
amsfonts bibtex cm colorprofiles dvipdfmx dvips ec enctex etex etex-pkg glyphlist graphics-def hyph-utf8 hyphen-base hyphenex ifplatform iftex knuth-lib knuth-local kpathsea lua-alt-getopt luahbtex luatex makeindex metafont mflogo mfware modes pdftex plain tex tex-ini-files texlive-common texlive-en texlive-msg-translations texlive-scripts texlive.infra tlshell unicode-data xdvi
```
```
tlmgr info --list collection-latex
package:     collection-latex
depends:
ae amscls amsmath atbegshi atveryend auxhook babel babel-english babelbib bigintcalc bitset bookmark carlisle collection-basic colortbl epstopdf-pkg etexcmds fancyhdr firstaid fix2col geometry gettitlestring graphics graphics-cfg grfext hopatch hycolor hyperref intcalc kvdefinekeys kvoptions kvsetkeys l3backend l3kernel l3packages latex latex-bin latex-fonts latex-lab latexconfig letltxmacro ltxcmds ltxmisc mfnfss mptopdf natbib oberdiek pagesel pdfescape pslatex psnfss pspicture refcount rerunfilecheck stringenc tools uniquecounter url
```
### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
Closes #2288 
## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests


- [x] Use correct spelling and grammar.
- [x] Close/update issues.
- [ ] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- **Test**:
```
nix build .#artiq-manual-pdf && ls -lhLs ./result/
total 824K
820K -r--r--r-- 2 root root 818K Jan  1  1970 ARTIQ.pdf
4.0K dr-xr-xr-x 2 root root 4.0K Jan  1  1970 nix-support
```

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
