### PR TITLE
firmware: add UnwrapNoneError exception

### DIFF
--- a/artiq/compiler/embedding.py
+++ b/artiq/compiler/embedding.py
@@ -114,6 +114,7 @@ class EmbeddingMap:
             "0:ValueError",
             "0:ZeroDivisionError",
             "0:LinAlgError",
+            "UnwrapNoneError",
         ])
 
     def preallocate_runtime_exception_names(self, names):

--- a/artiq/coredevice/exceptions.py
+++ b/artiq/coredevice/exceptions.py
@@ -182,3 +182,8 @@ class I2CError(Exception):
 class SPIError(Exception):
     """Raised when a SPI transaction fails."""
     artiq_builtin = True
+
+
+class UnwrapNoneError(Exception):
+    """Raised when unwrapping a none Option."""
+    artiq_builtin = True

--- a/artiq/firmware/ksupport/eh_artiq.rs
+++ b/artiq/firmware/ksupport/eh_artiq.rs
@@ -329,7 +329,7 @@ extern fn stop_fn(_version: c_int,
 }
 
 // Must be kept in sync with `artiq.compiler.embedding`
-static EXCEPTION_ID_LOOKUP: [(&str, u32); 21] = [
+static EXCEPTION_ID_LOOKUP: [(&str, u32); 22] = [
     ("RTIOUnderflow", 0),
     ("RTIOOverflow", 1),
     ("RTIODestinationUnreachable", 2),
@@ -351,6 +351,7 @@ static EXCEPTION_ID_LOOKUP: [(&str, u32); 21] = [
     ("ValueError", 18),
     ("ZeroDivisionError", 19),
     ("LinAlgError", 20),
+    ("UnwrapNoneError", 21),
 ];
 
 pub fn get_exception_id(name: &str) -> u32 {


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
Adds `UnwrapNoneError` Exception type.
### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.


### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
