### PR TITLE
moninj: urukul display square bracket notation

### DIFF
--- a/artiq/dashboard/moninj.py
+++ b/artiq/dashboard/moninj.py
@@ -202,7 +202,10 @@ class _DDSWidget(_MoninjWidget):
         self.dds_name = title
         self.cur_frequency = 0
         self.dds_model = _DDSModel(dds_type, ref_clk, cpld, pll, clk_div)
-        self.title = title
+        if self.dds_model.is_urukul:
+            self.title = "{}[{}]".format(cpld, self.channel)
+        else:
+            self.title = title
 
         _MoninjWidget.__init__(self, title)
 
@@ -321,7 +324,7 @@ class _DDSWidget(_MoninjWidget):
         return (1, self.bus_channel, self.channel)
 
     def uid(self):
-        return self.title
+        return self.dds_name
 
     def to_model_path(self):
         return "dds/{}".format(self.title)


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Change Urukul Moninj widgets to display with square brackets:

![Screenshot from 2024-07-15 15-16-43](https://github.com/user-attachments/assets/d20ad314-540e-4290-90dd-f48e18ec0315)
![Screenshot from 2024-07-15 15-16-22](https://github.com/user-attachments/assets/af27dc18-718a-48e8-b28f-b2a8d4aaf8c8)

## Steps

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
See screenshots.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
