### PR TITLE
flake: clean up devShells

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -423,52 +423,66 @@
 
       defaultPackage.x86_64-linux = pkgs.python3.withPackages(ps: [ packages.x86_64-linux.artiq ]);
 
-      # Main development shell with everything you need to develop ARTIQ on Linux.
-      # The current copy of the ARTIQ sources is added to PYTHONPATH so changes can be tested instantly.
-      # Additionally, executable wrappers that import the current ARTIQ sources for the ARTIQ frontends
-      # are added to PATH.
-      devShells.x86_64-linux.default = pkgs.mkShell {
-        name = "artiq-dev-shell";
-        buildInputs = [
-          (pkgs.python3.withPackages(ps: with packages.x86_64-linux; [ migen misoc ps.paramiko microscope ps.packaging ] ++ artiq.propagatedBuildInputs ))
-          rust
-          pkgs.llvmPackages_15.clang-unwrapped
-          pkgs.llvm_15
-          pkgs.lld_15
-          pkgs.git
-          artiq-frontend-dev-wrappers
-          # To manually run compiler tests:
-          pkgs.lit
-          pkgs.outputcheck
-          libartiq-support
-          # use the vivado-env command to enter a FHS shell that lets you run the Vivado installer
-          packages.x86_64-linux.vivadoEnv
-          packages.x86_64-linux.vivado
-          packages.x86_64-linux.openocd-bscanspi
-          pkgs.python3Packages.sphinx pkgs.python3Packages.sphinx_rtd_theme pkgs.pdf2svg
-          pkgs.python3Packages.sphinx-argparse pkgs.python3Packages.sphinxcontrib-wavedrom latex-artiq-manual
-          pkgs.python3Packages.sphinxcontrib-tikz
-        ];
-        shellHook = ''
-          export LIBARTIQ_SUPPORT=`libartiq-support`
-          export QT_PLUGIN_PATH=${qtPaths.QT_PLUGIN_PATH}
-          export QML2_IMPORT_PATH=${qtPaths.QML2_IMPORT_PATH}
-          export PYTHONPATH=`git rev-parse --show-toplevel`:$PYTHONPATH
-        '';
-      };
+      devShells.x86_64-linux = {
+        # Main development shell with everything you need to develop ARTIQ on Linux.
+        # The current copy of the ARTIQ sources is added to PYTHONPATH so changes can be tested instantly.
+        # Additionally, executable wrappers that import the current ARTIQ sources for the ARTIQ frontends
+        # are added to PATH.
+        default = pkgs.mkShell {
+          name = "artiq-dev-shell";
+          packages = with pkgs; [
+            git
+            lit
+            lld_15
+            llvm_15
+            llvmPackages_15.clang-unwrapped
+            outputcheck
+            pdf2svg
 
-      # Lighter development shell optimized for building firmware and flashing boards.
-      devShells.x86_64-linux.boards = pkgs.mkShell {
-        name = "artiq-boards-shell";
-        buildInputs = [
-          (pkgs.python3.withPackages(ps: with packages.x86_64-linux; [ migen misoc artiq ps.packaging ps.paramiko ]))
-          rust
-          pkgs.llvmPackages_15.clang-unwrapped
-          pkgs.llvm_15
-          pkgs.lld_15
-          packages.x86_64-linux.vivado
-          packages.x86_64-linux.openocd-bscanspi
-        ];
+            python3Packages.sphinx
+            python3Packages.sphinx-argparse
+            python3Packages.sphinxcontrib-tikz
+            python3Packages.sphinxcontrib-wavedrom 
+            python3Packages.sphinx_rtd_theme
+
+            (python3.withPackages(ps: [ migen misoc microscope ps.packaging ps.paramiko ] ++ artiq.propagatedBuildInputs ))
+          ] ++ 
+          [
+            latex-artiq-manual
+            rust
+            artiq-frontend-dev-wrappers
+
+            # To manually run compiler tests:
+            libartiq-support
+
+            # use the vivado-env command to enter a FHS shell that lets you run the Vivado installer
+            packages.x86_64-linux.vivadoEnv
+            packages.x86_64-linux.vivado
+            packages.x86_64-linux.openocd-bscanspi
+          ];
+          shellHook = ''
+            export LIBARTIQ_SUPPORT=`libartiq-support`
+            export QT_PLUGIN_PATH=${qtPaths.QT_PLUGIN_PATH}
+            export QML2_IMPORT_PATH=${qtPaths.QML2_IMPORT_PATH}
+            export PYTHONPATH=`git rev-parse --show-toplevel`:$PYTHONPATH
+          '';
+        };
+        # Lighter development shell optimized for building firmware and flashing boards.
+        boards = pkgs.mkShell {
+          name = "artiq-boards-shell";
+          packages = [
+            rust
+
+            pkgs.llvmPackages_15.clang-unwrapped
+            pkgs.llvm_15
+            pkgs.lld_15
+
+            packages.x86_64-linux.vivado
+            packages.x86_64-linux.openocd-bscanspi
+
+            (pkgs.python3.withPackages(ps:  [ migen misoc artiq ps.packaging ps.paramiko ]))
+          ];
+        };
       };
 
       packages.aarch64-linux = {


### PR DESCRIPTION
Move both devShells into devshells.<...>,
packages should be used in shells, as the logical difference between nativeBuildInputs and buildInputs no longer applies.

can't really test since I don't have vivado installed, it should *just work* however.

<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [ ] Close/update issues.
- [ ] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes


- [ ] Test your changes or have someone test them. Mention what was tested and how.

