### PR TITLE
doc: Warning on Urukul cycle alignment in DMA

### DIFF
--- a/artiq/coredevice/ad9910.py
+++ b/artiq/coredevice/ad9910.py
@@ -534,8 +534,16 @@ class AD9910:
         After the SPI transfer, the shared IO update pin is pulsed to
         activate the data.
 
-        .. seealso: :meth:`AD9910.set_phase_mode` for a definition of the different
+        .. seealso:: :meth:`AD9910.set_phase_mode` for a definition of the different
             phase modes.
+
+        .. warning::
+            Deterministic phase control depends on correct alignment of operations
+            to a 4ns grid (``SYNC_CLK``). This function uses :meth:`~artiq.language.core.now_mu()`
+            to ensure such alignment automatically. When replayed over DMA, however, the ensuing
+            event sequence *must* be started at the same offset relative to ``SYNC_CLK``, or
+            unstable ``SYNC_CLK`` cycle assignment (i.e. inconsistent delays of exactly 4ns) will
+            result.
 
         :param ftw: Frequency tuning word: 32-bit.
         :param pow_: Phase tuning word: 16-bit unsigned.


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Closes #2646 by adding warning in replies to AD9910 driver documentation. 

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Close/update issues.

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
