### PR TITLE
satman: replace forward with send for InjectionRequest

### DIFF
--- a/artiq/firmware/satman/repeater.rs
+++ b/artiq/firmware/satman/repeater.rs
@@ -12,7 +12,7 @@ fn rep_link_rx_up(repno: u8) -> bool {
 
 #[cfg(has_drtio_routing)]
 #[derive(Clone, Copy, PartialEq)]
-enum RepeaterState {
+pub enum RepeaterState {
     Down,
     SendPing { ping_count: u16 },
     WaitPingReply { ping_count: u16, timeout: u64 },
@@ -29,8 +29,8 @@ impl Default for RepeaterState {
 #[derive(Clone, Copy, Default)]
 pub struct Repeater {
     repno: u8,
-    auxno: u8,
-    state: RepeaterState
+    pub auxno: u8,
+    pub state: RepeaterState
 }
 
 #[cfg(has_drtio_routing)]


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

For `release-7` only.

`InjectionRequest` should not wait for response when forwarded to the next satellite. 

In `release-8` this is already handled by `expects_response` #2628.

See corresponding PR in artiq-zynq. https://git.m-labs.hk/M-Labs/artiq-zynq/pulls/343
## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.
Tested with kasli-soc as core device and daisy chained kasli v2 -> kasli-soc. Also tested kasli-soc -> kasli-soc -> kasli v2 for the corresponding PR in artiq-zynq. Injections can now be made to the third satellite.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
