### PR TITLE
doc: Fix Python indentation

### DIFF
--- a/doc/manual/getting_started_mgmt.rst
+++ b/doc/manual/getting_started_mgmt.rst
@@ -139,8 +139,8 @@ Experiments may have arguments, values which can be set in the dashboard on subm
         self.setattr_argument("count", NumberValue(precision=0, step=1))
 
     def run(self):
-    for i in range(self.count):
-        print("Hello World", i)
+        for i in range(self.count):
+            print("Hello World", i)
 
 The method :meth:`~artiq.language.environment.HasEnvironment.setattr_argument` acts to set the argument and make its value accessible, similar to the effect of :meth:`~artiq.language.environment.HasEnvironment.setattr_device`. The second input sets the type of the argument; here, :class:`~artiq.language.environment.NumberValue` represents a floating point numerical value. To learn what other types are supported, see :class:`artiq.language.environment` and :class:`artiq.language.scan`.
 


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Fix Python indentation.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Documentation Changes

- [x] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`nix build .#artiq-manual-html; nix build .#artiq-manual-pdf`) to ensure no errors.

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
