### PR TITLE
New Feature: AD9834 core device driver

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -20,6 +20,7 @@ ARTIQ-9 (Unreleased)
 * Compiler can now give automatic suggestions for ``kernel_invariants``. 
 * Idle kernels now restart when written with ``artiq_coremgmt`` and stop when erased/removed from config.
 * New support for the EBAZ4205 Zynq-SoC control card.
+* New core device driver for AD9834 DDS.
 
 ARTIQ-8
 -------

--- a/artiq/coredevice/ad9834.py
+++ b/artiq/coredevice/ad9834.py
@@ -6,13 +6,11 @@ RTIO Driver for the Analog Devices AD9834 DDS via 3-wire SPI interface.
 # https://www.analog.com/media/en/technical-documentation/data-sheets/AD9834.pdf
 # https://www.analog.com/media/en/technical-documentation/app-notes/an-1070.pdf
 
-from enum import Enum
-
+from artiq.coredevice import spi2 as spi
 from artiq.experiment import *
 from artiq.language.core import *
 from artiq.language.types import *
 from artiq.language.units import *
-from artiq.coredevice import spi2 as spi
 
 AD9834_B28 = 1 << 13
 AD9834_HLB = 1 << 12

--- a/artiq/coredevice/ad9834.py
+++ b/artiq/coredevice/ad9834.py
@@ -1,0 +1,353 @@
+"""
+RTIO Driver for the Analog Devices AD9834 DDS via 3-wire SPI interface.
+"""
+
+# https://github.com/analogdevicesinc/linux/blob/main/drivers/staging/iio/frequency/ad9834.c
+# https://www.analog.com/media/en/technical-documentation/data-sheets/AD9834.pdf
+# https://www.analog.com/media/en/technical-documentation/app-notes/an-1070.pdf
+
+from enum import Enum
+
+from artiq.experiment import *
+from artiq.language.core import *
+from artiq.language.types import *
+from artiq.language.units import *
+from artiq.coredevice import spi2 as spi
+
+from artiq.coredevice.spi2 import SPIMaster
+from artiq.coredevice.core import Core
+
+# Control Register Bits
+
+AD9834_B28 = 1 << 13
+AD9834_HLB = 1 << 12
+AD9834_FSEL = 1 << 11
+AD9834_PSEL = 1 << 10
+AD9834_PIN_SW = 1 << 9
+AD9834_RESET = 1 << 8
+AD9834_SLEEP1 = 1 << 7
+AD9834_SLEEP12 = 1 << 6
+AD9834_OPBITEN = 1 << 5
+AD9834_SIGN_PIB = 1 << 4
+AD9834_DIV2 = 1 << 3
+AD9834_MODE = 1 << 1
+
+
+class FreqReg(Enum):
+    REG0 = 0b01 << 14
+    REG1 = 0b10 << 14
+
+
+class PhaseReg(Enum):
+    REG0 = (0b11 << 14) | (0 << 13)
+    REG1 = (0b11 << 14) | (1 << 13)
+
+
+class AD9834:
+    """
+    AD9834 DDS channel driver.
+
+    This class provides control for a single DDS channel on the AD9834.
+
+    The driver utilizes bit-controlled FSELECT, PSELECT, and RESET.
+    To pin control these, set AD9834_PIN_SW.
+    The `ctrl_reg` attribute is used to maintain the state of the control register,
+    enabling persistent management of various configurations.
+
+    :param spi_device: SPI bus device name.
+    :param spi_freq: SPI bus clock frequency (default: 10 MHz, max: 40 MHz).
+    :param clk_freq: DDS clock frequency (default: 75 MHz).
+    :param core_device: Core device name (default: "core").
+    """
+
+    kernel_invariants = {"core", "bus", "spi_freq", "clk_freq"}
+
+    def __init__(
+        self, dmgr, spi_device, spi_freq=10 * MHz, clk_freq=75 * MHz, core_device="core"
+    ):
+        self.core = dmgr.get(core_device)
+        self.bus = dmgr.get(spi_device)
+        self.spi_freq = spi_freq
+        self.clk_freq = clk_freq
+        self.ctrl_reg = 0x0000
+        assert (
+            self.spi_freq <= 40 * MHz
+        ), "SPI frequency exceeds maximum value of 40 MHz"
+
+    @kernel
+    def init(self):
+        """
+        Initialize the AD9834, configure the SPI bus, and reset the DDS.
+
+        This method performs the necessary setup for the AD9834 device, including:
+        - Configuring the SPI bus parameters (clock polarity, data width, and frequency).
+        - Putting the AD9834 into a reset state to ensure proper initialization.
+
+        The SPI bus is configured to use 16 bits of data width with the clock frequency
+        provided as a parameter when creating the `AD9834` instance. After configuring
+        the SPI bus, the method invokes the `enable_reset` method to reset the AD9834.
+        This is an essential step to prepare the device for subsequent configuration
+        of frequency and phase.
+
+        This method should be called before any other operations are performed
+        on the AD9834 to ensure that the device is in a known state.
+        """
+        self.bus.set_config(spi.SPI_CLK_POLARITY | spi.SPI_END, 16, self.spi_freq, 1)
+        self.enable_reset()
+
+    @kernel
+    def set_frequency(self, freq_reg: FreqReg, frequency: TInt32):
+        """
+        Set the frequency for the specified FREQ register.
+
+        This method calculates the frequency word based on the provided frequency in Hz
+        and writes it to the specified frequency register.
+
+        :param freq_reg: The frequency register to write to, must be one of
+                         FreqReg.REG0 or FreqReg.REG1.
+        :param frequency: The desired frequency in Hz, which will be converted to a
+                         frequency word suitable for the AD9834.
+
+        The frequency word is calculated using the formula:
+            freq_word = (frequency * (1 << 28)) / clk_freq
+        The result is limited to the lower 28 bits for compatibility with the AD9834.
+
+        The method first sets the control register to enable the appropriate settings,
+        then sends the least significant byte (LSB) and most significant byte (MSB) in
+        two consecutive writes to the specified frequency register.
+        """
+        freq_word = int((frequency * (1 << 28)) / self.clk_freq) & 0x0FFFFFFF
+        self.ctrl_reg |= AD9834_B28
+        self.write(self.ctrl_reg)
+        lsb = freq_word & 0x3FFF
+        msb = (freq_word >> 14) & 0x3FFF
+        self.write(freq_reg.value | lsb)
+        self.write(freq_reg.value | msb)
+
+    @kernel
+    def set_frequency_msb_word(self, freq_reg: FreqReg, word: TInt32):
+        """
+        Set the most significant byte (MSB) of the specified FREQ register.
+
+        This method updates the specified frequency register with the provided MSB value.
+        It configures the control register to indicate that the MSB is being set.
+
+        :param freq_reg: The frequency register to update, must be one of
+                         FreqReg.REG0 or FreqReg.REG1.
+        :param word: The MSB value to be written to the frequency register,
+                     limited to the lower 14 bits.
+
+        The method first clears the appropriate control bits, sets the HLB bit to
+        indicate that the MSB is being sent, and then writes the updated control register
+        followed by the MSB value to the specified frequency register.
+        """
+        self.ctrl_reg &= ~AD9834_B28
+        self.ctrl_reg |= AD9834_HLB
+        self.write(self.ctrl_reg)
+        self.write(freq_reg.value | (word & 0x3FFF))
+
+    @kernel
+    def set_frequency_lsb_word(self, freq_reg: FreqReg, word: TInt32):
+        """
+        Set the least significant byte (LSB) of the specified FREQ register.
+
+        This method updates the specified frequency register with the provided LSB value.
+        It configures the control register to indicate that the LSB is being set.
+
+        :param freq_reg: The frequency register to update, must be one of
+                         FreqReg.REG0 or FreqReg.REG1.
+        :param word: The LSB value to be written to the frequency register,
+                     limited to the lower 14 bits.
+
+        The method first clears the appropriate control bits and writes the updated control
+        register followed by the LSB value to the specified frequency register.
+        """
+        self.ctrl_reg &= ~AD9834_B28
+        self.ctrl_reg &= ~AD9834_HLB
+        self.write(self.ctrl_reg)
+        self.write(freq_reg.value | (word & 0x3FFF))
+
+    @kernel
+    def set_phase(self, phase_reg: PhaseReg, phase: TInt32):
+        """
+        Set the phase for the specified PHASE register.
+
+        This method updates the specified phase register with the provided phase value.
+
+        :param phase_reg: The phase register to update, must be one of
+                          PhaseReg.REG0 or PhaseReg.REG1.
+        :param phase: The phase value to be written to the phase register,
+                      limited to the lower 12 bits.
+
+        The method masks the phase value to ensure it fits within the 12-bit limit
+        and writes it to the specified phase register.
+        """
+        phase_word = phase & 0x0FFF
+        self.write(phase_reg.value | phase_word)
+
+    @kernel
+    def enable_reset(self):
+        """
+        Enable the DDS reset.
+
+        This method sets the reset bit in the control register, putting the AD9834
+        into a reset state. While in this state, the digital-to-analog converter
+        (DAC) is not operational.
+
+        This method should be called during initialization or when a reset is required
+        to reinitialize the device and ensure proper operation.
+        """
+        self.ctrl_reg |= AD9834_RESET
+        self.write(self.ctrl_reg)
+
+    @kernel
+    def output_enable(self):
+        """
+        Disable the DDS reset and start signal generation.
+
+        This method clears the reset bit in the control register, allowing the AD9834
+        to begin generating signals. Once this method is called, the device will
+        resume normal operation and output the generated waveform.
+
+        This method should be called after configuration of the frequency and phase
+        settings to activate the output.
+        """
+        self.ctrl_reg &= ~AD9834_RESET
+        self.write(self.ctrl_reg)
+
+    @kernel
+    def sleep(
+        self,
+        dac_powerdown: bool = False,
+        internal_clk_disable: bool = False,
+        pin_sw: bool = False,
+    ):
+        """
+        Put the AD9834 into sleep mode based on specified conditions.
+
+        :param dac_powerdown: Power down the DAC (SLEEP12 bit).
+        :param internal_clk_disable: Disable the internal clock (SLEEP1 bit).
+        :param pin_sw: Control via PIN/SW (PIN/SW bit).
+        """
+        # Control PIN/SW bit
+        if pin_sw:
+            self.ctrl_reg |= AD9834_PIN_SW
+        else:
+            self.ctrl_reg &= ~AD9834_PIN_SW
+
+        # Handle SLEEP12 (DAC power-down)
+        if dac_powerdown:
+            self.ctrl_reg |= AD9834_SLEEP12
+        else:
+            self.ctrl_reg &= ~AD9834_SLEEP12
+
+        # Handle SLEEP1 (internal clock disable)
+        if internal_clk_disable:
+            self.ctrl_reg |= AD9834_SLEEP1
+        else:
+            self.ctrl_reg &= ~AD9834_SLEEP1
+
+        # Write the updated control register to the AD9834
+        self.write(self.ctrl_reg)
+
+    @kernel
+    def configure_sign_bit_out(
+        self,
+        high_impedance: bool = False,
+        dac_data_msb_2: bool = False,
+        dac_data_msb: bool = False,
+        comparator_output: bool = False,
+    ):
+        """
+        Configure the SIGN BIT OUT pin based on boolean flags.
+
+        The user can pass True for one of the parameters to set the desired output mode.
+
+        :param high_impedance: Set to True for High Impedance mode.
+        :param dac_data_msb_2: Set to True for DAC Data MSB/2 output.
+        :param dac_data_msb: Set to True for DAC Data MSB output.
+        :param comparator_output: Set to True for Comparator output.
+        """
+
+        # Default to high impedance if nothing is explicitly enabled
+        if high_impedance:
+            # High impedance state, clear OPBITEN
+            self.ctrl_reg &= ~AD9834_OPBITEN
+
+        elif dac_data_msb_2:
+            # DAC data MSB/2: OPBITEN = 1, MODE = 0, SIGN/PIB = 0, DIV2 = 0
+            self.ctrl_reg |= AD9834_OPBITEN
+            self.ctrl_reg &= ~AD9834_MODE
+            self.ctrl_reg &= ~AD9834_SIGN_PIB
+            self.ctrl_reg &= ~AD9834_DIV2
+
+        elif dac_data_msb:
+            # DAC data MSB: OPBITEN = 1, MODE = 0, SIGN/PIB = 0, DIV2 = 1
+            self.ctrl_reg |= AD9834_OPBITEN
+            self.ctrl_reg &= ~AD9834_MODE
+            self.ctrl_reg &= ~AD9834_SIGN_PIB
+            self.ctrl_reg |= AD9834_DIV2
+
+        elif comparator_output:
+            # Comparator output: OPBITEN = 1, MODE = 0, SIGN/PIB = 1, DIV2 = 1
+            self.ctrl_reg |= AD9834_OPBITEN
+            self.ctrl_reg &= ~AD9834_MODE
+            self.ctrl_reg |= AD9834_SIGN_PIB
+            self.ctrl_reg |= AD9834_DIV2
+
+        else:
+            # Default to high impedance if no valid mode is selected
+            self.ctrl_reg &= ~AD9834_OPBITEN
+
+        # Write the updated control register to the AD9834
+        self.write(self.ctrl_reg)
+
+    @kernel
+    def enable_triangular_waveform(self):
+        """
+        Enable triangular waveform generation.
+
+        This method configures the AD9834 to output a triangular waveform. It does so
+        by clearing the OPBITEN bit in the control register and setting the MODE bit.
+        Once this method is called, the AD9834 will begin generating a triangular waveform
+        at the frequency set for the selected frequency register.
+
+        This method should be called when a triangular waveform is desired for signal
+        generation. Ensure that the frequency is set appropriately before invoking this method.
+        """
+        self.ctrl_reg &= ~AD9834_OPBITEN
+        self.ctrl_reg |= AD9834_MODE
+        self.write(self.ctrl_reg)
+
+    @kernel
+    def disable_triangular_waveform(self):
+        """
+        Disable triangular waveform generation.
+
+        This method disables the triangular waveform output by clearing the MODE bit
+        in the control register. After invoking this method, the AD9834 will cease
+        generating a triangular waveform. The device can then be configured to output
+        other waveform types if needed.
+
+        This method should be called when switching to a different waveform type or
+        when the triangular waveform is no longer required.
+        """
+        self.ctrl_reg &= ~AD9834_MODE
+        self.write(self.ctrl_reg)
+
+    @kernel
+    def write(self, data: TInt32):
+        """
+        Write a 16-bit word to the AD9834.
+
+        This method sends a 16-bit data word to the AD9834 via the SPI bus. The input
+        data is left-shifted by 16 bits to ensure proper alignment for the SPI controller,
+        allowing for accurate processing of the command by the AD9834.
+
+        This method is used internally by other methods to update the control registers
+        and frequency settings of the AD9834. It should not be called directly unless
+        low-level register manipulation is required.
+
+        :param data: The 16-bit word to be sent to the AD9834.
+        """
+        self.bus.write(data << 16)

--- a/artiq/test/coredevice/test_ad9834.py
+++ b/artiq/test/coredevice/test_ad9834.py
@@ -1,0 +1,321 @@
+from artiq.experiment import *
+from artiq.test.hardware_testbench import ExperimentCase
+from artiq.language.units import MHz
+from artiq.coredevice.ad9834 import (
+    AD9834_B28,
+    AD9834_HLB,
+    AD9834_FSEL,
+    AD9834_PSEL,
+    AD9834_PIN_SW,
+    AD9834_RESET,
+    AD9834_SLEEP1,
+    AD9834_SLEEP12,
+    AD9834_OPBITEN,
+    AD9834_SIGN_PIB,
+    AD9834_DIV2,
+    AD9834_MODE,
+    FREQ_REGS,
+    PHASE_REGS,
+)
+
+
+class AD9834Exp(EnvExperiment):
+    def build(self, runner):
+        self.setattr_device("core")
+        self.dev = self.get_device("dds0")
+        self.runner = runner
+
+    def run(self):
+        getattr(self, self.runner)()
+
+    @kernel
+    def instantiate(self):
+        pass
+
+    @kernel
+    def init(self):
+        self.core.break_realtime()
+        self.dev.init()
+        self.set_dataset("spi_freq", self.dev.spi_freq)
+        self.set_dataset("clk_freq", self.dev.clk_freq)
+        self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
+
+    @kernel
+    def write_frequency_reg_fail1(self):
+        self.core.break_realtime()
+        frequency = 10 * MHz
+        self.dev.write_frequency_reg(19, frequency)
+
+    @kernel
+    def write_frequency_reg_fail2(self):
+        self.core.break_realtime()
+        self.dev.write_frequency_reg(FREQ_REGS[0], 37.6 * MHz)
+
+    @kernel
+    def write_frequency_reg(self):
+        self.core.break_realtime()
+        self.dev.init()
+        self.dev.write_frequency_reg(FREQ_REGS[1], 19 * MHz)
+        self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
+
+    @kernel
+    def write_frequency_reg_msb(self):
+        self.core.break_realtime()
+        self.dev.init()
+        self.dev.ctrl_reg |= AD9834_B28
+        self.dev.write_frequency_reg_msb(FREQ_REGS[0], 0x1111)
+        self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
+
+    @kernel
+    def write_frequency_reg_lsb(self):
+        self.core.break_realtime()
+        self.dev.init()
+        self.dev.ctrl_reg |= AD9834_B28 | AD9834_HLB
+        self.dev.write_frequency_reg_lsb(FREQ_REGS[1], 0xFFFF)
+        self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
+
+    @kernel
+    def select_frequency_reg_0(self):
+        self.core.break_realtime()
+        self.dev.ctrl_reg |= AD9834_FSEL | AD9834_PIN_SW
+        self.dev.select_frequency_reg(False)
+        self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
+
+    @kernel
+    def select_frequency_reg_1(self):
+        self.core.break_realtime()
+        self.dev.ctrl_reg |= AD9834_PIN_SW
+        self.dev.select_frequency_reg(True)
+        self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
+
+    @kernel
+    def write_phase_reg_fail(self):
+        self.core.break_realtime()
+        self.dev.write_phase_reg(19, 0x123)
+
+    @kernel
+    def write_phase_reg(self):
+        self.core.break_realtime()
+        self.dev.init()
+        self.dev.write_phase_reg(PHASE_REGS[0], 0x123)
+        self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
+
+    @kernel
+    def select_phase_reg_0(self):
+        self.core.break_realtime()
+        self.dev.ctrl_reg |= AD9834_PSEL | AD9834_PIN_SW
+        self.dev.select_phase_reg(False)
+        self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
+
+    @kernel
+    def select_phase_reg_1(self):
+        self.core.break_realtime()
+        self.dev.ctrl_reg |= AD9834_PIN_SW
+        self.dev.select_phase_reg(True)
+        self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
+
+    @kernel
+    def enable_reset(self):
+        self.core.break_realtime()
+        self.dev.enable_reset()
+        self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
+
+    @kernel
+    def output_enable(self):
+        self.core.break_realtime()
+        self.dev.ctrl_reg |= AD9834_RESET
+        self.dev.output_enable()
+        self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
+
+    @kernel
+    def sleep_dac_powerdown(self):
+        self.core.break_realtime()
+        self.dev.sleep(dac_pd=True)
+        self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
+
+    @kernel
+    def sleep_internal_clk_disable(self):
+        self.core.break_realtime()
+        self.dev.sleep(clk_dis=True)
+        self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
+
+    @kernel
+    def sleep(self):
+        self.core.break_realtime()
+        self.dev.sleep(dac_pd=True, clk_dis=True)
+        self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
+
+    @kernel
+    def awake(self):
+        self.core.break_realtime()
+        self.dev.ctrl_reg |= AD9834_SLEEP1 | AD9834_SLEEP12
+        self.dev.sleep()
+        self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
+
+    @kernel
+    def sign_bit_high_z(self):
+        self.core.break_realtime()
+        self.dev.ctrl_reg |= AD9834_OPBITEN
+        self.dev.config_sign_bit_out()
+        self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
+
+    @kernel
+    def sign_bit_msb_2(self):
+        self.core.break_realtime()
+        self.dev.ctrl_reg |= AD9834_MODE | AD9834_SIGN_PIB | AD9834_DIV2
+        self.dev.config_sign_bit_out(msb_2=True)
+        self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
+
+    @kernel
+    def sign_bit_msb(self):
+        self.core.break_realtime()
+        self.dev.ctrl_reg |= AD9834_MODE | AD9834_SIGN_PIB
+        self.dev.config_sign_bit_out(msb=True)
+        self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
+
+    @kernel
+    def sign_bit_comp_out(self):
+        self.core.break_realtime()
+        self.dev.ctrl_reg |= AD9834_MODE
+        self.dev.config_sign_bit_out(comp_out=True)
+        self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
+
+    @kernel
+    def enable_triangular_waveform(self):
+        self.core.break_realtime()
+        self.dev.ctrl_reg |= AD9834_OPBITEN
+        self.dev.enable_triangular_waveform()
+        self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
+
+    @kernel
+    def disable_triangular_waveform(self):
+        self.core.break_realtime()
+        self.dev.ctrl_reg |= AD9834_MODE
+        self.dev.disable_triangular_waveform()
+        self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
+
+
+class AD9834Test(ExperimentCase):
+    def test_instantiate(self):
+        self.execute(AD9834Exp, "instantiate")
+
+    def test_init(self):
+        self.execute(AD9834Exp, "init")
+        spi_freq = self.dataset_mgr.get("spi_freq")
+        clk_freq = self.dataset_mgr.get("clk_freq")
+        ctrl_reg = self.dataset_mgr.get("ctrl_reg")
+        self.assertEqual(spi_freq, 10 * MHz)
+        self.assertEqual(clk_freq, 75 * MHz)
+        self.assertEqual(ctrl_reg, 0x0000 | AD9834_RESET)
+
+    def test_write_frequency_reg_fail(self):
+        with self.assertRaises(ValueError):
+            self.execute(AD9834Exp, "write_frequency_reg_fail1")
+        with self.assertRaises(AssertionError):
+            self.execute(AD9834Exp, "write_frequency_reg_fail2")
+
+    def test_write_frequency_reg(self):
+        self.execute(AD9834Exp, "write_frequency_reg")
+        ctrl_reg = self.dataset_mgr.get("ctrl_reg")
+        self.assertEqual(ctrl_reg, 0x0000 | AD9834_RESET | AD9834_B28)
+
+    def test_write_frequency_reg_msb(self):
+        self.execute(AD9834Exp, "write_frequency_reg_msb")
+        ctrl_reg = self.dataset_mgr.get("ctrl_reg")
+        self.assertEqual(ctrl_reg, 0x0000 | AD9834_RESET | AD9834_HLB)
+
+    def test_write_frequency_reg_lsb(self):
+        self.execute(AD9834Exp, "write_frequency_reg_lsb")
+        ctrl_reg = self.dataset_mgr.get("ctrl_reg")
+        self.assertEqual(ctrl_reg, 0x0000 | AD9834_RESET)
+
+    def test_select_frequency_reg_0(self):
+        self.execute(AD9834Exp, "select_frequency_reg_0")
+        ctrl_reg = self.dataset_mgr.get("ctrl_reg")
+        self.assertEqual(ctrl_reg, 0x0000)
+
+    def test_select_frequency_reg_1(self):
+        self.execute(AD9834Exp, "select_frequency_reg_1")
+        ctrl_reg = self.dataset_mgr.get("ctrl_reg")
+        self.assertEqual(ctrl_reg, 0x0000 | AD9834_FSEL)
+
+    def test_write_phase_reg_fail(self):
+        with self.assertRaises(ValueError):
+            self.execute(AD9834Exp, "write_phase_reg_fail")
+
+    def test_write_phase_reg(self):
+        self.execute(AD9834Exp, "write_phase_reg")
+        ctrl_reg = self.dataset_mgr.get("ctrl_reg")
+        self.assertEqual(ctrl_reg, 0x0000 | AD9834_RESET)
+
+    def test_select_phase_reg_0(self):
+        self.execute(AD9834Exp, "select_phase_reg_0")
+        ctrl_reg = self.dataset_mgr.get("ctrl_reg")
+        self.assertEqual(ctrl_reg, 0x0000)
+
+    def test_select_phase_reg_1(self):
+        self.execute(AD9834Exp, "select_phase_reg_1")
+        ctrl_reg = self.dataset_mgr.get("ctrl_reg")
+        self.assertEqual(ctrl_reg, 0x0000 | AD9834_PSEL)
+
+    def test_enable_reset(self):
+        self.execute(AD9834Exp, "enable_reset")
+        ctrl_reg = self.dataset_mgr.get("ctrl_reg")
+        self.assertEqual(ctrl_reg, 0x0000 | AD9834_RESET)
+
+    def test_output_enable(self):
+        self.execute(AD9834Exp, "output_enable")
+        ctrl_reg = self.dataset_mgr.get("ctrl_reg")
+        self.assertEqual(ctrl_reg, 0x0000)
+
+    def test_sleep_dac_powerdown(self):
+        self.execute(AD9834Exp, "sleep_dac_powerdown")
+        ctrl_reg = self.dataset_mgr.get("ctrl_reg")
+        self.assertEqual(ctrl_reg, 0x0000 | AD9834_SLEEP12)
+
+    def test_sleep_internal_clk_disable(self):
+        self.execute(AD9834Exp, "sleep_internal_clk_disable")
+        ctrl_reg = self.dataset_mgr.get("ctrl_reg")
+        self.assertEqual(ctrl_reg, 0x0000 | AD9834_SLEEP1)
+
+    def test_sleep(self):
+        self.execute(AD9834Exp, "sleep")
+        ctrl_reg = self.dataset_mgr.get("ctrl_reg")
+        self.assertEqual(ctrl_reg, 0x0000 | AD9834_SLEEP1 | AD9834_SLEEP12)
+
+    def test_awake(self):
+        self.execute(AD9834Exp, "awake")
+        ctrl_reg = self.dataset_mgr.get("ctrl_reg")
+        self.assertEqual(ctrl_reg, 0x0000)
+
+    def test_sign_bit_high_z(self):
+        self.execute(AD9834Exp, "sign_bit_high_z")
+        ctrl_reg = self.dataset_mgr.get("ctrl_reg")
+        self.assertEqual(ctrl_reg, 0x0000)
+
+    def test_sign_bit_msb_2(self):
+        self.execute(AD9834Exp, "sign_bit_msb_2")
+        ctrl_reg = self.dataset_mgr.get("ctrl_reg")
+        self.assertEqual(ctrl_reg, 0x0000 | AD9834_OPBITEN)
+
+    def test_sign_bit_msb(self):
+        self.execute(AD9834Exp, "sign_bit_msb")
+        ctrl_reg = self.dataset_mgr.get("ctrl_reg")
+        self.assertEqual(ctrl_reg, 0x0000 | AD9834_OPBITEN | AD9834_DIV2)
+
+    def test_sign_bit_comp_out(self):
+        self.execute(AD9834Exp, "sign_bit_comp_out")
+        ctrl_reg = self.dataset_mgr.get("ctrl_reg")
+        self.assertEqual(
+            ctrl_reg, 0x0000 | AD9834_OPBITEN | AD9834_SIGN_PIB | AD9834_DIV2
+        )
+
+    def test_enble_triangular_waveform(self):
+        self.execute(AD9834Exp, "enable_triangular_waveform")
+        ctrl_reg = self.dataset_mgr.get("ctrl_reg")
+        self.assertEqual(ctrl_reg, 0x0000 | AD9834_MODE)
+
+    def test_disble_triangular_waveform(self):
+        self.execute(AD9834Exp, "disable_triangular_waveform")
+        ctrl_reg = self.dataset_mgr.get("ctrl_reg")
+        self.assertEqual(ctrl_reg, 0x0000)

--- a/artiq/test/coredevice/test_ad9834.py
+++ b/artiq/test/coredevice/test_ad9834.py
@@ -1,22 +1,22 @@
-from artiq.experiment import *
-from artiq.test.hardware_testbench import ExperimentCase
-from artiq.language.units import MHz
 from artiq.coredevice.ad9834 import (
     AD9834_B28,
-    AD9834_HLB,
+    AD9834_DIV2,
     AD9834_FSEL,
-    AD9834_PSEL,
+    AD9834_HLB,
+    AD9834_MODE,
+    AD9834_OPBITEN,
     AD9834_PIN_SW,
+    AD9834_PSEL,
     AD9834_RESET,
+    AD9834_SIGN_PIB,
     AD9834_SLEEP1,
     AD9834_SLEEP12,
-    AD9834_OPBITEN,
-    AD9834_SIGN_PIB,
-    AD9834_DIV2,
-    AD9834_MODE,
     FREQ_REGS,
     PHASE_REGS,
 )
+from artiq.experiment import *
+from artiq.language.units import MHz
+from artiq.test.hardware_testbench import ExperimentCase
 
 
 class AD9834Exp(EnvExperiment):

--- a/artiq/test/coredevice/test_ad9834.py
+++ b/artiq/test/coredevice/test_ad9834.py
@@ -41,77 +41,77 @@ class AD9834Exp(EnvExperiment):
         self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
 
     @kernel
-    def write_frequency_reg_fail1(self):
+    def set_frequency_reg_fail1(self):
         self.core.break_realtime()
         frequency = 10 * MHz
-        self.dev.write_frequency_reg(19, frequency)
+        self.dev.set_frequency_reg(19, frequency)
 
     @kernel
-    def write_frequency_reg_fail2(self):
+    def set_frequency_reg_fail2(self):
         self.core.break_realtime()
-        self.dev.write_frequency_reg(FREQ_REGS[0], 37.6 * MHz)
+        self.dev.set_frequency_reg(FREQ_REGS[0], 37.6 * MHz)
 
     @kernel
-    def write_frequency_reg(self):
+    def set_frequency_reg(self):
         self.core.break_realtime()
         self.dev.init()
-        self.dev.write_frequency_reg(FREQ_REGS[1], 19 * MHz)
+        self.dev.set_frequency_reg(FREQ_REGS[1], 19 * MHz)
         self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
 
     @kernel
-    def write_frequency_reg_msb(self):
+    def set_frequency_reg_msb(self):
         self.core.break_realtime()
         self.dev.init()
         self.dev.ctrl_reg |= AD9834_B28
-        self.dev.write_frequency_reg_msb(FREQ_REGS[0], 0x1111)
+        self.dev.set_frequency_reg_msb(FREQ_REGS[0], 0x1111)
         self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
 
     @kernel
-    def write_frequency_reg_lsb(self):
+    def set_frequency_reg_lsb(self):
         self.core.break_realtime()
         self.dev.init()
         self.dev.ctrl_reg |= AD9834_B28 | AD9834_HLB
-        self.dev.write_frequency_reg_lsb(FREQ_REGS[1], 0xFFFF)
+        self.dev.set_frequency_reg_lsb(FREQ_REGS[1], 0xFFFF)
         self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
 
     @kernel
     def select_frequency_reg_0(self):
         self.core.break_realtime()
         self.dev.ctrl_reg |= AD9834_FSEL | AD9834_PIN_SW
-        self.dev.select_frequency_reg(False)
+        self.dev.select_frequency_reg(FREQ_REGS[0])
         self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
 
     @kernel
     def select_frequency_reg_1(self):
         self.core.break_realtime()
         self.dev.ctrl_reg |= AD9834_PIN_SW
-        self.dev.select_frequency_reg(True)
+        self.dev.select_frequency_reg(FREQ_REGS[1])
         self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
 
     @kernel
-    def write_phase_reg_fail(self):
+    def set_phase_reg_fail(self):
         self.core.break_realtime()
-        self.dev.write_phase_reg(19, 0x123)
+        self.dev.set_phase_reg(19, 0x123)
 
     @kernel
-    def write_phase_reg(self):
+    def set_phase_reg(self):
         self.core.break_realtime()
         self.dev.init()
-        self.dev.write_phase_reg(PHASE_REGS[0], 0x123)
+        self.dev.set_phase_reg(PHASE_REGS[0], 0x123)
         self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
 
     @kernel
     def select_phase_reg_0(self):
         self.core.break_realtime()
         self.dev.ctrl_reg |= AD9834_PSEL | AD9834_PIN_SW
-        self.dev.select_phase_reg(False)
+        self.dev.select_phase_reg(PHASE_REGS[0])
         self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
 
     @kernel
     def select_phase_reg_1(self):
         self.core.break_realtime()
         self.dev.ctrl_reg |= AD9834_PIN_SW
-        self.dev.select_phase_reg(True)
+        self.dev.select_phase_reg(PHASE_REGS[1])
         self.set_dataset("ctrl_reg", self.dev.ctrl_reg)
 
     @kernel
@@ -208,24 +208,24 @@ class AD9834Test(ExperimentCase):
         self.assertEqual(clk_freq, 75 * MHz)
         self.assertEqual(ctrl_reg, 0x0000 | AD9834_RESET)
 
-    def test_write_frequency_reg_fail(self):
+    def test_set_frequency_reg_fail(self):
         with self.assertRaises(ValueError):
-            self.execute(AD9834Exp, "write_frequency_reg_fail1")
+            self.execute(AD9834Exp, "set_frequency_reg_fail1")
         with self.assertRaises(AssertionError):
-            self.execute(AD9834Exp, "write_frequency_reg_fail2")
+            self.execute(AD9834Exp, "set_frequency_reg_fail2")
 
-    def test_write_frequency_reg(self):
-        self.execute(AD9834Exp, "write_frequency_reg")
+    def test_set_frequency_reg(self):
+        self.execute(AD9834Exp, "set_frequency_reg")
         ctrl_reg = self.dataset_mgr.get("ctrl_reg")
         self.assertEqual(ctrl_reg, 0x0000 | AD9834_RESET | AD9834_B28)
 
-    def test_write_frequency_reg_msb(self):
-        self.execute(AD9834Exp, "write_frequency_reg_msb")
+    def test_set_frequency_reg_msb(self):
+        self.execute(AD9834Exp, "set_frequency_reg_msb")
         ctrl_reg = self.dataset_mgr.get("ctrl_reg")
         self.assertEqual(ctrl_reg, 0x0000 | AD9834_RESET | AD9834_HLB)
 
-    def test_write_frequency_reg_lsb(self):
-        self.execute(AD9834Exp, "write_frequency_reg_lsb")
+    def test_set_frequency_reg_lsb(self):
+        self.execute(AD9834Exp, "set_frequency_reg_lsb")
         ctrl_reg = self.dataset_mgr.get("ctrl_reg")
         self.assertEqual(ctrl_reg, 0x0000 | AD9834_RESET)
 
@@ -239,12 +239,12 @@ class AD9834Test(ExperimentCase):
         ctrl_reg = self.dataset_mgr.get("ctrl_reg")
         self.assertEqual(ctrl_reg, 0x0000 | AD9834_FSEL)
 
-    def test_write_phase_reg_fail(self):
+    def test_set_phase_reg_fail(self):
         with self.assertRaises(ValueError):
-            self.execute(AD9834Exp, "write_phase_reg_fail")
+            self.execute(AD9834Exp, "set_phase_reg_fail")
 
-    def test_write_phase_reg(self):
-        self.execute(AD9834Exp, "write_phase_reg")
+    def test_set_phase_reg(self):
+        self.execute(AD9834Exp, "set_phase_reg")
         ctrl_reg = self.dataset_mgr.get("ctrl_reg")
         self.assertEqual(ctrl_reg, 0x0000 | AD9834_RESET)
 


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

* Add core device device driver for AD9834 DDS
* Add unit test for driver

This was tested on a Zonri AD9834 DDS board using experiements and the HIL unit tests.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |


## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
