### PR TITLE
example: expand interactive

### DIFF
--- a/artiq/examples/no_hardware/repository/interactive.py
+++ b/artiq/examples/no_hardware/repository/interactive.py
@@ -7,14 +7,28 @@ class InteractiveDemo(EnvExperiment):
 
     def run(self):
         print("Waiting for user input...")
-        with self.interactive() as interactive:
+        with self.interactive(title="Interactive Demo") as interactive:
+            interactive.setattr_argument("pyon_value",
+                                         PYONValue(self.get_dataset("foo", default=42)))
             interactive.setattr_argument("number", NumberValue(42e-6,
-                                                   unit="us",
-                                                   precision=4))
+                                         unit="us",
+                                         precision=4))
             interactive.setattr_argument("integer", NumberValue(42,
-                                                    step=1, precision=0))
+                                         step=1, precision=0))
             interactive.setattr_argument("string", StringValue("Hello World"))
+            interactive.setattr_argument("scan", Scannable(global_max=400,
+                                         default=NoScan(325),
+                                         precision=6))
+            interactive.setattr_argument("boolean", BooleanValue(True), "Group")
+            interactive.setattr_argument("enum",
+                                         EnumerationValue(["foo", "bar", "quux"], "foo"),
+                                         "Group")
         print("Done! Values:")
+        print(interactive.pyon_value)
+        print(interactive.boolean)
+        print(interactive.enum)
         print(interactive.number, type(interactive.number))
         print(interactive.integer, type(interactive.integer))
         print(interactive.string)
+        for i in interactive.scan:
+            print(i)


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Expands `examples/no_hardware/repository/interactive.py` with all value types used in `arguments_demo.py`.

## Related Issue

Closes #2373 

## Type of Change

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps

### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Close/update issues.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.

### Testing

| Test  | Observation |
| ------------- | ------------- |
|  `artiq_client show interactive-args` | Title is shown and shows all arguments properly. |
| supply-interactive` with valid arguments (tested with multiple scan types) | Prints all arguments as expected. Scan works as expected.|
|  `supply-interactive` with incorrect number of args | Experiment is not deleted. ValueError: supplied and requested keys do not match |
|  `supply-interactive` with correct number of args but invalid values (tested for each type) | Experiment is deleted. Various `TypeError` / `ValueError` depending on type tested. |

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
