### PR TITLE
math_fns: Delete duplicated definition

### DIFF
--- a/artiq/compiler/math_fns.py
+++ b/artiq/compiler/math_fns.py
@@ -61,22 +61,6 @@ unary_fp_runtime_calls = [
     ("cbrt", "cbrt"),
 ]
 
-#: float -> float numpy.* math functions lowered to runtime calls.
-unary_fp_runtime_calls = [
-    ("tan", "tan"),
-    ("arcsin", "asin"),
-    ("arccos", "acos"),
-    ("arctan", "atan"),
-    ("sinh", "sinh"),
-    ("cosh", "cosh"),
-    ("tanh", "tanh"),
-    ("arcsinh", "asinh"),
-    ("arccosh", "acosh"),
-    ("arctanh", "atanh"),
-    ("expm1", "expm1"),
-    ("cbrt", "cbrt"),
-]
-
 scipy_special_unary_runtime_calls = [
     ("erf", "erf"),
     ("erfc", "erfc"),


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Exact same definition listed twice in math_fns, deleted the second   

### All Pull Requests

- [x] Use correct spelling and grammar.

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
