### PR TITLE
doc: Add TTuple to compiler section

### DIFF
--- a/doc/manual/compiler.rst
+++ b/doc/manual/compiler.rst
@@ -48,44 +48,48 @@ ARTIQ types
 
 Python/NumPy types correspond to ARTIQ types as follows:
 
-+---------------+-------------------------+
-| Python        | ARTIQ                   |
-+===============+=========================+
-| NoneType      | TNone                   |
-+---------------+-------------------------+
-| bool          | TBool                   |
-+---------------+-------------------------+
-| int           | TInt32 or TInt64        |
-+---------------+-------------------------+
-| float         | TFloat                  |
-+---------------+-------------------------+
-| str           | TStr                    |
-+---------------+-------------------------+
-| bytes         | TBytes                  |
-+---------------+-------------------------+
-| bytearray     | TByteArray              |
-+---------------+-------------------------+
-| list of T     | TList(T)                |
-+---------------+-------------------------+
-| NumPy array   | TArray(T, num_dims)     |
-+---------------+-------------------------+
-| range         | TRange32, TRange64      |
-+---------------+-------------------------+
-| numpy.int32   | TInt32                  |
-+---------------+-------------------------+
-| numpy.int64   | TInt64                  |
-+---------------+-------------------------+
-| numpy.float64 | TFloat                  |
-+---------------+-------------------------+
++------------------------+-------------------------+
+| Python                 | ARTIQ                   |
++========================+=========================+
+| NoneType               | TNone                   |
++------------------------+-------------------------+
+| bool                   | TBool                   |
++------------------------+-------------------------+
+| int                    | TInt32 or TInt64        |
++------------------------+-------------------------+
+| float                  | TFloat                  |
++------------------------+-------------------------+
+| str                    | TStr                    |
++------------------------+-------------------------+
+| bytes                  | TBytes                  |
++------------------------+-------------------------+
+| bytearray              | TByteArray              |
++------------------------+-------------------------+
+| list of T              | TList(T)                |
++------------------------+-------------------------+
+| NumPy array            | TArray(T, num_dims)     |
++------------------------+-------------------------+
+| tuple of (T1, T2, ...) | TTuple([T1, T2, ...])   |
++------------------------+-------------------------+
+| range                  | TRange32, TRange64      |
++------------------------+-------------------------+
+| numpy.int32            | TInt32                  |
++------------------------+-------------------------+
+| numpy.int64            | TInt64                  |
++------------------------+-------------------------+
+| numpy.float64          | TFloat                  |
++------------------------+-------------------------+
 
 Integers are 32-bit by default but may be converted to 64-bit with ``numpy.int64``.
 
-The ARTIQ compiler can be thought of as overriding all built-in Python types, and types in kernel code cannot always be assumed to behave as they would in host Python. In particular, normally heap-allocated types such as arrays, lists, and strings are very limited in what they support. Strings must be constant and lists and arrays must be of constant size. Methods like ``append``, ``push``, and ``pop`` are unavailable as a matter of principle, and will not compile. Certain types, notably dictionaries, have no ARTIQ implementation and cannot be used in kernels at all.
+The ARTIQ compiler can be thought of as overriding all built-in Python types, and types in kernel code cannot always be assumed to behave as they would in host Python. In particular, normally heap-allocated types such as arrays, lists, tuples, and strings are very limited in what they support. Strings must be constant and lists and arrays must be of constant size. Methods like ``append``, ``push``, and ``pop`` are unavailable as a matter of principle, and will not compile. Certain types, notably dictionaries, have no ARTIQ implementation and cannot be used in kernels at all.
 
 .. tip::
     Instead of pushing or appending, preallocate for the maximum number of elements you expect with a list comprehension, i.e. ``x = [0 for _ in range(1024)]``, and then keep a variable ``n`` noting the last filled element of the array. Afterwards, ``x[0:n]`` will give you a list with that number of elements.
 
 Multidimensional arrays are allowed (using NumPy syntax). Element-wise operations (e.g. ``+``, ``/``), matrix multiplication (``@``) and multidimensional indexing are supported; slices and views (currently) are not.
+
+Tuples may contain a mixture of different types. They cannot be indexed or iterated over, although multiple assignment is supported.
 
 User-defined classes are supported, provided their attributes are of other supported types (attributes that are not used in the kernel are ignored and thus unrestricted). When several instances of a user-defined class are referenced from the same kernel, every attribute must have the same type in every instance of the class.
 
@@ -101,11 +105,19 @@ Kernel code can call host functions without any additional ceremony. However, su
     def return_four() -> TInt32:
         return 4
 
+.. tip::
+    Multiple variables of different types can be sent in one RPC call by returning a tuple, e.g. ::
+
+        def return_many() -> TTuple([TInt32, TFloat, TStr]):
+            return (4, 12.34, "hello",)
+
+    Which can be retrieved from a kernel with ``(a, b, c) = return_many()``
+
 Kernels can freely modify attributes of objects shared with the host. However, by necessity, these modifications are actually applied to local copies of the objects, as the latency of immediate writeback would be unsupportable in a real-time environment. Instead, modifications are written back *when the kernel completes;* notably, this means RPCs called by a kernel itself will only have access to the unmodified host version of the object, as the kernel hasn't finished execution yet. In some cases, accessing data on the host is better handled by calling RPCs specifically to make the desired modifications.
 
 .. warning::
 
-    Kernels *cannot and should not* return lists, arrays, or strings they have created, or any objects containing them; in the absence of a heap, the way these values are allocated means they cannot outlive the kernels they are created in. Trying to do so will normally be discovered by lifetime tracking and result in compilation errors, but in certain cases lifetime tracking will fail to detect a problem and experiments will encounter memory corruption at runtime. For example: ::
+    Kernels *cannot and should not* return lists, arrays, tuples, or strings they have created, or any objects containing them; in the absence of a heap, the way these values are allocated means they cannot outlive the kernels they are created in. Trying to do so will normally be discovered by lifetime tracking and result in compilation errors, but in certain cases lifetime tracking will fail to detect a problem and experiments will encounter memory corruption at runtime. For example: ::
 
         def func(a):
             return a


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Adds TTuple type to the compiler documentation, and gives an example of multiple return usage,

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Documentation Changes

- [x ] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`nix build .#artiq-manual-html; nix build .#artiq-manual-pdf`) to ensure no errors.


### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
