### PR TITLE
Sync exceptions release 7

### DIFF
--- a/artiq/compiler/embedding.py
+++ b/artiq/compiler/embedding.py
@@ -57,9 +57,9 @@ class EmbeddingMap:
         self.str_forward_map = {}
         self.str_reverse_map = {}
 
-        # Keep this list of exceptions in sync with `EXCEPTION_ID_LOOKUP` in `artiq.firmware.ksupport.eh_artiq``
-        # The exceptions declared here should be defined in `artiq.coredeive.exceptions``
-        # Without sync, test cases in artiq.test.coredevice.test_exceptions would fail
+        # Keep this list of exceptions in sync with `EXCEPTION_ID_LOOKUP` in `artiq::firmware::ksupport::eh_artiq`
+        # The exceptions declared here must be defined in `artiq.coredevice.exceptions`
+        # Verify synchronization by running the test cases in `artiq.test.coredevice.test_exceptions`
         self.preallocate_runtime_exception_names([
             "RTIOUnderflow",
             "RTIOOverflow",

--- a/artiq/compiler/embedding.py
+++ b/artiq/compiler/embedding.py
@@ -57,16 +57,31 @@ class EmbeddingMap:
         self.str_forward_map = {}
         self.str_reverse_map = {}
 
-        self.preallocate_runtime_exception_names(["RuntimeError",
-                                                  "RTIOUnderflow",
-                                                  "RTIOOverflow",
-                                                  "RTIODestinationUnreachable",
-                                                  "DMAError",
-                                                  "I2CError",
-                                                  "CacheError",
-                                                  "SPIError",
-                                                  "0:ZeroDivisionError",
-                                                  "0:IndexError"])
+        # Keep this list of exceptions in sync with `EXCEPTION_ID_LOOKUP` in `artiq.firmware.ksupport.eh_artiq``
+        # The exceptions declared here should be defined in `artiq.coredeive.exceptions``
+        # Without sync, test cases in artiq.test.coredevice.test_exceptions would fail
+        self.preallocate_runtime_exception_names([
+            "RTIOUnderflow",
+            "RTIOOverflow",
+            "RTIODestinationUnreachable",
+            "DMAError",
+            "I2CError",
+            "CacheError",
+            "SPIError",
+
+            "0:AssertionError",
+            "0:AttributeError",
+            "0:IndexError",
+            "0:IOError",
+            "0:KeyError",
+            "0:NotImplementedError",
+            "0:OverflowError",
+            "0:RuntimeError",
+            "0:TimeoutError",
+            "0:TypeError",
+            "0:ValueError",
+            "0:ZeroDivisionError"
+        ])
 
     def preallocate_runtime_exception_names(self, names):
         for i, name in enumerate(names):

--- a/artiq/coredevice/comm_kernel.py
+++ b/artiq/coredevice/comm_kernel.py
@@ -3,6 +3,7 @@ import logging
 import traceback
 import numpy
 import socket
+import builtins
 from enum import Enum
 from fractions import Fraction
 from collections import namedtuple
@@ -600,9 +601,10 @@ class CommKernel:
                 self._write_int32(embedding_map.store_str(function))
             else:
                 exn_type = type(exn)
-                if exn_type in (ZeroDivisionError, ValueError, IndexError, RuntimeError) or \
-                        hasattr(exn, "artiq_builtin"):
-                    name = "0:{}".format(exn_type.__name__)
+                if exn_type in builtins.__dict__.values():
+                    name = "0:{}".format(exn_type.__qualname__)
+                elif hasattr(exn, "artiq_builtin"):
+                    name = "0:{}.{}".format(exn_type.__module__, exn_type.__qualname__)
                 else:
                     exn_id = embedding_map.store_object(exn_type)
                     name = "{}:{}.{}".format(exn_id,

--- a/artiq/coredevice/core.py
+++ b/artiq/coredevice/core.py
@@ -52,6 +52,9 @@ def rtio_get_destination_status(linkno: TInt32) -> TBool:
 def rtio_get_counter() -> TInt64:
     raise NotImplementedError("syscall not simulated")
 
+@syscall
+def raise_exception(id: TInt32) -> TNone:
+    raise NotImplementedError("syscall not simulated")
 
 class Core:
     """Core device driver.

--- a/artiq/coredevice/core.py
+++ b/artiq/coredevice/core.py
@@ -53,7 +53,7 @@ def rtio_get_counter() -> TInt64:
     raise NotImplementedError("syscall not simulated")
 
 @syscall
-def raise_exception(id: TInt32) -> TNone:
+def test_exception_id_sync(id: TInt32) -> TNone:
     raise NotImplementedError("syscall not simulated")
 
 class Core:

--- a/artiq/coredevice/exceptions.py
+++ b/artiq/coredevice/exceptions.py
@@ -7,10 +7,10 @@ from artiq import __artiq_dir__ as artiq_dir
 from artiq.coredevice.runtime import source_loader
 
 """
-This file should provide class definition for all the exceptions declared in `EmbeddingMap` in artiq.compiler.embedding
+This file provides class definition for all the exceptions declared in `EmbeddingMap` in `artiq.compiler.embedding`
 
-For python builtin exceptions, use the `builtins` module
-For artiq specific exceptions, inherit from `Exception` class
+For Python builtin exceptions, use the `builtins` module
+For ARTIQ specific exceptions, inherit from `Exception` class
 """
 
 AssertionError = builtins.AssertionError

--- a/artiq/coredevice/exceptions.py
+++ b/artiq/coredevice/exceptions.py
@@ -6,12 +6,26 @@ import os
 from artiq import __artiq_dir__ as artiq_dir
 from artiq.coredevice.runtime import source_loader
 
+"""
+This file should provide class definition for all the exceptions declared in `EmbeddingMap` in artiq.compiler.embedding
 
-ZeroDivisionError = builtins.ZeroDivisionError
-ValueError = builtins.ValueError
-IndexError = builtins.IndexError
-RuntimeError = builtins.RuntimeError
+For python builtin exceptions, use the `builtins` module
+For artiq specific exceptions, inherit from `Exception` class
+"""
+
 AssertionError = builtins.AssertionError
+AttributeError = builtins.AttributeError
+IndexError = builtins.IndexError
+IOError = builtins.IOError
+KeyError = builtins.KeyError
+NotImplementedError = builtins.NotImplementedError
+OverflowError = builtins.OverflowError
+RuntimeError = builtins.RuntimeError
+TimeoutError = builtins.TimeoutError
+TypeError = builtins.TypeError
+ValueError = builtins.ValueError
+ZeroDivisionError = builtins.ZeroDivisionError
+OSError = builtins.OSError
 
 
 class CoreException:
@@ -150,13 +164,13 @@ class DMAError(Exception):
 
 class ClockFailure(Exception):
     """Raised when RTIO PLL has lost lock."""
-
+    artiq_builtin = True
 
 class I2CError(Exception):
     """Raised when a I2C transaction fails."""
-    pass
+    artiq_builtin = True
 
 
 class SPIError(Exception):
     """Raised when a SPI transaction fails."""
-    pass
+    artiq_builtin = True

--- a/artiq/firmware/ksupport/api.rs
+++ b/artiq/firmware/ksupport/api.rs
@@ -171,7 +171,8 @@ static mut API: &'static [(&'static str, *const ())] = &[
     /*
      * syscall for unit tests
      * Used in `artiq.tests.coredevice.test_exceptions.ExceptionTest.test_raise_exceptions_kernel`
-     * `EmbeddingMap` (`artiq.compiler.embedding`) and `EXCEPTION_ID_LOOKUP` (`artiq.firmware.ksupport.eh_artiq`)
+     * This syscall checks that the exception IDs used in the Python `EmbeddingMap` (in `artiq.compiler.embedding`)
+     * match the `EXCEPTION_ID_LOOKUP` defined in the firmware (`artiq::firmware::ksupport::eh_artiq`)
      */
     api!(test_exception_id_sync = ::eh_artiq::test_exception_id_sync)
 ];

--- a/artiq/firmware/ksupport/api.rs
+++ b/artiq/firmware/ksupport/api.rs
@@ -167,4 +167,11 @@ static mut API: &'static [(&'static str, *const ())] = &[
     api!(spi_set_config = ::nrt_bus::spi::set_config),
     api!(spi_write = ::nrt_bus::spi::write),
     api!(spi_read = ::nrt_bus::spi::read),
+
+    /*
+     * syscall for unit tests
+     * Used in `artiq.tests.coredevice.test_exceptions.ExceptionTest.test_raise_exceptions_kernel`
+     * `EmbeddingMap` (`artiq.compiler.embedding`) and `EXCEPTION_ID_LOOKUP` (`artiq.firmware.ksupport.eh_artiq`)
+     */
+    api!(test_exception_id_sync = ::eh_artiq::test_exception_id_sync)
 ];

--- a/artiq/firmware/ksupport/eh_artiq.rs
+++ b/artiq/firmware/ksupport/eh_artiq.rs
@@ -333,18 +333,27 @@ extern fn stop_fn(_version: c_int,
     }
 }
 
-static EXCEPTION_ID_LOOKUP: [(&str, u32); 11] = [
-    ("RuntimeError", 0),
-    ("RTIOUnderflow", 1),
-    ("RTIOOverflow", 2),
-    ("RTIODestinationUnreachable", 3),
-    ("DMAError", 4),
-    ("I2CError", 5),
-    ("CacheError", 6),
-    ("SPIError", 7),
-    ("ZeroDivisionError", 8),
+// Must be kept in sync with `artq.compiler.embedding`
+static EXCEPTION_ID_LOOKUP: [(&str, u32); 19] = [
+    ("RTIOUnderflow", 0),
+    ("RTIOOverflow", 1),
+    ("RTIODestinationUnreachable", 2),
+    ("DMAError", 3),
+    ("I2CError", 4),
+    ("CacheError", 5),
+    ("SPIError", 6),
+    ("AssertionError", 7),
+    ("AttributeError", 8),
     ("IndexError", 9),
-    ("UnwrapNoneError", 10),
+    ("IOError", 10),
+    ("KeyError", 11),
+    ("NotImplementedError", 12),
+    ("OverflowError", 13),
+    ("RuntimeError", 14),
+    ("TimeoutError", 15),
+    ("TypeError", 16),
+    ("ValueError", 17),
+    ("ZeroDivisionError", 18),
 ];
 
 pub fn get_exception_id(name: &str) -> u32 {

--- a/artiq/firmware/ksupport/eh_artiq.rs
+++ b/artiq/firmware/ksupport/eh_artiq.rs
@@ -333,7 +333,7 @@ extern fn stop_fn(_version: c_int,
     }
 }
 
-// Must be kept in sync with `artq.compiler.embedding`
+// Must be kept in sync with `artiq.compiler.embedding`
 static EXCEPTION_ID_LOOKUP: [(&str, u32); 19] = [
     ("RTIOUnderflow", 0),
     ("RTIOOverflow", 1),
@@ -363,5 +363,27 @@ pub fn get_exception_id(name: &str) -> u32 {
         }
     }
     unimplemented!("unallocated internal exception id")
+}
+
+// Performs a reverse lookup on `EXCEPTION_ID_LOOKUP` 
+// Unconditionally raises an exception given its id
+#[no_mangle]
+#[unwind(allowed)]
+pub extern fn test_exception_id_sync(exn_id: u32) {
+    let message = EXCEPTION_ID_LOOKUP
+        .iter()
+        .find_map(|&(name, id)| if id == exn_id { Some(name) } else { None })
+        .unwrap_or("Unknown exception ID");
+    
+    let exn = Exception {
+        id:       exn_id,
+        file:     file!().as_c_slice(),
+        line:     0,
+        column:   0,
+        function: "test_exception_id_sync".as_c_slice(),
+        message:  message.as_c_slice(),
+        param:    [0, 0, 0]
+    };
+    unsafe { raise(&exn) };
 }
 

--- a/artiq/firmware/ksupport/eh_artiq.rs
+++ b/artiq/firmware/ksupport/eh_artiq.rs
@@ -365,15 +365,20 @@ pub fn get_exception_id(name: &str) -> u32 {
     unimplemented!("unallocated internal exception id")
 }
 
-// Performs a reverse lookup on `EXCEPTION_ID_LOOKUP` 
-// Unconditionally raises an exception given its id
+/// Takes as input exception id from host
+/// Generates a new exception with:
+///   * `id` set to `exn_id`
+///   * `message` set to corresponding exception name from `EXCEPTION_ID_LOOKUP`
+///
+/// The message is matched on host to ensure correct exception is being referred 
+/// This test checks the synchronization of exception ids for runtime errors
 #[no_mangle]
 #[unwind(allowed)]
 pub extern fn test_exception_id_sync(exn_id: u32) {
     let message = EXCEPTION_ID_LOOKUP
         .iter()
         .find_map(|&(name, id)| if id == exn_id { Some(name) } else { None })
-        .unwrap_or("Unknown exception ID");
+        .unwrap_or("unallocated internal exception id");
     
     let exn = Exception {
         id:       exn_id,

--- a/artiq/test/coredevice/test_exceptions.py
+++ b/artiq/test/coredevice/test_exceptions.py
@@ -4,16 +4,16 @@ import artiq.coredevice.exceptions as exceptions
 from artiq.experiment import *
 from artiq.test.hardware_testbench import ExperimentCase
 from artiq.compiler.embedding import EmbeddingMap
-from artiq.coredevice.core import raise_exception
+from artiq.coredevice.core import test_exception_id_sync
 
 """
 Test sync in exceptions raised between host and kernel
-Check artiq.compiler.embedding and artiq.frontend.ksupport.eh_artiq
+Check `artiq.compiler.embedding` and `artiq::firmware::ksupport::eh_artiq`
 
 Considers the following two cases:
     1) Exception raised on kernel and passed to host
-    2) Exception raised in host function called from kernel
-Ensures integirty of exceptions is maintained as it passes between kernel and host
+    2) Exception raised in a host function called from kernel
+Ensures same exception is raised on both kernel and host in either case
 """
 
 exception_names = EmbeddingMap().str_reverse_map
@@ -35,7 +35,7 @@ class _TestExceptionSync(EnvExperiment):
 
     @kernel
     def raise_exception_kernel(self, id):
-        raise_exception(id)
+        test_exception_id_sync(id)
 
     
 class ExceptionTest(ExperimentCase):

--- a/artiq/test/coredevice/test_exceptions.py
+++ b/artiq/test/coredevice/test_exceptions.py
@@ -1,0 +1,59 @@
+import unittest
+import artiq.coredevice.exceptions as exceptions
+
+from artiq.experiment import *
+from artiq.test.hardware_testbench import ExperimentCase
+from artiq.compiler.embedding import EmbeddingMap
+from artiq.coredevice.core import raise_exception
+
+"""
+Test sync in exceptions raised between host and kernel
+Check artiq.compiler.embedding and artiq.frontend.ksupport.eh_artiq
+
+Considers the following two cases:
+    1) Exception raised on kernel and passed to host
+    2) Exception raised in host function called from kernel
+Ensures integirty of exceptions is maintained as it passes between kernel and host
+"""
+
+exception_names = EmbeddingMap().str_reverse_map
+
+
+class _TestExceptionSync(EnvExperiment):
+    def build(self):
+        self.setattr_device("core")
+    
+    @rpc
+    def _raise_exception_host(self, id):
+        exn = exception_names[id].split('.')[-1].split(':')[-1]
+        exn = getattr(exceptions, exn)
+        raise exn
+
+    @kernel
+    def raise_exception_host(self, id):
+        self._raise_exception_host(id)
+
+    @kernel
+    def raise_exception_kernel(self, id):
+        raise_exception(id)
+
+    
+class ExceptionTest(ExperimentCase):
+    def test_raise_exceptions_kernel(self):
+        exp = self.create(_TestExceptionSync)
+        
+        for id, name in list(exception_names.items())[::-1]:
+            name = name.split('.')[-1].split(':')[-1]
+            with self.assertRaises(getattr(exceptions, name)) as ctx:
+                exp.raise_exception_kernel(id)
+            self.assertEqual(str(ctx.exception).strip("'"), name)
+            
+            
+    def test_raise_exceptions_host(self):
+        exp = self.create(_TestExceptionSync)
+
+        for id, name in exception_names.items():
+            name = name.split('.')[-1].split(':')[-1]
+            with self.assertRaises(getattr(exceptions, name)) as ctx:
+                exp.raise_exception_host(id)
+

--- a/artiq/test/lit/exceptions/catch_all.py
+++ b/artiq/test/lit/exceptions/catch_all.py
@@ -8,7 +8,7 @@ def catch(f):
     except Exception as e:
         print(e)
 
-# CHECK-L: 8(0, 0, 0)
+# CHECK-L: 18(0, 0, 0)
 catch(lambda: 1/0)
 # CHECK-L: 9(10, 1, 0)
 catch(lambda: [1.0][10])

--- a/artiq/test/lit/exceptions/catch_multi.py
+++ b/artiq/test/lit/exceptions/catch_multi.py
@@ -10,7 +10,7 @@ def catch(f):
     except IndexError as ie:
         print(ie)
 
-# CHECK-L: 8(0, 0, 0)
+# CHECK-L: 18(0, 0, 0)
 catch(lambda: 1/0)
 # CHECK-L: 9(10, 1, 0)
 catch(lambda: [1.0][10])

--- a/artiq/test/lit/exceptions/reraise.py
+++ b/artiq/test/lit/exceptions/reraise.py
@@ -3,7 +3,7 @@
 # REQUIRES: exceptions
 
 def f():
-    # CHECK-L: Uncaught 8
+    # CHECK-L: Uncaught 18
     # CHECK-L: at input.py:${LINE:+1}:
     1/0
 

--- a/artiq/test/lit/exceptions/reraise_update.py
+++ b/artiq/test/lit/exceptions/reraise_update.py
@@ -9,7 +9,7 @@ def g():
     try:
         f()
     except Exception as e:
-        # CHECK-L: Uncaught 8
+        # CHECK-L: Uncaught 18
         # CHECK-L: at input.py:${LINE:+1}:
         raise e
 

--- a/artiq/test/lit/exceptions/uncaught.py
+++ b/artiq/test/lit/exceptions/uncaught.py
@@ -2,6 +2,6 @@
 # RUN: OutputCheck %s --file-to-check=%t
 # REQUIRES: exceptions
 
-# CHECK-L: Uncaught 8: cannot divide by zero (0, 0, 0)
+# CHECK-L: Uncaught 18: cannot divide by zero (0, 0, 0)
 # CHECK-L: at input.py:${LINE:+1}:
 1/0


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
Sync exception names and ids between `artiq.compiler.embedding` and `artiq::firmware::ksupport::eh_artiq`.
Continuation of #2526

`SubkernelError` has been removed from the exception lists as it was introduced in release-8 and is not part of release-7.
### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :hammer: Refactoring  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)



### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
