### PR TITLE
RTIO: Make event spreading optional in gateware

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -19,6 +19,7 @@ ARTIQ-9 (Unreleased)
 * Python 3.12 support.
 * Compiler can now give automatic suggestions for ``kernel_invariants``. 
 * Idle kernels now restart when written with ``artiq_coremgmt`` and stop when erased/removed from config.
+* event spreading is now optional and can be controlled using the `enable_spread` parameter.
 
 ARTIQ-8
 -------

--- a/artiq/coredevice/coredevice_generic.schema.json
+++ b/artiq/coredevice/coredevice_generic.schema.json
@@ -83,6 +83,11 @@
             "default": 8,
             "description": "Number of FIFOs in the SED, must be a power of 2"
         },
+        "enable_spread": {
+            "type": "boolean",
+            "default": true,
+            "description": "If enabled, switch to the next line if the current is at its high water mark"
+        },
         "peripherals": {
             "type": "array",
             "items": {

--- a/artiq/gateware/drtio/core.py
+++ b/artiq/gateware/drtio/core.py
@@ -49,7 +49,7 @@ async_errors_layout = [
 
 
 class SyncRTIO(Module):
-    def __init__(self, tsc, channels, lane_count=8, fifo_depth=128):
+    def __init__(self, tsc, channels, lane_count=8, fifo_depth=128, enable_spread=True):
         self.cri = cri.Interface()
         self.async_errors = Record(async_errors_layout)
         self.sed_spread_enable = Signal()
@@ -63,8 +63,8 @@ class SyncRTIO(Module):
         self.submodules.outputs = ClockDomainsRenamer("rio")(
             SED(channels, tsc.glbl_fine_ts_width,
                 lane_count=lane_count, fifo_depth=fifo_depth,
-                fifo_high_watermark=0.75, report_buffer_space=True,
-                interface=self.cri))
+                enable_spread=enable_spread, fifo_high_watermark=0.75,
+                report_buffer_space=True, interface=self.cri))
         self.comb += self.outputs.coarse_timestamp.eq(tsc.coarse_ts)
         self.sync += self.outputs.minimum_coarse_timestamp.eq(tsc.coarse_ts + 16)
         self.specials += MultiReg(self.sed_spread_enable, self.outputs.enable_spread, "rio")

--- a/artiq/gateware/rtio/core.py
+++ b/artiq/gateware/rtio/core.py
@@ -14,7 +14,7 @@ from artiq.gateware.rtio.input_collector import *
 
 
 class Core(Module, AutoCSR):
-    def __init__(self, tsc, channels, lane_count=8, fifo_depth=128):
+    def __init__(self, tsc, channels, lane_count=8, fifo_depth=128, enable_spread=True):
         self.cri = cri.Interface()
         self.reset = CSR()
         self.reset_phy = CSR()
@@ -63,7 +63,7 @@ class Core(Module, AutoCSR):
 
         outputs = ClockDomainsRenamer("rio")(SED(channels, tsc.glbl_fine_ts_width,
             quash_channels=quash_channels,
-            lane_count=lane_count, fifo_depth=fifo_depth,
+            lane_count=lane_count, fifo_depth=fifo_depth, enable_spread=enable_spread,
             interface=self.cri))
         self.submodules += outputs
         self.comb += outputs.coarse_timestamp.eq(tsc.coarse_ts)


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Allow configuration of `event_spreading` in gateware for standalone and drtio crates. 

c2d645ed0a712a1f28a7e6d479fc3894eb63641d introduced event spreading for DRTIO satellites which is often a good idea, but not always: for example, this broke our sequence. This PR adds the ability to opt out of event spreading on DRTIO systems if you want to. 

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

None. 

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Close/update issues.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [ ] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [ ] Add and check docstrings and comments
- [ ] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

- [ ] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`nix build .#artiq-manual-html; nix build .#artiq-manual-pdf`) to ensure no errors.

### Git Logistics

- [ ] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [ ] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
