### PR TITLE
browser: fix ctrl scroll type error

### DIFF
--- a/artiq/browser/files.py
+++ b/artiq/browser/files.py
@@ -83,7 +83,7 @@ class ZoomIconView(QtWidgets.QListView):
             w = self.iconSize().width()*self.zoom_step**(
                 ev.angleDelta().y()/120.)
             if a <= w <= b:
-                self.setIconSize(QtCore.QSize(w, w*self.aspect))
+                self.setIconSize(QtCore.QSize(int(w), int(w*self.aspect)))
         else:
             QtWidgets.QListView.wheelEvent(self, ev)
 


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Error occurs when attempting to ctrl scroll in `artiq_browser` file explorer. Seems related to #1887.

```
TypeError: arguments did not match any overloaded call:
  QSize(): too many arguments
  QSize(w: int, h: int): argument 1 has unexpected type 'float'
  QSize(a0: QSize): argument 1 has unexpected type 'float'
```

Found by @architeuthidae.

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
Tested and bug no longer occurs when ctrl scrolling.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
