### PR TITLE
DRTIO: Resolve remote RTIO channel names using the global RTIO channel number

### DIFF
--- a/artiq/firmware/runtime/rtio_mgt.rs
+++ b/artiq/firmware/runtime/rtio_mgt.rs
@@ -369,15 +369,18 @@ pub mod drtio {
                                 }
                                 drtioaux::Packet::DestinationOkReply => (),
                                 drtioaux::Packet::DestinationSequenceErrorReply { channel } => {
-                                    error!("[DEST#{}] RTIO sequence error involving channel 0x{:04x}:{}", destination, channel, resolve_channel_name(channel as u32));
+                                    let global_ch = ((destination as u32) << 16) | channel as u32;
+                                    error!("[DEST#{}] RTIO sequence error involving channel 0x{:04x}:{}", destination, channel, resolve_channel_name(global_ch));
                                     unsafe { SEEN_ASYNC_ERRORS |= ASYNC_ERROR_SEQUENCE_ERROR };
                                 }
                                 drtioaux::Packet::DestinationCollisionReply { channel } => {
-                                    error!("[DEST#{}] RTIO collision involving channel 0x{:04x}:{}", destination, channel, resolve_channel_name(channel as u32));
+                                    let global_ch = ((destination as u32) << 16) | channel as u32;
+                                    error!("[DEST#{}] RTIO collision involving channel 0x{:04x}:{}", destination, channel, resolve_channel_name(global_ch));
                                     unsafe { SEEN_ASYNC_ERRORS |= ASYNC_ERROR_COLLISION };
                                 }
                                 drtioaux::Packet::DestinationBusyReply { channel } => {
-                                    error!("[DEST#{}] RTIO busy error involving channel 0x{:04x}:{}", destination, channel, resolve_channel_name(channel as u32));
+                                    let global_ch = ((destination as u32) << 16) | channel as u32;
+                                    error!("[DEST#{}] RTIO busy error involving channel 0x{:04x}:{}", destination, channel, resolve_channel_name(global_ch));
                                     unsafe { SEEN_ASYNC_ERRORS |= ASYNC_ERROR_BUSY };
                                 }
                                 packet => error!("[DEST#{}] received unexpected aux packet: {:?}", destination, packet),


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
When given a remote RTIO error, runtime now resolves RTIO channel name with consideration of the remote destination number.

### Related Issue
See https://forum.m-labs.hk/d/878-upload-device-map-to-satellites.

The new error message form runtime reports this:
`[    13.937600s] ERROR(runtime::rtio_mgt::drtio): [DEST#1] RTIO collision involving channel 0x0001:fastino1`

Note that the reported channel number is still the local RTIO channel number.


## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
