### PR TITLE
Make EFC firmware build from JSON, instead of CLI arguments

### DIFF
--- a/artiq/coredevice/coredevice_generic.schema.json
+++ b/artiq/coredevice/coredevice_generic.schema.json
@@ -137,6 +137,18 @@
                     "enum": ["v1.0", "v1.1"]
                 }
             }
+        },
+        {
+            "properties": {
+                "target": {
+                    "type": "string",
+                    "const": "efc"
+                },
+                "hw_rev": {
+                    "type": "string",
+                    "enum": ["v1.0", "v1.1"]
+                }
+            }
         }
     ],
 

--- a/artiq/gateware/targets/efc.py
+++ b/artiq/gateware/targets/efc.py
@@ -19,6 +19,7 @@ from artiq.gateware.drtio.rx_synchronizer import NoRXSynchronizer
 from artiq.gateware.drtio import *
 from artiq.gateware.shuttler import Shuttler
 from artiq.build_soc import *
+from artiq.coredevice import jsondesc
 
 
 class Satellite(BaseSoC, AMPSoC):
@@ -243,16 +244,17 @@ def main():
         description="ARTIQ device binary builder for EEM FMC Carrier systems")
     builder_args(parser)
     parser.set_defaults(output_dir="artiq_efc")
-    parser.add_argument("-V", "--variant", default="shuttler")
-    parser.add_argument("--hw-rev", choices=["v1.0", "v1.1"], default="v1.1", 
-                        help="Hardware revision")
+    parser.add_argument("description", metavar="DESCRIPTION",
+                        help="JSON system description file")
     parser.add_argument("--gateware-identifier-str", default=None,
                         help="Override ROM identifier")
     args = parser.parse_args()
+    description = jsondesc.load(args.description)
 
     argdict = dict()
     argdict["gateware_identifier_str"] = args.gateware_identifier_str
-    argdict["hw_rev"] = args.hw_rev
+    argdict["hw_rev"] = description["hw_rev"]
+    args.variant = description["variant"]
 
     soc = Satellite(**argdict)
     build_artiq_soc(soc, builder_argdict(args))


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Make EFC firmware build from JSON, instead of CLI arguments.

### Related Issue

Closes #2405 

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps

Tested by building with `python -m artiq.gateware.targets.efc efct.json`. The `efct.json` file:
```json
{
    "target": "efc",
    "min_artiq_version": "7.0",
    "variant": "shuttler_test",
    "hw_rev": "v1.1",
    "peripherals": []
}
```

### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [ ] Close/update issues.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).


### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
