### PR TITLE
Schema EFC HW_REV support

### DIFF
--- a/artiq/coredevice/coredevice_generic.schema.json
+++ b/artiq/coredevice/coredevice_generic.schema.json
@@ -634,6 +634,10 @@
                         },
                         "drtio_destination": {
                             "type": "integer"
+                        },
+                        "hw_rev": {
+                            "type": "string",
+                            "enum": ["v1.0", "v1.1"]
                         }
                     },
                     "required": ["ports"]

--- a/artiq/examples/kasli_shuttler/kasli_shuttler.json
+++ b/artiq/examples/kasli_shuttler/kasli_shuttler.json
@@ -6,6 +6,7 @@
     "peripherals": [
         {
             "type": "shuttler",
+            "hw_rev": "v1.1",
             "ports": [0]
         },
         {


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

This PR adds ``hw_rev`` field to Shuttler (indicating EFC board hardware version). This is to allow customers to build EFC firmware alongside Kasli.

ARTIQ side of things is quite simple, it includes only the change in the json schema to allow the field, and the example is updated.

AFWS  (client/server) changes are coming as well to support actually building the firmware

### Related Issue

Closes #2405

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
