### PR TITLE
firmware: remove the duplicate test_exception_id_sync

### DIFF
--- a/artiq/firmware/ksupport/eh_artiq.rs
+++ b/artiq/firmware/ksupport/eh_artiq.rs
@@ -388,29 +388,3 @@ pub extern "C-unwind" fn test_exception_id_sync(exn_id: u32) {
     };
     unsafe { raise(&exn) };
 }
-
-/// Takes as input exception id from host
-/// Generates a new exception with:
-///   * `id` set to `exn_id`
-///   * `message` set to corresponding exception name from `EXCEPTION_ID_LOOKUP`
-///
-/// The message is matched on host to ensure correct exception is being referred 
-/// This test checks the synchronization of exception ids for runtime errors
-#[no_mangle]
-pub extern "C-unwind" fn test_exception_id_sync(exn_id: u32) {
-    let message = EXCEPTION_ID_LOOKUP
-        .iter()
-        .find_map(|&(name, id)| if id == exn_id { Some(name) } else { None })
-        .unwrap_or("unallocated internal exception id");
-    
-    let exn = Exception {
-        id:       exn_id,
-        file:     file!().as_c_slice(),
-        line:     0,
-        column:   0,
-        function: "test_exception_id_sync".as_c_slice(),
-        message:  message.as_c_slice(),
-        param:    [0, 0, 0]
-    };
-    unsafe { raise(&exn) };
-}


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
Remove the duplicate of `test_exception_id_sync` created in #2563
### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
