### PR TITLE
fix missing get_dataset_metadata

### DIFF
--- a/artiq/frontend/artiq_master.py
+++ b/artiq/frontend/artiq_master.py
@@ -120,6 +120,7 @@ def main():
         "get_device_db": device_db.get_device_db,
         "get_device": device_db.get,
         "get_dataset": dataset_db.get,
+        "get_dataset_metadata": dataset_db.get_metadata,
         "update_dataset": dataset_db.update,
         "get_interactive_arguments": get_interactive_arguments,
         "scheduler_submit": scheduler.submit,

--- a/artiq/master/worker_impl.py
+++ b/artiq/master/worker_impl.py
@@ -73,6 +73,7 @@ class ParentDeviceDB:
 class ParentDatasetDB:
     get = make_parent_action("get_dataset")
     update = make_parent_action("update_dataset")
+    get_metadata = make_parent_action("get_dataset_metadata")
 
 
 class Watchdog:
@@ -185,6 +186,10 @@ class ExamineDatasetMgr:
     @staticmethod
     def get(key, archive=False):
         return ParentDatasetDB.get(key)
+
+    @staticmethod
+    def get_metadata(key):
+        return ParentDatasetDB.get_metadata(key)
 
 
 def examine(device_mgr, dataset_mgr, file):


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Fix missing 'get_metadata' in 'ExamineDatasetMgr'.

### Related Issue

See https://forum.m-labs.hk/d/730-get-dataset-metadata-does-not-seem-to-work.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how. Quick test with the violating test case provided from forum. Was able to correctly print the metadata of a persistent dataset when build was called.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
