### PR TITLE
compiler: fix TList[TBool] inferred as TList[TInt32] in embedding

### DIFF
--- a/artiq/compiler/embedding.py
+++ b/artiq/compiler/embedding.py
@@ -310,7 +310,9 @@ class ASTSynthesizer:
         if len(value) > 0:
             v = value[0]
             is_T = True
-            if isinstance(v, int):
+            if isinstance(v, bool):
+                is_T = False
+            elif isinstance(v, int):
                 T = int
             elif isinstance(v, float):
                 T = float


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

See discussion in #2652. 

### Related Issue

#2652 

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps

### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Close/update issues.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.

The following minimal example can be used to verify the behavior.
```python
from artiq.experiment import *

def get_type(obj) -> TStr:
    return str(type(obj))

class TestBoolList(EnvExperiment):
    def build(self):
        self.setattr_device("core")
        self.x = [True]

    @kernel
    def run(self):
        print(get_type(self.x[0]))

```
Output before: `<class='numpy.int32'>`
Output after: `<class='bool'>`. 

Unit tests:
`test_embedding` and `test_performance` both pass on a Kasli-SoC.

- [x] Add and check docstrings and comments

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
