### PR TITLE
artiq_client: fix deprecated wait usage

### DIFF
--- a/artiq/frontend/artiq_client.py
+++ b/artiq/frontend/artiq_client.py
@@ -307,7 +307,7 @@ def _run_subscriber(host, port, subscriber):
             loop.run_until_complete(subscriber.connect(host, port))
             try:
                 _, pending = loop.run_until_complete(asyncio.wait(
-                    [signal_handler.wait_terminate(), subscriber.receive_task],
+                    [loop.create_task(signal_handler.wait_terminate()), subscriber.receive_task],
                     return_when=asyncio.FIRST_COMPLETED))
                 for task in pending:
                     task.cancel()


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

`artiq_client show datasets` fails with error (python 3.11):

```
Traceback (most recent call last):
  File "/nix/store/0y91cs8w5ka4zadb9mmjpb9imq5lbr24-python3.11-artiq-8.8727+a803002.beta/bin/.artiq_client-wrapped", line 9, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/srenblad/artiq/artiq/frontend/artiq_client.py", line 370, in main
    _show_dict(args, "datasets", _show_datasets)
  File "/home/srenblad/artiq/artiq/frontend/artiq_client.py", line 332, in _show_dict
    _run_subscriber(args.server, port, subscriber)
  File "/home/srenblad/artiq/artiq/frontend/artiq_client.py", line 309, in _run_subscriber
    _, pending = loop.run_until_complete(asyncio.wait(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/rac8pxbi1vapwrlqzbrkycbyg521djzw-python3-3.11.6/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/nix/store/rac8pxbi1vapwrlqzbrkycbyg521djzw-python3-3.11.6/lib/python3.11/asyncio/tasks.py", line 425, in wait
    raise TypeError("Passing coroutines is forbidden, use tasks explicitly.")
TypeError: Passing coroutines is forbidden, use tasks explicitly.
sys:1: RuntimeWarning: coroutine 'SignalHandler.wait_terminate' was never awaited
```

Fixed by wrapping the coro in a task object.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps 

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
Tested show commands and they work with the change.
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
