### PR TITLE
almazny: fix missing delay import

### DIFF
--- a/artiq/coredevice/almazny.py
+++ b/artiq/coredevice/almazny.py
@@ -1,4 +1,4 @@
-from artiq.language.core import kernel, portable
+from artiq.language.core import kernel, portable, delay
 from artiq.language.units import us
 
 from numpy import int32


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Identified missing `delay` import for the `AlmaznyLegacy` coredevice driver.

Can be applied on `release-8` as well.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
