### PR TITLE
Repeater: fix setting tsc

### DIFF
--- a/artiq/gateware/drtio/rt_controller_repeater.py
+++ b/artiq/gateware/drtio/rt_controller_repeater.py
@@ -17,12 +17,11 @@ class RTController(Module, AutoCSR):
 
         self.sync += rt_packet.reset.eq(self.reset.storage)
 
-        set_time_stb = Signal()
         self.sync += [
-            If(rt_packet.set_time_stb, set_time_stb.eq(0)),
-            If(self.set_time.re, set_time_stb.eq(1))
+            If(rt_packet.set_time_ack, rt_packet.set_time_stb.eq(0)),
+            If(self.set_time.re, rt_packet.set_time_stb.eq(1))
         ]
-        self.comb += self.set_time.w.eq(set_time_stb)
+        self.comb += self.set_time.w.eq(rt_packet.set_time_stb)
 
         errors = [
             (rt_packet.err_unknown_packet_type, "rtio_rx", None, None),


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Minor mistake was made when doing the clock switch with the repeater TSC, ``set_time`` signals were not connected properly - this PR fixes that.

Tested with two Kasli 2.0s with satellite firmware.

### Related Issue

Closes #2293 

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
