### PR TITLE
remove CancelledError workaround

### DIFF
--- a/artiq/coredevice/comm_moninj.py
+++ b/artiq/coredevice/comm_moninj.py
@@ -94,9 +94,7 @@ class CommMonInj:
                     self.injection_status_cb(channel, override, value)
                 else:
                     raise ValueError("Unknown packet type", ty)
-        except asyncio.CancelledError:
-            raise
-        except:
+        except Exception:
             logger.error("Moninj connection terminating with exception", exc_info=True)
         finally:
             if self.disconnect_cb is not None:

--- a/artiq/dashboard/moninj.py
+++ b/artiq/dashboard/moninj.py
@@ -719,10 +719,7 @@ class _DeviceManager:
                     self.disconnect_cb)
             try:
                 await new_mi_connection.connect(self.mi_addr, self.mi_port)
-            except asyncio.CancelledError:
-                logger.info("cancelled connection to moninj")
-                break
-            except:
+            except Exception:
                 logger.error("failed to connect to moninj. Is aqctl_moninj_proxy running?", exc_info=True)
                 await asyncio.sleep(10.)
                 self.reconnect_mi.set()


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

+ [CancelledError base class](https://bugs.python.org/issue32528) was changed to `BaseException` in Python 3.8, removing need for ugly pattern:

```
try:
    await some_task
except asyncio.CancelledError:
    raise
except:
    logger.error("error message")
```

## Steps

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
