### PR TITLE
testing: add coreanalyzer proxy smoke test

### DIFF
--- a/artiq/test/test_frontends.py
+++ b/artiq/test/test_frontends.py
@@ -9,7 +9,7 @@ class TestFrontends(unittest.TestCase):
         """Test --help as a simple smoke test against catastrophic breakage."""
         commands = {
             "aqctl": [
-                "corelog", "moninj_proxy"
+                "corelog", "moninj_proxy", "coreanalyzer_proxy"
             ],
             "artiq": [
                 "client", "compile", "coreanalyzer", "coremgmt",


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

+ add `aqctl_coreanalyzer_proxy` smoke test

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
