### PR TITLE
waveform: remove unused setTimescale

### DIFF
--- a/artiq/dashboard/waveform.py
+++ b/artiq/dashboard/waveform.py
@@ -195,9 +195,6 @@ class _BaseWaveform(pg.PlotWidget):
         self.stopped_x = stopped_x
         self.view_box.setLimits(xMax=stopped_x)
 
-    def setTimescale(self, timescale):
-        self.timescale = timescale
-
     def setData(self, data):
         if len(data) == 0:
             self.x_data, self.y_data = [], []
@@ -478,8 +475,6 @@ class _WaveformView(QtWidgets.QWidget):
     def setTimescale(self, timescale):
         self._timescale = timescale
         self._top.setScale(1e-12 * timescale)
-        for i in range(self._model.rowCount()):
-            self._splitter.widget(i).setTimescale(timescale)
 
     def setStoppedX(self, stopped_x):
         self._stopped_x = stopped_x
@@ -531,7 +526,6 @@ class _WaveformView(QtWidgets.QWidget):
         w = waveform_cls(name, width, precision, unit, parent=self._splitter)
         w.setXLink(self._ref_vb)
         w.setStoppedX(self._stopped_x)
-        w.setTimescale(self._timescale)
         w.cursorMove.connect(self.cursorMove)
         w.onCursorMove(self._cursor_x)
         action = QtWidgets.QAction("Delete waveform", w)


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

'timescale' variable is not used in _BaseWaveform or it's subclasses, should be removed.

## Steps

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
