### PR TITLE
Restore exception ids release 7

### DIFF
--- a/artiq/compiler/embedding.py
+++ b/artiq/compiler/embedding.py
@@ -61,6 +61,7 @@ class EmbeddingMap:
         # The exceptions declared here must be defined in `artiq.coredevice.exceptions`
         # Verify synchronization by running the test cases in `artiq.test.coredevice.test_exceptions`
         self.preallocate_runtime_exception_names([
+            "0:RuntimeError",
             "RTIOUnderflow",
             "RTIOOverflow",
             "RTIODestinationUnreachable",
@@ -68,19 +69,9 @@ class EmbeddingMap:
             "I2CError",
             "CacheError",
             "SPIError",
-
-            "0:AssertionError",
-            "0:AttributeError",
+            "0:ZeroDivisionError",
             "0:IndexError",
-            "0:IOError",
-            "0:KeyError",
-            "0:NotImplementedError",
-            "0:OverflowError",
-            "0:RuntimeError",
-            "0:TimeoutError",
-            "0:TypeError",
-            "0:ValueError",
-            "0:ZeroDivisionError"
+            "UnwrapNoneError",
         ])
 
     def preallocate_runtime_exception_names(self, names):

--- a/artiq/coredevice/exceptions.py
+++ b/artiq/coredevice/exceptions.py
@@ -174,3 +174,7 @@ class I2CError(Exception):
 class SPIError(Exception):
     """Raised when a SPI transaction fails."""
     artiq_builtin = True
+
+class UnwrapNoneError(Exception):
+    """Raised when unwrapping a none Option."""
+    artiq_builtin = True

--- a/artiq/firmware/ksupport/eh_artiq.rs
+++ b/artiq/firmware/ksupport/eh_artiq.rs
@@ -334,26 +334,18 @@ extern fn stop_fn(_version: c_int,
 }
 
 // Must be kept in sync with `artiq.compiler.embedding`
-static EXCEPTION_ID_LOOKUP: [(&str, u32); 19] = [
-    ("RTIOUnderflow", 0),
-    ("RTIOOverflow", 1),
-    ("RTIODestinationUnreachable", 2),
-    ("DMAError", 3),
-    ("I2CError", 4),
-    ("CacheError", 5),
-    ("SPIError", 6),
-    ("AssertionError", 7),
-    ("AttributeError", 8),
+static EXCEPTION_ID_LOOKUP: [(&str, u32); 11] = [
+    ("RuntimeError", 0),
+    ("RTIOUnderflow", 1),
+    ("RTIOOverflow", 2),
+    ("RTIODestinationUnreachable", 3),
+    ("DMAError", 4),
+    ("I2CError", 5),
+    ("CacheError", 6),
+    ("SPIError", 7),
+    ("ZeroDivisionError", 8),
     ("IndexError", 9),
-    ("IOError", 10),
-    ("KeyError", 11),
-    ("NotImplementedError", 12),
-    ("OverflowError", 13),
-    ("RuntimeError", 14),
-    ("TimeoutError", 15),
-    ("TypeError", 16),
-    ("ValueError", 17),
-    ("ZeroDivisionError", 18),
+    ("UnwrapNoneError", 10),
 ];
 
 pub fn get_exception_id(name: &str) -> u32 {

--- a/artiq/test/lit/exceptions/catch_all.py
+++ b/artiq/test/lit/exceptions/catch_all.py
@@ -8,7 +8,7 @@ def catch(f):
     except Exception as e:
         print(e)
 
-# CHECK-L: 18(0, 0, 0)
+# CHECK-L: 8(0, 0, 0)
 catch(lambda: 1/0)
 # CHECK-L: 9(10, 1, 0)
 catch(lambda: [1.0][10])

--- a/artiq/test/lit/exceptions/catch_multi.py
+++ b/artiq/test/lit/exceptions/catch_multi.py
@@ -10,7 +10,7 @@ def catch(f):
     except IndexError as ie:
         print(ie)
 
-# CHECK-L: 18(0, 0, 0)
+# CHECK-L: 8(0, 0, 0)
 catch(lambda: 1/0)
 # CHECK-L: 9(10, 1, 0)
 catch(lambda: [1.0][10])

--- a/artiq/test/lit/exceptions/reraise.py
+++ b/artiq/test/lit/exceptions/reraise.py
@@ -3,7 +3,7 @@
 # REQUIRES: exceptions
 
 def f():
-    # CHECK-L: Uncaught 18
+    # CHECK-L: Uncaught 8
     # CHECK-L: at input.py:${LINE:+1}:
     1/0
 

--- a/artiq/test/lit/exceptions/reraise_update.py
+++ b/artiq/test/lit/exceptions/reraise_update.py
@@ -9,7 +9,7 @@ def g():
     try:
         f()
     except Exception as e:
-        # CHECK-L: Uncaught 18
+        # CHECK-L: Uncaught 8
         # CHECK-L: at input.py:${LINE:+1}:
         raise e
 

--- a/artiq/test/lit/exceptions/uncaught.py
+++ b/artiq/test/lit/exceptions/uncaught.py
@@ -2,6 +2,6 @@
 # RUN: OutputCheck %s --file-to-check=%t
 # REQUIRES: exceptions
 
-# CHECK-L: Uncaught 18: cannot divide by zero (0, 0, 0)
+# CHECK-L: Uncaught 8: cannot divide by zero (0, 0, 0)
 # CHECK-L: at input.py:${LINE:+1}:
 1/0


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
Remove the new exceptions added in 9591549b37f0973e18f1058c1017708b2b7b12c7 and restores the order from [e82cf94cae6a33d5906b566b90678c63948ca5b7](https://github.com/m-labs/artiq/tree/e82cf94cae6a33d5906b566b90678c63948ca5b7).

Adds a new class `UnwrapNoneError` to the exceptions for https://github.com/m-labs/artiq/blob/723f41c78b1948c05fd6bdf7d2014e85afebe5aa/artiq/firmware/ksupport/eh_artiq.rs#L347
### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
