### PR TITLE
NAC3: Synchronize embedding map by the internal string store

### DIFF
--- a/artiq/firmware/ksupport/eh_artiq.rs
+++ b/artiq/firmware/ksupport/eh_artiq.rs
@@ -328,7 +328,7 @@ extern fn stop_fn(_version: c_int,
     }
 }
 
-// Must be kept in sync with `artiq.language.embedding_map`
+// Must be kept in sync with `nac3artiq::Nac3::new`
 static EXCEPTION_ID_LOOKUP: [(&str, u32); 22] = [
     ("RTIOUnderflow", 0),
     ("RTIOOverflow", 1),

--- a/artiq/language/embedding_map.py
+++ b/artiq/language/embedding_map.py
@@ -7,42 +7,6 @@ class EmbeddingMap:
         self.function_map = {}
         self.attributes_writeback = []
 
-        # Keep this list of exceptions in sync with `EXCEPTION_ID_LOOKUP` in `artiq::firmware::ksupport::eh_artiq`
-        # The exceptions declared here must be defined in `artiq.coredevice.exceptions`
-        # Verify synchronization by running the test cases in `artiq.test.coredevice.test_exceptions`
-        self.preallocate_runtime_exception_names([
-            "RTIOUnderflow",
-            "RTIOOverflow",
-            "RTIODestinationUnreachable",
-            "DMAError",
-            "I2CError",
-            "CacheError",
-            "SPIError",
-            "SubkernelError",
-
-            "0:AssertionError",
-            "0:AttributeError",
-            "0:IndexError",
-            "0:IOError",
-            "0:KeyError",
-            "0:NotImplementedError",
-            "0:OverflowError",
-            "0:RuntimeError",
-            "0:TimeoutError",
-            "0:TypeError",
-            "0:ValueError",
-            "0:ZeroDivisionError",
-            "0:LinAlgError",
-            "UnwrapNoneError",
-        ])
-
-    def preallocate_runtime_exception_names(self, names):
-        for i, name in enumerate(names):
-            if ":" not in name:
-                name = "0:artiq.coredevice.exceptions." + name
-            exn_id = self.store_str(name)
-            assert exn_id == i
-
     def store_function(self, key, fun):
         self.function_map[key] = fun
         return key


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
The complementary patch for the NAC3 PR. See the [NAC3 PR 558](https://git.m-labs.hk/M-Labs/nac3/pulls/558).

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
