### PR TITLE
fix nix build for efc shuttler & kc705

### DIFF
--- a/artiq/firmware/libboard_misoc/io_expander.rs
+++ b/artiq/firmware/libboard_misoc/io_expander.rs
@@ -10,25 +10,6 @@ struct Registers {
     gpiob: u8,  // Output Port 1
 }
 
-#[cfg(has_si549)]
-const IODIR_CLK_SEL: u8 = 0x80; // out
-#[cfg(has_si5324)]
-const IODIR_CLK_SEL: u8 = 0x00; // in
-
-#[cfg(has_si549)]
-const CLK_SEL_OUT: u8 = 1 << 7;
-#[cfg(has_si5324)]
-const CLK_SEL_OUT: u8 = 0;
-
-const IODIR0 : [u8; 2] = [
-    0xFF,
-    0xFF & !IODIR_CLK_SEL
-];
-
-const OUT_TAR0 : [u8; 2] = [
-    0,
-    CLK_SEL_OUT
-];
 pub struct IoExpander {
     busno: u8,
     port: u8,
@@ -45,6 +26,26 @@ impl IoExpander {
     pub fn new(index: u8) -> Result<Self, &'static str> {
         const VIRTUAL_LED_MAPPING0: [(u8, u8, u8); 2] = [(0, 0, 6), (1, 1, 6)];
         const VIRTUAL_LED_MAPPING1: [(u8, u8, u8); 2] = [(2, 0, 6), (3, 1, 6)];
+
+        #[cfg(has_si549)]
+        const IODIR_CLK_SEL: u8 = 0x80; // out
+        #[cfg(has_si5324)]
+        const IODIR_CLK_SEL: u8 = 0x00; // in
+        
+        #[cfg(has_si549)]
+        const CLK_SEL_OUT: u8 = 1 << 7;
+        #[cfg(has_si5324)]
+        const CLK_SEL_OUT: u8 = 0;
+        
+        const IODIR0 : [u8; 2] = [
+            0xFF,
+            0xFF & !IODIR_CLK_SEL
+        ];
+        
+        const OUT_TAR0 : [u8; 2] = [
+            0,
+            CLK_SEL_OUT
+        ];        
 
         // Both expanders on SHARED I2C bus
         let mut io_expander = match index {

--- a/flake.nix
+++ b/flake.nix
@@ -239,7 +239,7 @@
           cargoDeps = rustPlatform.importCargoLock {
             lockFile = ./artiq/firmware/Cargo.lock;
             outputHashes = {
-              "fringe-1.2.1" = "sha256-m4rzttWXRlwx53LWYpaKuU5AZe4GSkbjHS6oINt5d3Y=";
+              "fringe-1.2.1" = "sha256-u7NyZBzGrMii79V+Xs4Dx9tCpiby6p8IumkUl7oGBm0=";
               "tar-no-std-0.1.8" = "sha256-xm17108v4smXOqxdLvHl9CxTCJslmeogjm4Y87IXFuM=";
             };
           };


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

- nix build error after merging #2418 
 - update libfringe hash in `flake.nix`
 - inline the IO constants to `IoExpander::new()` to fix efc shuttler compilation error after the hash update

- ran `nix build` with `artiq-board-efc-shuttler` & `artiq-board-kc705-nist_clock`, both ran without any errors

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)


### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
