### PR TITLE
NAC3: Pass return value from kernel to host

### DIFF
--- a/artiq/coredevice/comm_kernel.py
+++ b/artiq/coredevice/comm_kernel.py
@@ -689,7 +689,12 @@ class CommKernel:
 
         if service_id == 0:
             def service(*values):
-                counter = 0
+                if embedding_map.expects_return:
+                    embedding_map.return_value = values[0]
+                    counter = 1
+                else:
+                    counter = 0
+
                 for obj in embedding_map.attributes_writeback:
                     old_val = obj["obj"]
                     if "fields" in obj:

--- a/artiq/coredevice/core.py
+++ b/artiq/coredevice/core.py
@@ -123,6 +123,10 @@ class Core:
 
         self._run_compiled(kernel_library, embedding_map)
 
+        # set by NAC3
+        if embedding_map.expects_return:
+            return embedding_map.return_value
+
     def _run_compiled(self, kernel_library, embedding_map):
         if self.first_run:
             self.comm.check_system_info()

--- a/artiq/test/coredevice/test_embedding.py
+++ b/artiq/test/coredevice/test_embedding.py
@@ -323,7 +323,6 @@ class _Annotation(EnvExperiment):
     def build(self):
         self.setattr_device("core")
 
-    # NAC3TODO https://git.m-labs.hk/M-Labs/nac3/issues/101
     @kernel
     def overflow(self, x: int64) -> bool:
         return (x << 32) != int64(0)
@@ -334,7 +333,6 @@ class _Annotation(EnvExperiment):
 
 
 class AnnotationTest(ExperimentCase):
-    @unittest.skip("NAC3TODO https://git.m-labs.hk/M-Labs/nac3/issues/101")
     def test_annotation(self):
         exp = self.create(_Annotation)
         self.assertEqual(exp.overflow(int64(1)), True)


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
In [NAC3 552](https://git.m-labs.hk/M-Labs/nac3/pulls/552), the return value is sent to the host via the service 0 RPC.
The return value (and its existence) are captured by the `embedding_map` in this PR, and sent back to the host after the kernel has finished.

These changes pass the annotation test.

Note: The legacy compiler makes use of a local RPC function to write back the return value, instead of going through the `embedding_map` and service 0 (for `attributes_writeback`).

### Related Issue
[NAC3 101](https://git.m-labs.hk/M-Labs/nac3/issues/101)

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
