### PR TITLE
Handle EFC DRTIO Disconnection

### DIFF
--- a/artiq/firmware/libboard_artiq/drtio_eem.rs
+++ b/artiq/firmware/libboard_artiq/drtio_eem.rs
@@ -147,44 +147,43 @@ unsafe fn assign_delay() -> SerdesConfig {
     }
 }
 
-unsafe fn align_comma() {
-    loop {
-        for slip in 1..=10 {
-            // The soft transceiver has 2 8b10b decoders, which receives lane
-            // 0/1 and lane 2/3 respectively. The decoder are time-multiplexed
-            // to decode exactly 1 lane each sysclk cycle.
-            //
-            // The decoder decodes lane 0/2 data on odd sysclk cycles, buffer
-            // on even cycles, and vice versa for lane 1/3. Data/Clock latency
-            // could change timing. The extend bit flips the decoding timing,
-            // so lane 0/2 data are decoded on even cycles, and lane 1/3 data
-            // are decoded on odd cycles.
-            //
-            // This is needed because transmitting/receiving a 8b10b character
-            // takes 2 sysclk cycles. Adjusting bitslip only via ISERDES
-            // limits the range to 1 cycle. The wordslip bit extends the range
-            // to 2 sysclk cycles.
-            csr::eem_transceiver::wordslip_write((slip > 5) as u8);
+pub unsafe fn align_comma(trx_no: u8) -> bool {
+    csr::eem_transceiver::transceiver_sel_write(trx_no);
 
-            // Apply a double bitslip since the ISERDES is 2x oversampled.
-            // Bitslip is used for comma alignment purposes once setup/hold
-            // timing is met.
-            csr::eem_transceiver::bitslip_write(1);
-            csr::eem_transceiver::bitslip_write(1);
-            clock::spin_us(1);
+    for slip in 1..=10 {
+        // The soft transceiver has 2 8b10b decoders, which receives lane
+        // 0/1 and lane 2/3 respectively. The decoder are time-multiplexed
+        // to decode exactly 1 lane each sysclk cycle.
+        //
+        // The decoder decodes lane 0/2 data on odd sysclk cycles, buffer
+        // on even cycles, and vice versa for lane 1/3. Data/Clock latency
+        // could change timing. The extend bit flips the decoding timing,
+        // so lane 0/2 data are decoded on even cycles, and lane 1/3 data
+        // are decoded on odd cycles.
+        //
+        // This is needed because transmitting/receiving a 8b10b character
+        // takes 2 sysclk cycles. Adjusting bitslip only via ISERDES
+        // limits the range to 1 cycle. The wordslip bit extends the range
+        // to 2 sysclk cycles.
+        csr::eem_transceiver::wordslip_write((slip > 5) as u8);
 
-            csr::eem_transceiver::comma_align_reset_write(1);
-            clock::spin_us(100);
+        // Apply a double bitslip since the ISERDES is 2x oversampled.
+        // Bitslip is used for comma alignment purposes once setup/hold
+        // timing is met.
+        csr::eem_transceiver::bitslip_write(1);
+        csr::eem_transceiver::bitslip_write(1);
+        clock::spin_us(1);
 
-            if csr::eem_transceiver::comma_read() == 1 {
-                debug!("comma alignment completed after {} bitslips", slip);
-                return;
-            }
+        csr::eem_transceiver::comma_align_reset_write(1);
+        clock::spin_us(100);
+
+        if csr::eem_transceiver::comma_read() == 1 {
+            debug!("comma alignment completed after {} bitslips", slip);
+            return true;
         }
-
-        error!("comma alignment failed, retrying in 1s...");
-        clock::spin_us(1_000_000);
     }
+
+    false
 }
 
 pub fn init() {
@@ -210,10 +209,5 @@ pub fn init() {
                 }
             }
         });
-
-        unsafe {
-            align_comma();
-            csr::eem_transceiver::rx_ready_write(1);
-        }
     }
 }

--- a/artiq/firmware/runtime/rtio_mgt.rs
+++ b/artiq/firmware/runtime/rtio_mgt.rs
@@ -16,6 +16,8 @@ const ASYNC_ERROR_SEQUENCE_ERROR: u8 = 1 << 2;
 pub mod drtio {
     use super::*;
     use alloc::vec::Vec;
+    #[cfg(has_drtio_eem)]
+    use board_artiq::drtio_eem;
     use drtioaux;
     use proto_artiq::drtioaux_proto::{MASTER_PAYLOAD_MAX_SIZE, PayloadStatus};
     use rtio_dma::remote_dma;
@@ -23,6 +25,9 @@ pub mod drtio {
     use analyzer::remote_analyzer::RemoteBuffer;
     use kernel::subkernel;
     use sched::Error as SchedError;
+
+    #[cfg(has_drtio_eem)]
+    const DRTIO_EEM_LINKNOS: core::ops::Range<usize> = (csr::DRTIO.len()-csr::CONFIG_EEM_DRTIO_COUNT as usize)..csr::DRTIO.len();
 
     #[derive(Fail, Debug)]
     pub enum Error {
@@ -73,6 +78,14 @@ pub mod drtio {
 
     fn link_rx_up(linkno: u8) -> bool {
         let linkno = linkno as usize;
+        #[cfg(has_drtio_eem)]
+        {
+            if DRTIO_EEM_LINKNOS.contains(&linkno) {
+                return unsafe {
+                    csr::eem_transceiver::rx_alive_read() == 1
+                }
+            }
+        }
         unsafe {
             (csr::DRTIO[linkno].rx_up_read)() == 1
         }
@@ -418,6 +431,17 @@ pub mod drtio {
                 } else {
                     /* link was previously down */
                     if link_rx_up(linkno) {
+                        #[cfg(has_drtio_eem)]
+                        if DRTIO_EEM_LINKNOS.contains(&(linkno as usize)) {
+                            let eem_trx_no = linkno - DRTIO_EEM_LINKNOS.start as u8;
+                            if !unsafe {drtio_eem::align_comma(eem_trx_no)} {
+                                error!("[LINK#{}] link RX became up but comma alignment failed", linkno);
+                                continue;
+                            }
+                            unsafe {
+                                csr::eem_transceiver::rx_ready_en_write(1)
+                            }
+                        }
                         info!("[LINK#{}] link RX became up, pinging", linkno);
                         let ping_count = ping_remote(&io, aux_mutex, linkno);
                         if ping_count > 0 {

--- a/artiq/firmware/satman/main.rs
+++ b/artiq/firmware/satman/main.rs
@@ -55,9 +55,15 @@ fn drtiosat_reset_phy(reset: bool) {
 }
 
 fn drtiosat_link_rx_up() -> bool {
+    #[cfg(not(has_drtio_eem))]
     unsafe {
         csr::drtiosat::rx_up_read() == 1
     }
+
+    // RX is always up for satellite devices with EEM master
+    // See the OOB reset
+    #[cfg(has_drtio_eem)]
+    true
 }
 
 fn drtiosat_tsc_loaded() -> bool {
@@ -777,7 +783,16 @@ pub extern fn main() -> i32 {
     });
 
     #[cfg(has_drtio_eem)]
-    drtio_eem::init();
+    {
+        drtio_eem::init();
+        while !unsafe { drtio_eem::align_comma(0) } {
+            error!("comma alignment failed, retrying in 1s...");
+            clock::spin_us(1_000_000);
+        }
+        unsafe {
+            csr::eem_transceiver::rx_ready_en_write(1)
+        }
+    }
 
     #[cfg(has_drtio_routing)]
     let mut repeaters = [repeater::Repeater::default(); csr::DRTIOREP.len()];

--- a/artiq/gateware/drtio/transceiver/eem_serdes.py
+++ b/artiq/gateware/drtio/transceiver/eem_serdes.py
@@ -1,4 +1,5 @@
 from migen import *
+from migen.genlib.cdc import MultiReg
 from migen.genlib.resetsync import AsyncResetSynchronizer
 from misoc.interconnect.csr import *
 from misoc.cores.code_8b10b import SingleEncoder, Decoder
@@ -473,7 +474,8 @@ class OOBReset(Module):
 
 class EEMSerdes(Module, TransceiverInterface, AutoCSR):
     def __init__(self, platform, data_pads):
-        self.rx_ready = CSRStorage()
+        self.rx_ready_en = CSR()
+        self.rx_alive = CSRStatus()
 
         self.transceiver_sel = CSRStorage(max(1, log2_int(len(data_pads))))
         self.lane_sel = CSRStorage(2)
@@ -505,7 +507,12 @@ class EEMSerdes(Module, TransceiverInterface, AutoCSR):
             serdes_list.append(serdes)
 
             chan_if = ChannelInterface(serdes.encoder, serdes.decoders)
-            self.comb += chan_if.rx_ready.eq(self.rx_ready.storage)
+            self.sync += \
+                If(~chan_if.rx_ready,
+                    chan_if.rx_ready.eq(self.rx_ready_en.re & self.rx_alive.status),
+                ).Elif(~self.rx_alive.status,
+                    chan_if.rx_ready.eq(0),
+                )
             channel_interfaces.append(chan_if)
 
         # Route CSR signals using transceiver_sel
@@ -555,6 +562,8 @@ class EEMSerdes(Module, TransceiverInterface, AutoCSR):
         self.submodules.oob_reset = OOBReset(platform, serdes_list[0].rx_serdes.o[0])
         self.rst = self.oob_reset.rst
         self.rst.attr.add("no_retiming")
+
+        self.specials += MultiReg(~self.oob_reset.rst, self.rx_alive.status)
 
         TransceiverInterface.__init__(self, channel_interfaces, async_rx=False)
 


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
Prior to #2559, the DRTIO-over-EEM link between EFC and Kasli would never terminate on EFC's perspective for these reasons:
- The EEM connection is intended to stay on (no hot-plugging).
- EFC would enter OOB reset once the master's DRTIO-over-EEM link is down.
This PR implements DRTIO-over-EEM handling after disconnection for DRTIO master.

A separate PR is needed in MiSoC to add false paths for driving the RX status from OOB reset via MultiReg.

### Test
Able to establish DRTIO-over-EEM connection.
With #2559, EFC can be reflashed with DRTIO link re-established after rebooting.
```
[     2.551762s]  INFO(runtime::rtio_mgt::drtio): [LINK#3] link RX became up, pinging
[     2.775096s]  INFO(runtime::rtio_mgt::drtio): [LINK#3] remote replied after 1 packets
[     3.047025s]  INFO(runtime::rtio_mgt::drtio): [LINK#3] link initialization completed
[     3.054715s]  INFO(runtime::rtio_mgt::drtio): [DEST#4] destination is up
[     3.060141s]  INFO(runtime::rtio_mgt::drtio): [DEST#4] buffer space is 128
[    30.831612s]  INFO(runtime::mgmt): new connection from 192.168.1.231:45592
[    45.915031s]  INFO(runtime::rtio_mgt::drtio): [LINK#3] link is down
[    45.920011s]  INFO(runtime::rtio_mgt::drtio): [DEST#4] destination is down
[    72.934801s]  INFO(runtime::rtio_mgt::drtio): [LINK#3] link RX became up, pinging
[    73.144061s]  INFO(runtime::rtio_mgt::drtio): [LINK#3] remote replied after 1 packets
[    73.432268s]  INFO(runtime::rtio_mgt::drtio): [LINK#3] link initialization completed
[    73.439974s]  INFO(runtime::rtio_mgt::drtio): [DEST#4] destination is up
[    73.445376s]  INFO(runtime::rtio_mgt::drtio): [DEST#4] buffer space is 128
[    73.652152s] ERROR(runtime::rtio_mgt::drtio): [LINK#3] error(s) found (0x03):
[    73.657967s] ERROR(runtime::rtio_mgt::drtio): [LINK#3] received packet of an unknown type
[    73.666130s] ERROR(runtime::rtio_mgt::drtio): [LINK#3] received truncated packet
```
LEDs on EFC can be blinked after rebooting through DRTIO.

### Related Issue
#2559

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [ ] Close/update issues.
- [ ] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [ ] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [ ] Test your changes or have someone test them. Mention what was tested and how.
- [ ] Add and check docstrings and comments
- [ ] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)


### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
