### PR TITLE
doc: Fix some typos

### DIFF
--- a/artiq/coredevice/ad9910.py
+++ b/artiq/coredevice/ad9910.py
@@ -195,7 +195,7 @@ class AD9910:
           when changing frequency or phase. The DDS phase is the sum of the
           phase accumulator and the phase offset. The only discontinuous
           changes in the DDS output phase come from changes to the phase
-          offset. This mode is also knows as "relative phase mode".
+          offset. This mode is also known as "relative phase mode".
           :math:`\phi(t) = q(t^\prime) + p + (t - t^\prime) f`
 
         * :const:`PHASE_MODE_ABSOLUTE`: the phase accumulator is reset when

--- a/artiq/coredevice/suservo.py
+++ b/artiq/coredevice/suservo.py
@@ -489,7 +489,7 @@ class Channel:
     def get_y_mu(self, profile):
         """Get a profile's IIR state (filter output, Y0) in machine units.
 
-        The IIR state is also know as the "integrator", or the DDS amplitude
+        The IIR state is also known as the "integrator", or the DDS amplitude
         scale factor. It is 17 bits wide and unsigned.
 
         This method does not advance the timeline but consumes all slack.
@@ -507,7 +507,7 @@ class Channel:
     def get_y(self, profile):
         """Get a profile's IIR state (filter output, Y0).
 
-        The IIR state is also know as the "integrator", or the DDS amplitude
+        The IIR state is also known as the "integrator", or the DDS amplitude
         scale factor. It is 17 bits wide and unsigned.
 
         This method does not advance the timeline but consumes all slack.
@@ -525,7 +525,7 @@ class Channel:
     def set_y_mu(self, profile, y):
         """Set a profile's IIR state (filter output, Y0) in machine units.
 
-        The IIR state is also know as the "integrator", or the DDS amplitude
+        The IIR state is also known as the "integrator", or the DDS amplitude
         scale factor. It is 17 bits wide and unsigned.
 
         This method must not be used when the servo could be writing to the
@@ -545,7 +545,7 @@ class Channel:
     def set_y(self, profile, y):
         """Set a profile's IIR state (filter output, Y0).
 
-        The IIR state is also know as the "integrator", or the DDS amplitude
+        The IIR state is also known as the "integrator", or the DDS amplitude
         scale factor. It is 17 bits wide and unsigned.
 
         This method must not be used when the servo could be writing to the

--- a/artiq/gui/applets.py
+++ b/artiq/gui/applets.py
@@ -398,7 +398,7 @@ class _CompleterDelegate(QtWidgets.QStyledItemDelegate):
             # case, but causes unnecessary flickering and trashing of the user
             # selection when datasets are modified due to Qt's naive handler.
             # Doing this is of course convoluted due to Qt's arrogance
-            # about private fields and not letting users knows what
+            # about private fields and not letting users know what
             # slots are connected to signals, but thanks to the complicated
             # model system there is a short dirty hack in this particular case.
             nodatachanged_model = QtCore.QIdentityProxyModel()


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Fix some typos I found.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Documentation Changes

- [x] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`nix build .#artiq-manual-html; nix build .#artiq-manual-pdf`) to ensure no errors.

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
