### PR TITLE
moninj: revert zotino square bracket notation

### DIFF
--- a/artiq/dashboard/moninj.py
+++ b/artiq/dashboard/moninj.py
@@ -29,7 +29,7 @@ class _CancellableLineEdit(QtWidgets.QLineEdit):
 
 
 class _MoninjWidget(QtWidgets.QFrame):
-    def __init__(self, title, channel=None):
+    def __init__(self, title):
         QtWidgets.QFrame.__init__(self)
         self.setFrameShape(QtWidgets.QFrame.Box)
         self.setFrameShape(QtWidgets.QFrame.Box)
@@ -41,8 +41,7 @@ class _MoninjWidget(QtWidgets.QFrame):
         self.grid.setHorizontalSpacing(0)
         self.grid.setVerticalSpacing(0)
         self.setLayout(self.grid)
-        title = elide(title, 17)
-        title += "" if channel is None else "[{}]".format(channel) 
+        title = elide(title, 20)
         label = QtWidgets.QLabel(title)
         label.setAlignment(QtCore.Qt.AlignHCenter | QtCore.Qt.AlignTop)
         self.grid.addWidget(label, 1, 1)
@@ -329,7 +328,7 @@ class _DDSWidget(_MoninjWidget):
 
 class _DACWidget(_MoninjWidget):
     def __init__(self, dm, spi_channel, channel, title, vref, offset_dacs):
-        _MoninjWidget.__init__(self, title, channel)
+        _MoninjWidget.__init__(self, "{}_ch{}".format(title, channel))
         self.spi_channel = spi_channel
         self.channel = channel
         self.cur_value = 0x8000
@@ -360,7 +359,7 @@ class _DACWidget(_MoninjWidget):
         return (self.title, self.channel)
 
     def to_model_path(self):
-        return "dac/{}[{}]".format(self.title, self.channel)
+        return "dac/{}_ch{}".format(self.title, self.channel)
 
 
 _WidgetDesc = namedtuple("_WidgetDesc", "uid comment cls arguments")


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

See #2490 and #2476. 

Reverts the square bracket notation for the previous "_ch*" notation for `_DACWidget`.

## Steps

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
Quick smoke test.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
