### PR TITLE
Add current directory to the module search paths for frontend tools

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -200,7 +200,7 @@
       ## Modifies PATH to pass the wrapped python environment (i.e. python3.withPackages(...) to subprocesses.
       ## Allows subprocesses using python to find all packages you have installed
       makeWrapperArgs = [
-        ''--run 'if [ ! -z "$NIX_PYTHONPREFIX" ]; then export PATH=$NIX_PYTHONPREFIX/bin:$PATH;fi' ''
+        ''--run 'if [ ! -z "$NIX_PYTHONPREFIX" ]; then export PYTHONPATH=`pwd`:$PYTHONPATH; export PATH=$NIX_PYTHONPREFIX/bin:$PATH;fi' ''
         "--set FONTCONFIG_FILE ${pkgs.fontconfig.out}/etc/fonts/fonts.conf"
       ];
 
@@ -390,7 +390,7 @@
             progname=`basename -s .py $program`
             outname=$out/bin/$progname
             echo "#!${pkgs.bash}/bin/bash" >> $outname
-            echo "PYTHONPATH=`pwd`:$PYTHONPATH exec python3 -m artiq.frontend.$progname \"\$@\"" >> $outname
+            echo "exec python3 -m artiq.frontend.$progname \"\$@\"" >> $outname
             chmod 755 $outname
           fi
         done

--- a/flake.nix
+++ b/flake.nix
@@ -390,7 +390,7 @@
             progname=`basename -s .py $program`
             outname=$out/bin/$progname
             echo "#!${pkgs.bash}/bin/bash" >> $outname
-            echo "exec python3 -m artiq.frontend.$progname \"\$@\"" >> $outname
+            echo "PYTHONPATH=`pwd`:$PYTHONPATH exec python3 -m artiq.frontend.$progname \"\$@\"" >> $outname
             chmod 755 $outname
           fi
         done


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

### Related Issue

#2309 (doesn't close but helps)

### How to reproduce

Install ARTIQ as a system package in NixOS (like in https://git.m-labs.hk/M-Labs/defenestrate), apply workaround described in https://github.com/m-labs/artiq/issues/2309#issuecomment-2342652475 , and before this patch it will produce "ModuleNotFoundError", after this patch it will work fine - same as if the ARTIQ would be entered by nix develop/shell.

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
