### PR TITLE
Update llvmlite to 0.43 and LLVM to 15, as in MSYS2

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -101,14 +101,14 @@
 
       llvmlite-new = pkgs.python3Packages.buildPythonPackage rec {
         pname = "llvmlite";
-        version = "0.40.1";
+        version = "0.43.0";
         src = pkgs.fetchFromGitHub {
             owner = "numba";
             repo = "llvmlite";
             rev = "v${version}";
-            sha256 = "sha256-gPEda9cMEsruvBt8I2VFfsTKZaPsNDgqx2Y9n0MSc4Y=";
+            sha256 = "sha256-5QBSRDb28Bui9IOhGofj+c7Rk7J5fNv5nPksEPY/O5o=";
           };
-        nativeBuildInputs = [ pkgs.llvm_14 ];
+        nativeBuildInputs = [ pkgs.llvm_15 ];
         # Disable static linking
         # https://github.com/numba/llvmlite/issues/93
         postPatch = ''
@@ -117,7 +117,7 @@
         '';
         # Set directory containing llvm-config binary
         preConfigure = ''
-          export LLVM_CONFIG=${pkgs.llvm_14.dev}/bin/llvm-config
+          export LLVM_CONFIG=${pkgs.llvm_15.dev}/bin/llvm-config
         '';
       };
 
@@ -134,7 +134,7 @@
 
         nativeBuildInputs = [ pkgs.qt5.wrapQtAppsHook ];
         # keep llvm_x and lld_x in sync with llvmlite
-        propagatedBuildInputs = [ pkgs.llvm_14 pkgs.lld_14 sipyco.packages.x86_64-linux.sipyco pythonparser llvmlite-new pkgs.qt5.qtsvg artiq-comtools.packages.x86_64-linux.artiq-comtools ]
+        propagatedBuildInputs = [ pkgs.llvm_15 pkgs.lld_15 sipyco.packages.x86_64-linux.sipyco pythonparser llvmlite-new pkgs.qt5.qtsvg artiq-comtools.packages.x86_64-linux.artiq-comtools ]
           ++ (with pkgs.python3Packages; [ pyqtgraph pygit2 numpy dateutil scipy prettytable pyserial levenshtein h5py pyqt5 qasync tqdm lmdb jsonschema ]);
 
         dontWrapQtApps = true;
@@ -157,10 +157,10 @@
           "--set FONTCONFIG_FILE ${pkgs.fontconfig.out}/etc/fonts/fonts.conf"
         ];
 
-        # FIXME: automatically propagate lld_14 llvm_14 dependencies
+        # FIXME: automatically propagate lld_15 llvm_15 dependencies
         # cacert is required in the check stage only, as certificates are to be
         # obtained from system elsewhere
-        nativeCheckInputs = with pkgs; [ lld_14 llvm_14 lit outputcheck cacert ] ++ [ libartiq-support ];
+        nativeCheckInputs = with pkgs; [ lld_15 llvm_15 lit outputcheck cacert ] ++ [ libartiq-support ];
         checkPhase = ''
           python -m unittest discover -v artiq.test
 
@@ -239,9 +239,9 @@
           nativeBuildInputs = [
             (pkgs.python3.withPackages(ps: [ migen misoc (artiq.withExperimentalFeatures experimentalFeatures) ps.packaging ]))
             rust
-            pkgs.llvmPackages_14.clang-unwrapped
-            pkgs.llvm_14
-            pkgs.lld_14
+            pkgs.llvmPackages_15.clang-unwrapped
+            pkgs.llvm_15
+            pkgs.lld_15
             vivado
             rustPlatform.cargoSetupHook
           ];
@@ -395,9 +395,9 @@
         buildInputs = [
           (pkgs.python3.withPackages(ps: with packages.x86_64-linux; [ migen misoc ps.paramiko microscope ps.packaging ] ++ artiq.propagatedBuildInputs ))
           rust
-          pkgs.llvmPackages_14.clang-unwrapped
-          pkgs.llvm_14
-          pkgs.lld_14
+          pkgs.llvmPackages_15.clang-unwrapped
+          pkgs.llvm_15
+          pkgs.lld_15
           pkgs.git
           artiq-frontend-dev-wrappers
           # To manually run compiler tests:
@@ -425,9 +425,9 @@
         buildInputs = [
           (pkgs.python3.withPackages(ps: with packages.x86_64-linux; [ migen misoc artiq ps.packaging ]))
           rust
-          pkgs.llvmPackages_14.clang-unwrapped
-          pkgs.llvm_14
-          pkgs.lld_14
+          pkgs.llvmPackages_15.clang-unwrapped
+          pkgs.llvm_15
+          pkgs.lld_15
           packages.x86_64-linux.vivado
           packages.x86_64-linux.openocd-bscanspi
         ];
@@ -460,8 +460,8 @@
 
           buildInputs = [
             (pkgs.python3.withPackages(ps: with packages.x86_64-linux; [ artiq ps.paramiko ]))
-            pkgs.llvm_14
-            pkgs.lld_14
+            pkgs.llvm_15
+            pkgs.lld_15
             pkgs.openssh
             packages.x86_64-linux.openocd-bscanspi  # for the bscanspi bitstreams
           ];


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

As llvmlite at MSYS2 repositories was updated and retargeted to LLVM 15, it is better to keep in sync across platforms.

### Related Issue

https://github.com/msys2/MINGW-packages/pull/21363

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :arrow_up:  Update  |

## Steps

Checked:
* `python -m unittest discover -v artiq.test`
* `artiq_compile` and `artiq_run` against Kasli and Kasli-SoC.
