### PR TITLE
NAC3: inject fake module for experiments submitted by content

### DIFF
--- a/artiq/coredevice/core.py
+++ b/artiq/coredevice/core.py
@@ -102,7 +102,11 @@ class Core:
             raise NotImplementedError
 
         if not self.analyzed:
-            self.compiler.analyze(core_language._registered_functions, core_language._registered_classes)
+            self.compiler.analyze(
+                core_language._registered_functions,
+                core_language._registered_classes,
+                core_language._registered_modules
+            )
             self.analyzed = True
 
         if hasattr(method, "__self__"):

--- a/artiq/language/core.py
+++ b/artiq/language/core.py
@@ -56,6 +56,7 @@ def ceil64(x):
 # Delay NAC3 analysis until all referenced variables are supposed to exist on the CPython side.
 _registered_functions = set()
 _registered_classes = set()
+_registered_modules = set()
 
 def _register_function(fun):
     import_cache.add_module_to_cache(getmodule(fun))
@@ -64,6 +65,11 @@ def _register_function(fun):
 def _register_class(cls):
     import_cache.add_module_to_cache(getmodule(cls))
     _registered_classes.add(cls)
+
+def register_content_module(module):
+    # for kernels sent by content, they have no modules
+    # thus their source must be analyzed instead
+    _registered_modules.add(module)
 
 
 def extern(function):

--- a/artiq/master/worker_impl.py
+++ b/artiq/master/worker_impl.py
@@ -30,7 +30,9 @@ from artiq.master.worker_db import DeviceManager, DatasetManager, DummyDevice
 from artiq.language.environment import (
     is_public_experiment, TraceArgumentManager, ProcessArgumentManager
 )
-from artiq.language.core import set_watchdog_factory, TerminationRequested
+from artiq.language.core import (
+    register_content_module, set_watchdog_factory, TerminationRequested
+)
 from artiq.language import import_cache
 from artiq import __version__ as artiq_version
 
@@ -166,6 +168,7 @@ def get_experiment_from_content(content, class_name):
         StringLoader(fake_filename, content)
     )
     module = importlib.util.module_from_spec(spec)
+    register_content_module(module)
     spec.loader.exec_module(module)
     linecache.lazycache(fake_filename, module.__dict__)
     return tools.get_experiment(module, class_name)


### PR DESCRIPTION
Q Pull Request

## Description of Changes

NAC3 expects every function and class to be in a module which has a file. Kernels submitted by content do not have a file, but their source still needs to be sent to the compiler; so the fake module ``StringLoader`` is passed to the compiler.

Tested with a Kasli, by submitting kernels with artiq_client, with and without ``--content`` option.

Requires changes on the NAC3 side too.

### Related Issue

Closes nac3#223

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
