### PR TITLE
dashboard: fix pyqt6 gui bugs

### DIFF
--- a/artiq/dashboard/moninj.py
+++ b/artiq/dashboard/moninj.py
@@ -338,7 +338,7 @@ class _DACWidget(_MoninjWidget):
         self.offset_dacs = offset_dacs
 
         self.value = QtWidgets.QLabel()
-        self.value.setAlignment(QtCore.Qt.AlignHCenter | QtCore.Qt.AlignTop)
+        self.value.setAlignment(QtCore.Qt.AlignmentFlag.AlignHCenter | QtCore.Qt.AlignmentFlag.AlignTop)
         self.grid.addWidget(self.value, 2, 1, 6, 1)
 
         self.grid.setRowStretch(1, 1)

--- a/artiq/dashboard/waveform.py
+++ b/artiq/dashboard/waveform.py
@@ -208,16 +208,19 @@ class _BaseWaveform(pg.PlotWidget):
             pixmapi = QtWidgets.QApplication.style().standardIcon(
                 QtWidgets.QStyle.StandardPixmap.SP_FileIcon)
             drag.setPixmap(pixmapi.pixmap(32))
-            drag.exec_(QtCore.Qt.MoveAction)
+            drag.exec(QtCore.Qt.DropAction.MoveAction)
         else:
             super().mouseMoveEvent(e)
 
     def wheelEvent(self, e):
-        if e.modifiers() & QtCore.Qt.ControlModifier:
+        if e.modifiers() & QtCore.Qt.KeyboardModifier.ControlModifier:
             super().wheelEvent(e)
+        else:
+            e.ignore()
+
 
     def mouseDoubleClickEvent(self, e):
-        pos = self.view_box.mapSceneToView(e.pos())
+        pos = self.view_box.mapSceneToView(e.position())
         self.cursorMove.emit(pos.x())
 
 
@@ -393,6 +396,13 @@ class LogWaveform(_BaseWaveform):
             self.plot_data_item.setData(x=[], y=[])
 
 
+# pg.GraphicsView ignores dragEnterEvent but not dragLeaveEvent
+# https://github.com/pyqtgraph/pyqtgraph/blob/1e98704eac6b85de9c35371079f561042e88ad68/pyqtgraph/widgets/GraphicsView.py#L388
+class _RefAxis(pg.PlotWidget):
+    def dragLeaveEvent(self, ev):
+        ev.ignore()
+
+
 class _WaveformView(QtWidgets.QWidget):
     cursorMove = QtCore.pyqtSignal(float)
 
@@ -408,7 +418,7 @@ class _WaveformView(QtWidgets.QWidget):
         layout.setSpacing(0)
         self.setLayout(layout)
 
-        self._ref_axis = pg.PlotWidget()
+        self._ref_axis = _RefAxis()
         self._ref_axis.hideAxis("bottom")
         self._ref_axis.hideAxis("left")
         self._ref_axis.hideButtons()

--- a/artiq/frontend/artiq_dashboard.py
+++ b/artiq/frontend/artiq_dashboard.py
@@ -256,7 +256,7 @@ def main():
     right_docks = [
         d_explorer, d_shortcuts,
         d_datasets, d_applets,
-        # d_waveform, d_interactive_args
+        d_waveform, d_interactive_args
     ]
     main_window.addDockWidget(QtCore.Qt.DockWidgetArea.RightDockWidgetArea, right_docks[0])
     for d1, d2 in zip(right_docks, right_docks[1:]):

--- a/artiq/gui/dndwidgets.py
+++ b/artiq/gui/dndwidgets.py
@@ -24,7 +24,7 @@ class VDragDropSplitter(QtWidgets.QSplitter):
         e.accept()
 
     def dragMoveEvent(self, e):
-        pos = e.pos()
+        pos = e.position()
         src = e.source()
         src_i = self.indexOf(src)
         self.setRubberBand(self.height())
@@ -48,7 +48,7 @@ class VDragDropSplitter(QtWidgets.QSplitter):
 
     def dropEvent(self, e):
         self.setRubberBand(-1)
-        pos = e.pos()
+        pos = e.position()
         src = e.source()
         src_i = self.indexOf(src)
         for n in range(self.count()):
@@ -81,7 +81,7 @@ class VDragScrollArea(QtWidgets.QScrollArea):
         if e.type() == QtCore.QEvent.Type.DragMove:
             val = self.verticalScrollBar().value()
             height = self.viewport().height()
-            y = e.pos().y()
+            y = e.position().y()
             self._direction = 0
             if y < val + self._margin:
                 self._direction = -1
@@ -119,7 +119,7 @@ class DragDropFlowLayoutWidget(QtWidgets.QWidget):
     def mousePressEvent(self, event):
         if event.buttons() == QtCore.Qt.MouseButton.LeftButton \
            and event.modifiers() == QtCore.Qt.KeyboardModifier.ShiftModifier:
-            index = self._get_index(event.pos())
+            index = self._get_index(event.position())
             if index == -1:
                 return
             drag = QtGui.QDrag(self)
@@ -136,7 +136,7 @@ class DragDropFlowLayoutWidget(QtWidgets.QWidget):
         event.accept()
 
     def dropEvent(self, event):
-        index = self._get_index(event.pos())
+        index = self._get_index(event.position())
         source_layout = event.source()
         source_index = int(bytes(event.mimeData().data("index")).decode())
         if source_layout == self:

--- a/artiq/gui/entries.py
+++ b/artiq/gui/entries.py
@@ -23,13 +23,13 @@ class EntryTreeWidget(QtWidgets.QTreeWidget):
             set_resize_mode = self.header().setSectionResizeMode
         else:
             set_resize_mode = self.header().setResizeMode
-        set_resize_mode(0, QtWidgets.QHeaderView.ResizeToContents)
-        set_resize_mode(1, QtWidgets.QHeaderView.Stretch)
-        set_resize_mode(2, QtWidgets.QHeaderView.ResizeToContents)
+        set_resize_mode(0, QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
+        set_resize_mode(1, QtWidgets.QHeaderView.ResizeMode.Stretch)
+        set_resize_mode(2, QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
         self.header().setVisible(False)
-        self.setSelectionMode(self.NoSelection)
-        self.setHorizontalScrollMode(self.ScrollPerPixel)
-        self.setVerticalScrollMode(self.ScrollPerPixel)
+        self.setSelectionMode(self.SelectionMode.NoSelection)
+        self.setHorizontalScrollMode(self.ScrollMode.ScrollPerPixel)
+        self.setVerticalScrollMode(self.ScrollMode.ScrollPerPixel)
 
         self.setStyleSheet("QTreeWidget {background: " +
                            self.palette().midlight().color().name() + " ;}")
@@ -109,7 +109,6 @@ class EntryTreeWidget(QtWidgets.QTreeWidget):
         group = QtWidgets.QTreeWidgetItem([key])
         for col in range(3):
             group.setBackground(col, self.palette().mid())
-            group.setForeground(col, self.palette().brightText())
             font = group.font(col)
             font.setBold(True)
             group.setFont(col, font)


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Fixes a variety of GUI bugs introduced by #2504. Re-adds interactive args and waveform docks that were omitted in that PR.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

- [x] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`cd doc/manual/; make html`) to ensure no errors.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
