### PR TITLE
doc (meta): Fix sphinx 'duplicated reference' warnings

### DIFF
--- a/doc/manual/list_of_ndsps.rst
+++ b/doc/manual/list_of_ndsps.rst
@@ -26,7 +26,7 @@ The following network device support packages are available for ARTIQ. If you wo
 +---------------------------------+-----------------------------------+----------------------------------+-------------------------------------------------------------------+--------------------------------------------------------+
 | HighFinesse wavemeters          | ``highfinesse-net``               | Not available                    | Not available                                                     | https://github.com/quartiq/highfinesse-net             |
 +---------------------------------+-----------------------------------+----------------------------------+-------------------------------------------------------------------+--------------------------------------------------------+
-| InfluxDB database               | Not available                     | Not available                    | `HTML <https://gitlab.com/charlesbaynham/artiq_influx_generic>`_  | https://gitlab.com/charlesbaynham/artiq_influx_generic |
+| InfluxDB database               | Not available                     | Not available                    | `HTML <https://gitlab.com/charlesbaynham/artiq_influx_generic>`__ | https://gitlab.com/charlesbaynham/artiq_influx_generic |
 +---------------------------------+-----------------------------------+----------------------------------+-------------------------------------------------------------------+--------------------------------------------------------+
 
 MSYS2 packages all start with the ``mingw-w64-clang-x86_64-`` prefix.

--- a/doc/manual/release_notes.rst
+++ b/doc/manual/release_notes.rst
@@ -5,6 +5,6 @@ ARTIQ follows a rolling release model, with beta, stable, and legacy channels. D
 
 To install the current stable version of ARTIQ, consult the *current* `Installing ARTIQ <https://m-labs.hk/artiq/manual/installing.html>`_ page. To install beta or legacy versions, consult the same page in their respective manuals. Instructions given in pre-legacy versions of the manual may or may not install their corresponding ARTIQ systems, and may or may not currently be supported (e.g. M-Labs does not host older ARTIQ versions for Conda, and Conda support will probably eventually be removed entirely). Regardless, all out-of-date versions remain available as complete source code on the repository.
 
-The beta manual is hosted `here <https://m-labs.hk/artiq/manual-beta/>`_. The current manual is hosted `here <https://m-labs.hk/artiq/manual/>`_. The legacy manual is hosted `here <https://m-labs.hk/artiq/manual-legacy/>`_. Older versions of the manual can be rebuilt from the source files in ``doc/manual``, retrieved from the respective branch.
+The beta manual is hosted `here <https://m-labs.hk/artiq/manual-beta/>`_. The current manual is hosted `here <https://m-labs.hk/artiq/manual/>`__. The legacy manual is hosted `here <https://m-labs.hk/artiq/manual-legacy/>`___. Older versions of the manual can be rebuilt from the source files in ``doc/manual``, retrieved from the respective branch.
 
 .. include:: ../../RELEASE_NOTES.rst


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Avoids Sphinx warnings 'Duplicate external target name' for links that have the same text. (The warnings normally only display if you actually regenerate the pages with the links in question, but they display _every_ time when you're regenerating the full manual...). 

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
