### PR TITLE
waveform: fix log msg display

### DIFF
--- a/artiq/dashboard/waveform.py
+++ b/artiq/dashboard/waveform.py
@@ -386,9 +386,11 @@ class LogWaveform(_BaseWaveform):
             self._labels = []
             self.plot_data_item.setData(
                 x=self.x_data, y=np.ones(len(self.x_data)))
-            old_msg = ""
-            old_x = 0
-            for x, msg in data:
+            if len(data) == 0:
+                return
+            old_x = data[0][0]
+            old_msg = data[0][1]
+            for x, msg in data[1:]:
                 if x == old_x:
                     old_msg += "\n" + msg
                 else:


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Fixes visual bug where when a log message is the first message in an analyzer dump, it incorrectly receives a newline character in front of it. 

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
Tested with experiment writing a single log message.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
