### PR TITLE
adf5356: sync before setting muxout

### DIFF
--- a/artiq/coredevice/adf5356.py
+++ b/artiq/coredevice/adf5356.py
@@ -84,10 +84,11 @@ class ADF5356:
 
         :param blind: Do not attempt to verify presence.
         """
+        self.sync()
         if not blind:
             # MUXOUT = VDD
             self.regs[4] = ADF5356_REG4_MUXOUT_UPDATE(self.regs[4], 1)
-            self.sync()
+            self.write(self.regs[4])
             delay(1000 * us)
             if not self.read_muxout():
                 raise ValueError("MUXOUT not high")
@@ -95,7 +96,7 @@ class ADF5356:
 
             # MUXOUT = DGND
             self.regs[4] = ADF5356_REG4_MUXOUT_UPDATE(self.regs[4], 2)
-            self.sync()
+            self.write(self.regs[4])
             delay(1000 * us)
             if self.read_muxout():
                 raise ValueError("MUXOUT not low")
@@ -103,8 +104,7 @@ class ADF5356:
 
             # MUXOUT = digital lock-detect
             self.regs[4] = ADF5356_REG4_MUXOUT_UPDATE(self.regs[4], 6)
-        else:
-            self.sync()
+            self.write(self.regs[4])
 
     @kernel
     def set_att(self, att):


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

As mentioned in #2306 Mirny has a tendency to throw a ``MUXOUT not high/low`` errors during initialization. I changed the initialization sequence to one I described in the issue with ``sync()`` first to establish 3.3V logic level before changing the MUXOUT settings, and only that register.

I tested it with a Mirny 1.1 and 1.1.4, with 125MHz Kasli clock through MMCX. For full coverage this should be also tested with a slower reference clock, like described in the issue - possibly delay times should also be tuned then.

Regardless, each time after a restart (cutting off power) I could consistently get a ``MUXOUT not high`` error with one of the Mirnies without the change, and wouldn't get the error after the change. Hard to say when it's intermittent, so maybe we can wait with merging until low frequency external reference clock tests are done.

If it does work out, I believe it should also be backported to ARTIQ-7.

### Related Issue

Closes #2306 

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [ ] Test your changes or have someone test them. Mention what was tested and how.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
