### PR TITLE
Use nixpkgs sphinxcontrib-wavedrom

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -351,17 +351,6 @@
         paths = [ openocd-fixed bscan_spi_bitstreams-pkg ];
       };
 
-      sphinxcontrib-wavedrom = pkgs.python3Packages.buildPythonPackage rec {
-        pname = "sphinxcontrib-wavedrom";
-        version = "3.0.4";
-        format = "pyproject";
-        src = pkgs.python3Packages.fetchPypi {
-          inherit pname version;
-          sha256 = "sha256-0zTHVBr9kXwMEo4VRTFsxdX2HI31DxdHfLUHCQmw1Ko=";
-        };
-        nativeBuildInputs = [ pkgs.python3Packages.setuptools-scm ];
-        propagatedBuildInputs = (with pkgs.python3Packages; [ wavedrom sphinx xcffib cairosvg ]);
-      };
       latex-artiq-manual = pkgs.texlive.combine {
         inherit (pkgs.texlive)
           scheme-basic latexmk cmap collection-fontsrecommended fncychap
@@ -395,14 +384,14 @@
           target = "efc";
           variant = "shuttler";
         };
-        inherit sphinxcontrib-wavedrom latex-artiq-manual;
+        inherit latex-artiq-manual;
         artiq-manual-html = pkgs.stdenvNoCC.mkDerivation rec {
           name = "artiq-manual-html-${version}";
           version = artiqVersion;
           src = self;
-          buildInputs = [
-            pkgs.python3Packages.sphinx pkgs.python3Packages.sphinx_rtd_theme
-            pkgs.python3Packages.sphinx-argparse sphinxcontrib-wavedrom
+          buildInputs = with pkgs.python3Packages; [
+            sphinx sphinx_rtd_theme
+            sphinx-argparse sphinxcontrib-wavedrom
           ];
           buildPhase = ''
             export VERSIONEER_OVERRIDE=${artiqVersion}
@@ -420,11 +409,10 @@
           name = "artiq-manual-pdf-${version}";
           version = artiqVersion;
           src = self;
-          buildInputs = [
-            pkgs.python3Packages.sphinx pkgs.python3Packages.sphinx_rtd_theme
-            pkgs.python3Packages.sphinx-argparse sphinxcontrib-wavedrom
-            latex-artiq-manual
-          ];
+          buildInputs = with pkgs.python3Packages; [
+            sphinx sphinx_rtd_theme
+            sphinx-argparse sphinxcontrib-wavedrom
+          ] ++ [ latex-artiq-manual ];
           buildPhase = ''
             export VERSIONEER_OVERRIDE=${artiq.version}
             export SOURCE_DATE_EPOCH=${builtins.toString self.sourceInfo.lastModified}
@@ -468,7 +456,7 @@
           packages.x86_64-linux.vivado
           packages.x86_64-linux.openocd-bscanspi
           pkgs.python3Packages.sphinx pkgs.python3Packages.sphinx_rtd_theme
-          pkgs.python3Packages.sphinx-argparse sphinxcontrib-wavedrom latex-artiq-manual
+          pkgs.python3Packages.sphinx-argparse pkgs.python3Packages.sphinxcontrib-wavedrom latex-artiq-manual
         ];
         shellHook = ''
           export LIBARTIQ_SUPPORT=`libartiq-support`


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Use nixpkgs `sphinxcontrib-wavedrom`. 

Source: https://github.com/NixOS/nixpkgs/blob/nixos-23.11/pkgs/development/python-modules/sphinxcontrib-wavedrom/default.nix

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes
- [x] Test your changes or have someone test them. Mention what was tested and how.

artiq-manual-pdf:
```
nix build .#artiq-manual-pdf -L --show-trace && ls -lhLs ./result/
total 844K
840K -r--r--r-- 2 root root 837K Jan  1  1970 ARTIQ.pdf
4.0K dr-xr-xr-x 2 root root 4.0K Jan  1  1970 nix-support
```
artiq-manual-html:
```
nix build .#artiq-manual-html -L --show-trace && ls -lhLs ./result/
total 1.7M
 28K -r--r--r-- 2 root root  25K Jan  1  1970 compiler.html
 24K -r--r--r-- 2 root root  22K Jan  1  1970 core_device.html
652K -r--r--r-- 2 root root 652K Jan  1  1970 core_drivers_reference.html
 88K -r--r--r-- 2 root root  88K Jan  1  1970 core_language_reference.html
 12K -r--r--r-- 2 root root 9.1K Jan  1  1970 default_network_ports.html
 36K -r--r--r-- 2 root root  35K Jan  1  1970 developing_a_ndsp.html
 16K -r--r--r-- 2 root root  13K Jan  1  1970 developing.html
 24K -r--r--r-- 2 root root  23K Jan  1  1970 drtio.html
 16K -r--r--r-- 2 root root  15K Jan  1  1970 environment.html
 24K -r--r--r-- 2 root root  21K Jan  1  1970 faq.html
 96K -r--r--r-- 2 root root  94K Jan  1  1970 genindex.html
 64K -r--r--r-- 2 root root  61K Jan  1  1970 getting_started_core.html
 28K -r--r--r-- 2 root root  26K Jan  1  1970 getting_started_mgmt.html
 24K -r--r--r-- 2 root root  21K Jan  1  1970 index.html
 52K -r--r--r-- 2 root root  52K Jan  1  1970 installing.html
 12K -r--r--r-- 2 root root  11K Jan  1  1970 introduction.html
 16K -r--r--r-- 2 root root  13K Jan  1  1970 list_of_ndsps.html
 88K -r--r--r-- 2 root root  86K Jan  1  1970 management_system.html
4.0K dr-xr-xr-x 3 root root 4.0K Jan  1  1970 _modules
4.0K dr-xr-xr-x 2 root root 4.0K Jan  1  1970 nix-support
8.0K -r--r--r-- 2 root root 4.3K Jan  1  1970 objects.inv
 16K -r--r--r-- 2 root root  13K Jan  1  1970 py-modindex.html
 68K -r--r--r-- 2 root root  65K Jan  1  1970 release_notes.html
 36K -r--r--r-- 2 root root  36K Jan  1  1970 rtio.html
8.0K -r--r--r-- 2 root root 6.0K Jan  1  1970 search.html
164K -r--r--r-- 2 root root 163K Jan  1  1970 searchindex.js
4.0K dr-xr-xr-x 2 root root 4.0K Jan  1  1970 _sources
4.0K dr-xr-xr-x 4 root root 4.0K Jan  1  1970 _static
 48K -r--r--r-- 2 root root  48K Jan  1  1970 utilities.html
```

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
