### PR TITLE
kasli: fix v1.0 & v1.1 compilation error

### DIFF
--- a/artiq/gateware/targets/kasli.py
+++ b/artiq/gateware/targets/kasli.py
@@ -120,7 +120,8 @@ class StandaloneBase(MiniSoC, AMPSoC):
             self.config["HAS_SI549"] = None
             self.config["WRPLL_REF_CLK"] = "SMA_CLKIN"
         else:
-            self.submodules += SMAClkinForward(self.platform)
+            if self.platform.hw_rev == "v2.0":
+                self.submodules += SMAClkinForward(self.platform)
             self.config["HAS_SI5324"] = None
             self.config["SI5324_SOFT_RESET"] = None
 


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
- Fix compilation error for kasli v1.0 and v1.1. Will backport to release-8 after this PR got merge. 

### Related Issue
https://forum.m-labs.hk/d/746-changes-in-json-file-with-artiq-8-for-kasli-v11

### Testing
- successfully built v1.0 and v1.1 standalone with this patch

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.

### Documentation Changes


### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
