### PR TITLE
moninj: delete dock on close and reparent child widgets

### DIFF
--- a/artiq/dashboard/moninj.py
+++ b/artiq/dashboard/moninj.py
@@ -871,9 +871,9 @@ class _MonInjDock(QDockWidgetCloseDetect):
 
     def layout_widgets(self, widgets):
         for widget in sorted(widgets, key=lambda w: w.sort_key()):
-            widget.show()
             self.manager.dm.setup_monitoring(True, widget)
             self.flow.addWidget(widget)
+            widget.show()
 
     def restore_widgets(self):
         if self.widget_uids is not None:

--- a/artiq/dashboard/moninj.py
+++ b/artiq/dashboard/moninj.py
@@ -861,9 +861,10 @@ class _MonInjDock(QDockWidgetCloseDetect):
 
     def delete_widget(self, index, checked):
         widget = self.flow.itemAt(index).widget()
-        widget.hide()
         self.manager.dm.setup_monitoring(False, widget)
         self.flow.layout.takeAt(index)
+        widget.setParent(self.manager.main_window)
+        widget.hide()
 
     def add_channels(self):
         channels = self.channel_dialog.channels
@@ -948,7 +949,7 @@ class MonInj:
         del self.docks[name]
         self.update_closable()
         dock.delete_all_widgets()
-        dock.hide()  # dock may be parent, only delete on exit
+        dock.deleteLater()
 
     def update_closable(self):
         flags = (QtWidgets.QDockWidget.DockWidgetMovable |


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Currently:
MonInj docks are hidden instead of deleted since they may hold ownership over MonInj widgets. This causes bugs if the dock is resurrected by the user through the dock widget action menu.

Change:
When a MonInj widget is deleted, its parent will be set to the main window instead of its dock widget. This allows the dock to be deleted instead of hidden when closed. This is also more consistent with the behavior of the Log docks.

This patch should be applicable as is on `artiq-8`.

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
Tested closing a dock and deleting individual widgets without encountering errors.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
