### PR TITLE
Cherry-pick pygit2 fix from master onto release-8

### DIFF
--- a/artiq/master/experiments.py
+++ b/artiq/master/experiments.py
@@ -206,10 +206,9 @@ class GitBackend:
         a git hash
         """
         commit, _ = self.git.resolve_refish(rev)
-
-        logger.debug('Resolved git ref "%s" into "%s"', rev, commit.hex)
-
-        return commit.hex
+        commit_id = str(commit.id)
+        logger.debug('Resolved git ref "%s" into "%s"', rev, commit_id)
+        return commit_id
 
     def request_rev(self, rev):
         rev = self._get_pinned_rev(rev)


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Fix (replace) use of deprecated pygit2 `hex` attribute.

This was already done on master, in fbb1a2c25de67225ad1e58adc18569571657f4ed, so this just cherry-picks that commit onto the `release-8` branch (so that deployments using the release branch can get it).

### Related Issue

I couldn't find a GH issue for the original fix.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |