### PR TITLE
session: workaround for stream.close interrupted

### DIFF
--- a/artiq/firmware/runtime/session.rs
+++ b/artiq/firmware/runtime/session.rs
@@ -976,7 +976,13 @@ pub fn thread(io: Io, aux_mutex: &Mutex,
                         drtio::clear_buffers(&io, &aux_mutex);
                     }
                 }
-                stream.close().expect("session: close socket");
+                loop {
+                    match stream.close() {
+                        Ok(_) => break,
+                        Err(SchedError::Interrupted) => (),
+                        Err(e) => panic!("session: close socket: {:?}", e)
+                    };
+                }
             });
         }
 


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Our test setup with KC705 would very often fail in recent days with:
```
panic at runtime/session.rs:979:32: session: close socket: Interrupted
backtrace for software version 8.8687+1749fa6.beta;nist_clock:
0x40030d2c
0x4000a444
0x40009a44
0x40021df8
0x4000e128
0x4000e118
0x4002c3a4
0x40008068
0x4001a27c
0x4001a224
0x4002feb4
halting.
```

I can only assume that internal firmware changes caused the timing between each test to interrupt the device in the precise moment of closing the stream, and Interrupted error isn't handled like it would be when the kernel is running.

So simple handling of that was added: ``stream.close()`` is retried if ``Interrupted`` error comes up. Tried by re-running tests on local machine and nixbld.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
