### PR TITLE
entries: fix EnumerationEntry disable_scroll_wheel

### DIFF
--- a/artiq/gui/entries.py
+++ b/artiq/gui/entries.py
@@ -202,7 +202,6 @@ class EnumerationEntry(QtWidgets.QWidget):
 
     def __init__(self, argument):
         QtWidgets.QWidget.__init__(self)
-        disable_scroll_wheel(self)
         layout = QtWidgets.QHBoxLayout()
         self.setLayout(layout)
         procdesc = argument["desc"]
@@ -221,6 +220,7 @@ class EnumerationEntry(QtWidgets.QWidget):
             self.btn_group.idClicked.connect(submit)
         else:
             self.combo_box = QtWidgets.QComboBox()
+            disable_scroll_wheel(self.combo_box)
             self.combo_box.addItems(choices)
             idx = choices.index(argument["state"])
             self.combo_box.setCurrentIndex(idx)


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Fix `EnumerationEntry` scroll wheel not being properly disabled.

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
Tested on EnumerationEntry in browser.
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
