### PR TITLE
Implement Burst Memory Access for RTIO DMA & Analyzer

### DIFF
--- a/artiq/firmware/runtime/analyzer.rs
+++ b/artiq/firmware/runtime/analyzer.rs
@@ -10,7 +10,7 @@ use core::cell::RefCell;
 
 const BUFFER_SIZE: usize = 512 * 1024;
 
-#[repr(align(64))]
+#[repr(align(2048))]
 struct Buffer {
     data: [u8; BUFFER_SIZE],
 }

--- a/artiq/test/coredevice/test_rtio.py
+++ b/artiq/test/coredevice/test_rtio.py
@@ -720,13 +720,6 @@ class DMATest(ExperimentCase):
         self.assertLess(dt/count, 11*us)
 
     def test_dma_playback_time(self):
-        # Skip on Kasli until #946 is resolved.
-        try:
-            # hack to detect Kasli.
-            self.device_mgr.get_desc("ad9914dds0")
-        except KeyError:
-            raise unittest.SkipTest("skipped on Kasli for now")
-
         exp = self.create(_DMA)
         is_zynq = exp.core.target_cls == CortexA9Target
         count = 20000


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
The PR changes one-by-one memory access from DMA and Analyzer to burst memory read/write. Availability of burst access is indicated by the corresponding streaming FIFO control signals within DMA and the analyzer.

## Performance
Using the `DMASaturate` script in #946 on local I/O on standalone/master variant:
Before: 490mu
After: 65mu
It is on par with Zynq variants' performance reported in #946.

The analyzer memory buffer is expanded to observe the RTIO slack (in machine unit).
![image](https://github.com/user-attachments/assets/b1bc27d8-face-477a-9ce5-2d6fc38c7dc9)
The end-to-beginning transition of DMA playbacks is indicated by a sudden drop of RTIO slack. RTIO slack gradually recovers to the maximum value (SED FIFO depth * DMA events period / DMA events per period).

## Test
Passes unittests in `artiq.test` with `test_dma_playback_time` re-enabled.
```
test_dma_playback_time (artiq.test.coredevice.test_rtio.DMATest.test_dma_playback_time) ... dt=0.080111704, dt/count=4.0055852e-06
ok
```

### Related Issue
Closes #946

See [MiSoC 151](https://github.com/m-labs/misoc/pull/151), [MiSoC 150](https://github.com/m-labs/misoc/pull/150).

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [x] Close/update issues.

### Code Changes

- [ ] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [ ] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
