### PR TITLE
[WIP] sinara_tester: Almazny v1.2+ support, simplify legacy almazny tests

### DIFF
--- a/artiq/coredevice/almazny.py
+++ b/artiq/coredevice/almazny.py
@@ -1,4 +1,5 @@
 from artiq.language.core import kernel, portable
+from artiq.language.units import us
 
 from numpy import int32
 
@@ -116,11 +117,6 @@ class AlmaznyLegacy:
             ALMAZNY_LEGACY_SPIT_WR
         )
         delay(100 * us)
-
-    @kernel
-    def _update_all_registers(self):
-        for i in range(4):
-            self._update_register(i)
 
 
 class AlmaznyChannel:


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

This PR is about Almaznys: it adds support for testing Almazny v1.2, fixes and simplifies the test for legacy Almazny.

Legacy Almazny driver was missing units, after it was moved to a different file with the new Almazny driver.
For both instead of toggling manually between different attenuation states, a loop cycles between attenuators, vastly simplifying the procedure.

The new Almazny v1.2 tests should work but it wasn't tested as Almazny v1.2 is not working at the moment (#2414).  That's why I'm marking it as WIP. On the other hand, legacy tests are working.

### Related Issue

Closes #2085 

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [ ] Test your changes or have someone test them. Mention what was tested and how.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
