### PR TITLE
Updated EEM FMC Carrier support for v1.1

### DIFF
--- a/artiq/firmware/satman/main.rs
+++ b/artiq/firmware/satman/main.rs
@@ -669,6 +669,20 @@ pub extern fn main() -> i32 {
     let mut io_expander;
     #[cfg(soc_platform = "efc")]
     {
+        let p3v3_fmc_en_pin;
+        let vadj_fmc_en_pin;
+
+        #[cfg(hw_rev = "v1.0")]
+        {
+            p3v3_fmc_en_pin = 0;
+            vadj_fmc_en_pin = 1;
+        }
+        #[cfg(hw_rev = "v1.1")]
+        {
+            p3v3_fmc_en_pin = 1;
+            vadj_fmc_en_pin = 7;
+        }
+
         io_expander = board_misoc::io_expander::IoExpander::new().unwrap();
         io_expander.init().expect("I2C I/O expander initialization failed");
 
@@ -676,10 +690,10 @@ pub extern fn main() -> i32 {
         io_expander.set_oe(0, 1 << 5 | 1 << 6 | 1 << 7).unwrap();
         
         // Enable VADJ and P3V3_FMC
-        io_expander.set_oe(1, 1 << 0 | 1 << 1).unwrap();
+        io_expander.set_oe(1, 1 << p3v3_fmc_en_pin | 1 << vadj_fmc_en_pin).unwrap();
 
-        io_expander.set(1, 0, true);
-        io_expander.set(1, 1, true);
+        io_expander.set(1, p3v3_fmc_en_pin, true);
+        io_expander.set(1, vadj_fmc_en_pin, true);
 
         io_expander.service().unwrap();
     }
@@ -812,6 +826,20 @@ pub extern fn main() -> i32 {
 
 #[cfg(soc_platform = "efc")]
 fn enable_error_led() {
+    let p3v3_fmc_en_pin;
+    let vadj_fmc_en_pin;
+
+    #[cfg(hw_rev = "v1.0")]
+    {
+        p3v3_fmc_en_pin = 0;
+        vadj_fmc_en_pin = 1;
+    }
+    #[cfg(hw_rev = "v1.1")]
+    {
+        p3v3_fmc_en_pin = 1;
+        vadj_fmc_en_pin = 7;
+    }
+
     let mut io_expander = board_misoc::io_expander::IoExpander::new().unwrap();
 
     // Keep LEDs enabled
@@ -820,10 +848,10 @@ fn enable_error_led() {
     io_expander.set(0, 7, true);
 
     // Keep VADJ and P3V3_FMC enabled
-    io_expander.set_oe(1, 1 << 0 | 1 << 1).unwrap();
+    io_expander.set_oe(1, 1 << p3v3_fmc_en_pin | 1 << vadj_fmc_en_pin).unwrap();
 
-    io_expander.set(1, 0, true);
-    io_expander.set(1, 1, true);
+    io_expander.set(1, p3v3_fmc_en_pin, true);
+    io_expander.set(1, vadj_fmc_en_pin, true);
 
     io_expander.service().unwrap();
 }

--- a/artiq/frontend/artiq_flash.py
+++ b/artiq/frontend/artiq_flash.py
@@ -261,12 +261,19 @@ def main():
             "storage":      ("spi0", 0x440000),
             "firmware":     ("spi0", 0x450000),
         },
-        "efc": {
+        "efc1v0": {
             "programmer":   partial(ProgrammerXC7, board="efc", proxy="bscan_spi_xc7a100t.bit"),
             "gateware":     ("spi0", 0x000000),
-            "bootloader":   ("spi0", 0x400000),
-            "storage":      ("spi0", 0x440000),
-            "firmware":     ("spi0", 0x450000),
+            "bootloader":   ("spi0", 0x600000),
+            "storage":      ("spi0", 0x640000),
+            "firmware":     ("spi0", 0x650000),
+        },
+        "efc1v1": {
+            "programmer":   partial(ProgrammerXC7, board="efc", proxy="bscan_spi_xc7a200t.bit"),
+            "gateware":     ("spi0", 0x000000),
+            "bootloader":   ("spi0", 0x600000),
+            "storage":      ("spi0", 0x640000),
+            "firmware":     ("spi0", 0x650000),
         },
         "kc705": {
             "programmer":   partial(ProgrammerXC7, board="kc705", proxy="bscan_spi_xc7k325t.bit"),

--- a/artiq/gateware/targets/efc.py
+++ b/artiq/gateware/targets/efc.py
@@ -29,9 +29,10 @@ class Satellite(BaseSoC, AMPSoC):
     }
     mem_map.update(BaseSoC.mem_map)
 
-    def __init__(self, gateware_identifier_str=None, **kwargs):
+    def __init__(self, gateware_identifier_str=None, hw_rev="v1.1", **kwargs):
         BaseSoC.__init__(self,
                  cpu_type="vexriscv",
+                 hw_rev=hw_rev,
                  cpu_bus_width=64,
                  sdram_controller_type="minicon",
                  l2_size=128*1024,
@@ -243,12 +244,15 @@ def main():
     builder_args(parser)
     parser.set_defaults(output_dir="artiq_efc")
     parser.add_argument("-V", "--variant", default="shuttler")
+    parser.add_argument("--hw-rev", choices=["v1.0", "v1.1"], default="v1.1", 
+                        help="Hardware revision")
     parser.add_argument("--gateware-identifier-str", default=None,
                         help="Override ROM identifier")
     args = parser.parse_args()
 
     argdict = dict()
     argdict["gateware_identifier_str"] = args.gateware_identifier_str
+    argdict["hw_rev"] = args.hw_rev
 
     soc = Satellite(**argdict)
     build_artiq_soc(soc, builder_argdict(args))


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Added support for EEM FMC Carrier v1.1 with v1.0 backward compatibility.

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.

### Documentation Changes

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
