### PR TITLE
moninj: fix pyqt6 context menu exec

### DIFF
--- a/artiq/dashboard/moninj.py
+++ b/artiq/dashboard/moninj.py
@@ -847,7 +847,7 @@ class _MonInjDock(QDockWidgetCloseDetect):
         delete_action = QtGui.QAction("Delete widget", menu)
         delete_action.triggered.connect(partial(self.delete_widget, index))
         menu.addAction(delete_action)
-        menu.exec_(self.flow.mapToGlobal(pos))
+        menu.exec(self.flow.mapToGlobal(pos))
 
     def delete_all_widgets(self):
         for index in reversed(range(self.flow.count())):


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Problem: Custom context menu cannot be opened due to deprecated `exec_` usage in PyQt6.
Fix: Change to `exec` method. 

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.
Tested by clicking moninj widgets in dashboard.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
