### PR TITLE
coreanalyzer: enlarge thread stack

### DIFF
--- a/artiq/firmware/runtime/main.rs
+++ b/artiq/firmware/runtime/main.rs
@@ -240,7 +240,7 @@ fn startup() {
         let subkernel_mutex = subkernel_mutex.clone();
         let drtio_routing_table = drtio_routing_table.clone();
         let up_destinations = up_destinations.clone();
-        io.spawn(8192, move |io| { analyzer::thread(io, &aux_mutex, &ddma_mutex, &subkernel_mutex, &drtio_routing_table, &up_destinations) });
+        io.spawn(16384, move |io| { analyzer::thread(io, &aux_mutex, &ddma_mutex, &subkernel_mutex, &drtio_routing_table, &up_destinations) });
     }
 
     #[cfg(has_grabber)]


### PR DESCRIPTION
# ARTIQ Pull Request

## Issue
Using `artiq_coreanalyzer` on DRTIO device with connected satellites may cause panic:
```
Trap frame: TrapFrame { ra: 4000a290, t0: 4, t1: 5b4, t2: 0, t3: 147b, t4: 5f5e0ff, t5: 401069bc, t6: 36, a0: 4000, a1: d0000000, a2: 4000a770, a3: 40104220, a4: 0, a5: 1, a6: 0, a7: 40298000 }
@ 0x4000a2c8
+0000: 00b12823 00155513 00a12a23 00012c23
+0010: 00060067 40010c23 60d0006f 0014c483
+0020: 0e100513 5e10006f 0014ca03 0024c983
+0030: 3f64d903 00348593 02010513 3f200613
panic at runtime/main.rs:357:13: exception StoreFault at PC 0x4000a2c8, trap value 0x40298fd0
backtrace for software version 9.0+unknown.beta;bare_master:
0x40064674
0x40012c90
0x40063bdc
halting.
use `artiq_coremgmt config write -s panic_reset 1` to restart instead
```

The analyzer thread had triggered the stack guard. Bringing the stack size on par with other DRTIO enabled threads (`coremgmt` for example) would avoid the problem.

## Test
Tested with a Kasli master and Kasli-SoC satellite. `artiq_coreanalyzer -p` gives the following output after patch:
```
Log channel: 3
DDS one-hot: True
StoppedMessage(rtio_counter=361230647768)
StoppedMessage(rtio_counter=361236611888)
```
`artiq_coreanalyzer` terminated gracefully.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
