### PR TITLE
Fix missing jquery in docs - fixes broken search

### DIFF
--- a/doc/manual/conf.py
+++ b/doc/manual/conf.py
@@ -79,6 +79,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinxarg.ext',
     'sphinxcontrib.wavedrom',  # see also below for config
+    "sphinxcontrib.jquery",
 ]
 
 mathjax_path = "https://m-labs.hk/MathJax/MathJax.js?config=TeX-AMS-MML_HTMLorMML.js"


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Adds jquery extension do sphinx docs, which fixes broken search on release-8 and beta.
 Legacy release-7 doesn't have such issue.

### Related Issue

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :scroll: Docs |



