### PR TITLE
artiq_client: cancel interactive arguments

### DIFF
--- a/artiq/frontend/artiq_client.py
+++ b/artiq/frontend/artiq_client.py
@@ -121,6 +121,11 @@ def get_argparser():
         "arguments", metavar="ARGUMENTS", nargs="*",
         help="interactive arguments")
 
+    parser_cancel_interactive = subparsers.add_parser(
+        "cancel-interactive", help="cancel interactive arguments")
+    parser_cancel_interactive.add_argument(
+        "rid", metavar="RID", type=int, help="RID of target experiment")
+
     parser_show = subparsers.add_parser(
         "show", help="show schedule, log, devices or datasets")
     parser_show.add_argument(
@@ -220,6 +225,10 @@ def _action_scan_devices(remote, args):
 def _action_supply_interactive(remote, args):
     arguments = parse_arguments(args.arguments)
     remote.supply(args.rid, arguments)
+
+
+def _action_cancel_interactive(remote, args):
+    remote.cancel(args.rid)
 
 
 def _action_scan_repository(remote, args):
@@ -382,6 +391,7 @@ def main():
             "del_dataset": "dataset_db",
             "scan_devices": "device_db",
             "supply_interactive": "interactive_arg_db",
+            "cancel_interactive": "interactive_arg_db",
             "scan_repository": "experiment_db",
             "ls": "experiment_db",
             "terminate": "master_management",


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Cancel interactive argument requests with `artiq_client`.

```
artiq_client cancel-interactive <RID>
```

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
tested with #2376 

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
