### PR TITLE
flake: move defaultPackage.<system> to packages.<system>.default

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -421,7 +421,7 @@
 
       inherit qtPaths makeArtiqBoardPackage openocd-bscanspi-f;
 
-      defaultPackage.x86_64-linux = pkgs.python3.withPackages(ps: [ packages.x86_64-linux.artiq ]);
+      packages.x86_64-linux.default = pkgs.python3.withPackages(_: [ packages.x86_64-linux.artiq ]);
 
       # Main development shell with everything you need to develop ARTIQ on Linux.
       # The current copy of the ARTIQ sources is added to PYTHONPATH so changes can be tested instantly.


### PR DESCRIPTION
change [deprecated](https://github.com/NixOS/nix/issues/5532) defaultPackage.x86_64-linux to
packages.x86_64-linux.default,
remove unneeded ``ps`` since it's not being used. 

Tested using `nix build`

<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
### Code Changes

- [ X] Test your changes or have someone test them. Mention what was tested and how.

