### PR TITLE
Add Shuttler Support for Kasli Satellite

### DIFF
--- a/artiq/firmware/satman/main.rs
+++ b/artiq/firmware/satman/main.rs
@@ -698,7 +698,7 @@ pub extern fn main() -> i32 {
         io_expander.service().unwrap();
     }
 
-    #[cfg(not(has_drtio_eem))]
+    #[cfg(not(soc_platform = "efc"))]
     unsafe {
         csr::gt_drtio::txenable_write(0xffffffffu32 as _);
     }


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
This PR adds support for Shuttler on Kasli Satellite. An unique satellite repeater is created for each Shuttler. The Repeater ID for Shuttler starts from REP#3.

Functional test is done. After configuring the routing table correctly on Kasli master, Shuttler's hardware can be accessed through a Kasli Master and Kasli Satellite.

Test Connection 
- Kasli Master ->  Kasli Satellite -> Kasl Satellite @REP#3  -> Shuttler

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
