### PR TITLE
artiq_ddb_template: remove extra clk_div white space on release-7

### DIFF
--- a/artiq/frontend/artiq_ddb_template.py
+++ b/artiq/frontend/artiq_ddb_template.py
@@ -237,7 +237,7 @@ class PeripheralManager:
                     "io_update_device": "ttl_{name}_io_update",
                     "refclk": {refclk},
                     "clk_sel": {clk_sel},
-                    "clk_div" : {clk_div}
+                    "clk_div": {clk_div}
                 }}
             }}""",
             name=urukul_name,


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
- The flake8 issue is pointed out from @lriesebos (#2338)
- remove the extra white space from `clk_div` which caused a flake8 E203 error at the `device_db.py` 

## Testing

- a `device_db.py` is generated from the following json. And running flake8 on it does not show `device_db.py:111:18: E203 whitespace before ':'`  after this patch.
```json 
{
  "target": "kasli",
  "variant": "standalone",
  "hw_rev": "v2.0",
  "base": "standalone",
  "peripherals": [
    {
            "type": "urukul",
            "dds": "ad9910",
            "ports": [0, 1],
            "clk_sel": 2
        }
  ]
}

```
<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes
- [x] Test your changes or have someone test them. Mention what was tested and how.


### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
