### PR TITLE
kasli: raise error when enabling WRPLL with v1.x

### DIFF
--- a/artiq/gateware/targets/kasli.py
+++ b/artiq/gateware/targets/kasli.py
@@ -842,6 +842,8 @@ def main():
     has_shuttler = any(peripheral["type"] == "shuttler" for peripheral in description["peripherals"])
     if has_shuttler and (description["drtio_role"] == "standalone"):
         raise ValueError("Shuttler requires DRTIO, please switch role to master")
+    if description["enable_wrpll"] and description["hw_rev"] in ["v1.0", "v1.1"]:
+        raise ValueError("Kasli {} does not support WRPLL".format(description["hw_rev"])) 
 
     soc = cls(description, gateware_identifier_str=args.gateware_identifier_str, **soc_kasli_argdict(args))
     args.variant = description["variant"]


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
- raise a proper error message when enabling WRPLL with v1.x Kasli. Will backport after this PR got merged

### Old error message
```bash
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/user/scratch/artiq/artiq/gateware/targets/kasli.py", line 852, in <module>
    main()
  File "/home/user/scratch/artiq/artiq/gateware/targets/kasli.py", line 846, in main
    soc = cls(description, gateware_identifier_str=args.gateware_identifier_str, **soc_kasli_argdict(args))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/scratch/artiq/artiq/gateware/targets/kasli.py", line 663, in __init__
    StandaloneBase.__init__(self,
  File "/home/user/scratch/artiq/artiq/gateware/targets/kasli.py", line 108, in __init__
    clk_synth = self.platform.request("cdr_clk_clean_fabric")
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/vrpyf33l6n8p8kaq033b788ykznlclhn-python3-3.11.9-env/lib/python3.11/site-packages/migen/build/generic_platform.py", line 246, in request
    return self.constraint_manager.request(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/vrpyf33l6n8p8kaq033b788ykznlclhn-python3-3.11.9-env/lib/python3.11/site-packages/migen/build/generic_platform.py", line 165, in request
    resource = _lookup(self.available, name, number)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/vrpyf33l6n8p8kaq033b788ykznlclhn-python3-3.11.9-env/lib/python3.11/site-packages/migen/build/generic_platform.py", line 74, in _lookup
    raise ConstraintError("Resource not found: {}:{}".format(name, number))
migen.build.generic_platform.ConstraintError: Resource not found: cdr_clk_clean_fabric:None

```

### New error message

```bash
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/morgan/dev/artiq-master/artiq/gateware/targets/kasli.py", line 854, in <module>
    main()
  File "/home/morgan/dev/artiq-master/artiq/gateware/targets/kasli.py", line 846, in main
    raise ValueError("Kasli {} does not support WRPLL".format(description["hw_rev"]))
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: Kasli v1.0 does not support WRPLL

```

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
