### PR TITLE
change usage of "logs" field in waveform_data

### DIFF
--- a/artiq/coredevice/comm_analyzer.py
+++ b/artiq/coredevice/comm_analyzer.py
@@ -260,9 +260,8 @@ class WaveformManager:
 
     def get_channel(self, name, width, ty):
         if ty == WaveformType.LOG:
-            data = self.trace["logs"][self.current_scope + name] = list()
-        else:
-            data = self.trace["data"][self.current_scope + name] = list()
+            self.trace["logs"][self.current_scope + name] = (width, ty)
+        data = self.trace["data"][self.current_scope + name] = list()
         channel = WaveformChannel(data, self.current_time)
         self.channels.append(channel)
         return channel

--- a/artiq/dashboard/waveform.py
+++ b/artiq/dashboard/waveform.py
@@ -93,8 +93,7 @@ class WaveformDock(QtWidgets.QDockWidget):
         decoded_dump = comm_analyzer.decode_dump(dump)
         waveform_data = comm_analyzer.decoded_dump_to_waveform_data(self._ddb, decoded_dump)
         self._waveform_data.update(waveform_data)
-        for log in self._waveform_data['logs']:
-            self._channel_model[log] = (0, WaveformType.LOG)
+        self._channel_model.update(self._waveform_data['logs'])
 
     async def load_trace(self):
         try:


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

+ Change all 'logs' data to be stored in the 'data' field with only the width and type being stored in the 'logs' field. Simplifies the data management in the analyzer GUI.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
Smoke tested and tested with basic script.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
