### PR TITLE
Urukul: Update artiq.coredevice.urukul and artiq.coredevice.ad9910 for new Urukul capabilities

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -25,6 +25,15 @@ ARTIQ-9 (Unreleased)
 * Support for coredevice reflashing through the new ``flash`` tool in ``artiq_coremgmt``.
 * ``artiq_coremgmt`` now supports configuring satellites.
 * ``artiq.coredevice.fmcdio_vhdci_eem`` has been removed.
+* ``artiq.coredevice.urukul`` and ``artiq.coredevice.ad9910`` have been updated for new Urukul capabilities:
+   - Digital Ramp Generation (DRG)
+   - Individual DDS Channel control:
+      * PROFILE
+      * IO_UPDATE
+      * OSK
+      * DRCTRL
+      * DRHOLD
+      * ATT_EN
 
 ARTIQ-8
 -------

--- a/artiq/coredevice/ad9910.py
+++ b/artiq/coredevice/ad9910.py
@@ -13,18 +13,10 @@ urukul_sta_smp_err = urukul.urukul_sta_smp_err
 
 __all__ = [
     "AD9910",
-    "PHASE_MODE_CONTINUOUS",
-    "PHASE_MODE_ABSOLUTE",
-    "PHASE_MODE_TRACKING",
-    "RAM_DEST_FTW",
-    "RAM_DEST_POW",
-    "RAM_DEST_ASF",
-    "RAM_DEST_POWASF",
-    "RAM_MODE_DIRECTSWITCH",
-    "RAM_MODE_RAMPUP",
-    "RAM_MODE_BIDIR_RAMP",
-    "RAM_MODE_CONT_BIDIR_RAMP",
-    "RAM_MODE_CONT_RAMPUP",
+    "PHASE_MODE_CONTINUOUS", "PHASE_MODE_ABSOLUTE", "PHASE_MODE_TRACKING",
+    "RAM_DEST_FTW", "RAM_DEST_POW", "RAM_DEST_ASF", "RAM_DEST_POWASF",
+    "RAM_MODE_DIRECTSWITCH", "RAM_MODE_RAMPUP", "RAM_MODE_BIDIR_RAMP",
+    "RAM_MODE_CONT_BIDIR_RAMP", "RAM_MODE_CONT_RAMPUP",    
 ]
 
 _PHASE_MODE_DEFAULT = -1
@@ -144,33 +136,13 @@ class AD9910:
         to the same string value.
     """
 
-    def __init__(
-        self,
-        dmgr,
-        chip_select,
-        cpld_device,
-        sw_device=None,
-        pll_n=40,
-        pll_cp=7,
-        pll_vco=5,
-        sync_delay_seed=-1,
-        io_update_delay=0,
-        pll_en=1,
-    ):
-        self.kernel_invariants = {
-            "cpld",
-            "core",
-            "bus",
-            "chip_select",
-            "pll_en",
-            "pll_n",
-            "pll_vco",
-            "pll_cp",
-            "ftw_per_hz",
-            "sysclk_per_mu",
-            "sysclk",
-            "sync_data",
-        }
+    def __init__(self, dmgr, chip_select, cpld_device, sw_device=None,
+                 pll_n=40, pll_cp=7, pll_vco=5, sync_delay_seed=-1,
+                 io_update_delay=0, pll_en=1):
+        self.kernel_invariants = {"cpld", "core", "bus", "chip_select",
+                                  "pll_en", "pll_n", "pll_vco", "pll_cp",
+                                  "ftw_per_hz", "sysclk_per_mu", "sysclk",
+                                  "sync_data"}
         self.cpld = dmgr.get(cpld_device)
         self.core = self.cpld.core
         self.bus = self.cpld.bus
@@ -189,14 +161,8 @@ class AD9910:
             assert clk <= 60e6
             assert 12 <= pll_n <= 127
             assert 0 <= pll_vco <= 5
-            vco_min, vco_max = [
-                (370, 510),
-                (420, 590),
-                (500, 700),
-                (600, 880),
-                (700, 950),
-                (820, 1150),
-            ][pll_vco]
+            vco_min, vco_max = [(370, 510), (420, 590), (500, 700),
+                                (600, 880), (700, 950), (820, 1150)][pll_vco]            
             assert vco_min <= sysclk / 1e6 <= vco_max
             assert 0 <= pll_cp <= 7
         else:
@@ -211,13 +177,12 @@ class AD9910:
 
         if isinstance(sync_delay_seed, str) or isinstance(io_update_delay, str):
             if sync_delay_seed != io_update_delay:
-                raise ValueError(
-                    "When using EEPROM, sync_delay_seed must be "
-                    "equal to io_update_delay"
-                )
+                raise ValueError("When using EEPROM, sync_delay_seed must be "
+                                 "equal to io_update_delay")                
             self.sync_data = SyncDataEeprom(dmgr, self.core, sync_delay_seed)
         else:
-            self.sync_data = SyncDataUser(self.core, sync_delay_seed, io_update_delay)
+            self.sync_data = SyncDataUser(self.core, sync_delay_seed,
+                                          io_update_delay)
 
         self.phase_mode = PHASE_MODE_CONTINUOUS
 
@@ -271,10 +236,9 @@ class AD9910:
         :param addr: Register address
         :param data: Data to be written
         """
-        self.bus.set_config_mu(
-            urukul.SPI_CONFIG | spi.SPI_END, 24, urukul.SPIT_DDS_WR, self.chip_select
-        )
-        self.bus.write((addr << 24) | ((data & 0xFFFF) << 8))
+        self.bus.set_config_mu(urukul.SPI_CONFIG | spi.SPI_END, 24,
+                               urukul.SPIT_DDS_WR, self.chip_select)
+        self.bus.write((addr << 24) | ((data & 0xFFFF) << 8))        
 
     @kernel
     def write32(self, addr: TInt32, data: TInt32):
@@ -283,13 +247,11 @@ class AD9910:
         :param addr: Register address
         :param data: Data to be written
         """
-        self.bus.set_config_mu(
-            urukul.SPI_CONFIG, 8, urukul.SPIT_DDS_WR, self.chip_select
-        )
+        self.bus.set_config_mu(urukul.SPI_CONFIG, 8,
+                               urukul.SPIT_DDS_WR, self.chip_select)        
         self.bus.write(addr << 24)
-        self.bus.set_config_mu(
-            urukul.SPI_CONFIG | spi.SPI_END, 32, urukul.SPIT_DDS_WR, self.chip_select
-        )
+        self.bus.set_config_mu(urukul.SPI_CONFIG | spi.SPI_END, 32,
+                               urukul.SPIT_DDS_WR, self.chip_select)        
         self.bus.write(data)
 
     @kernel
@@ -298,16 +260,12 @@ class AD9910:
 
         :param addr: Register address
         """
-        self.bus.set_config_mu(
-            urukul.SPI_CONFIG, 8, urukul.SPIT_DDS_WR, self.chip_select
-        )
+        self.bus.set_config_mu(urukul.SPI_CONFIG, 8,
+                               urukul.SPIT_DDS_WR, self.chip_select)        
         self.bus.write((addr | 0x80) << 24)
         self.bus.set_config_mu(
             urukul.SPI_CONFIG | spi.SPI_END | spi.SPI_INPUT,
-            16,
-            urukul.SPIT_DDS_RD,
-            self.chip_select,
-        )
+            16, urukul.SPIT_DDS_RD, self.chip_select)            
         self.bus.write(0)
         return self.bus.read()
 
@@ -317,16 +275,12 @@ class AD9910:
 
         :param addr: Register address
         """
-        self.bus.set_config_mu(
-            urukul.SPI_CONFIG, 8, urukul.SPIT_DDS_WR, self.chip_select
-        )
+        self.bus.set_config_mu(urukul.SPI_CONFIG, 8,
+                               urukul.SPIT_DDS_WR, self.chip_select)        
         self.bus.write((addr | 0x80) << 24)
         self.bus.set_config_mu(
             urukul.SPI_CONFIG | spi.SPI_END | spi.SPI_INPUT,
-            32,
-            urukul.SPIT_DDS_RD,
-            self.chip_select,
-        )
+            32, urukul.SPIT_DDS_RD, self.chip_select)
         self.bus.write(0)
         return self.bus.read()
 
@@ -338,19 +292,16 @@ class AD9910:
         :return: 64-bit integer register value
         """
         self.bus.set_config_mu(
-            urukul.SPI_CONFIG, 8, urukul.SPIT_DDS_WR, self.chip_select
-        )
+            urukul.SPI_CONFIG, 8,
+            urukul.SPIT_DDS_WR, self.chip_select)            
         self.bus.write((addr | 0x80) << 24)
         self.bus.set_config_mu(
-            urukul.SPI_CONFIG | spi.SPI_INPUT, 32, urukul.SPIT_DDS_RD, self.chip_select
-        )
+            urukul.SPI_CONFIG | spi.SPI_INPUT, 32,
+            urukul.SPIT_DDS_RD, self.chip_select)            
         self.bus.write(0)
         self.bus.set_config_mu(
-            urukul.SPI_CONFIG | spi.SPI_END | spi.SPI_INPUT,
-            32,
-            urukul.SPIT_DDS_RD,
-            self.chip_select,
-        )
+            urukul.SPI_CONFIG | spi.SPI_END | spi.SPI_INPUT, 32,
+            urukul.SPIT_DDS_RD, self.chip_select)            
         self.bus.write(0)
         hi = self.bus.read()
         lo = self.bus.read()
@@ -361,20 +312,17 @@ class AD9910:
         """Write to 64-bit register.
 
         :param addr: Register address
-        :param data_high: High (MSB) 32 data bits
+        :param data_high: High (MSB) 32 data bits 
         :param data_low: Low (LSB) 32 data bits
         """
-        self.bus.set_config_mu(
-            urukul.SPI_CONFIG, 8, urukul.SPIT_DDS_WR, self.chip_select
-        )
+        self.bus.set_config_mu(urukul.SPI_CONFIG, 8,
+                               urukul.SPIT_DDS_WR, self.chip_select)        
         self.bus.write(addr << 24)
-        self.bus.set_config_mu(
-            urukul.SPI_CONFIG, 32, urukul.SPIT_DDS_WR, self.chip_select
-        )
+        self.bus.set_config_mu(urukul.SPI_CONFIG, 32,
+                               urukul.SPIT_DDS_WR, self.chip_select)        
         self.bus.write(data_high)
-        self.bus.set_config_mu(
-            urukul.SPI_CONFIG | spi.SPI_END, 32, urukul.SPIT_DDS_WR, self.chip_select
-        )
+        self.bus.set_config_mu(urukul.SPI_CONFIG | spi.SPI_END, 32,
+                               urukul.SPIT_DDS_WR, self.chip_select)        
         self.bus.write(data_low)
 
     @kernel
@@ -388,18 +336,15 @@ class AD9910:
 
         :param data: Data to be written to RAM.
         """
-        self.bus.set_config_mu(
-            urukul.SPI_CONFIG, 8, urukul.SPIT_DDS_WR, self.chip_select
-        )
+        self.bus.set_config_mu(urukul.SPI_CONFIG, 32,
+                               urukul.SPIT_DDS_WR, self.chip_select)        
         self.bus.write(_AD9910_REG_RAM << 24)
-        self.bus.set_config_mu(
-            urukul.SPI_CONFIG, 32, urukul.SPIT_DDS_WR, self.chip_select
-        )
+        self.bus.set_config_mu(urukul.SPI_CONFIG, 32,
+                               urukul.SPIT_DDS_WR, self.chip_select)        
         for i in range(len(data) - 1):
             self.bus.write(data[i])
-        self.bus.set_config_mu(
-            urukul.SPI_CONFIG | spi.SPI_END, 32, urukul.SPIT_DDS_WR, self.chip_select
-        )
+        self.bus.set_config_mu(urukul.SPI_CONFIG | spi.SPI_END, 32,
+                               urukul.SPIT_DDS_WR, self.chip_select)            
         self.bus.write(data[len(data) - 1])
 
     @kernel
@@ -408,53 +353,43 @@ class AD9910:
 
         The profile to read from and the step, start, and end address
         need to be configured before and separately using
-        :meth:`set_profile_ram` and the parent CPLD
+        :meth:`set_profile_ram` and the parent CPLD 
         :meth:`~artiq.coredevice.urukul.CPLD.set_profile`.
 
         :param data: List to be filled with data read from RAM.
         """
-        self.bus.set_config_mu(
-            urukul.SPI_CONFIG, 8, urukul.SPIT_DDS_WR, self.chip_select
-        )
+        self.bus.set_config_mu(urukul.SPI_CONFIG, 8, urukul.SPIT_DDS_WR,
+                               self.chip_select)        
         self.bus.write((_AD9910_REG_RAM | 0x80) << 24)
         n = len(data) - 1
         if n > 0:
-            self.bus.set_config_mu(
-                urukul.SPI_CONFIG | spi.SPI_INPUT,
-                32,
-                urukul.SPIT_DDS_RD,
-                self.chip_select,
-            )
+            self.bus.set_config_mu(urukul.SPI_CONFIG | spi.SPI_INPUT, 32,
+                                   urukul.SPIT_DDS_RD, self.chip_select)            
         preload = min(n, 8)
         for i in range(n):
             self.bus.write(0)
             if i >= preload:
                 data[i - preload] = self.bus.read()
         self.bus.set_config_mu(
-            urukul.SPI_CONFIG | spi.SPI_INPUT | spi.SPI_END,
-            32,
-            urukul.SPIT_DDS_RD,
-            self.chip_select,
-        )
+            urukul.SPI_CONFIG | spi.SPI_INPUT | spi.SPI_END, 32,
+            urukul.SPIT_DDS_RD, self.chip_select)            
         self.bus.write(0)
         for i in range(preload + 1):
             data[(n - preload) + i] = self.bus.read()
 
     @kernel
-    def set_cfr1(
-        self,
-        power_down: TInt32 = 0b0000,
-        phase_autoclear: TInt32 = 0,
-        drg_load_lrr: TInt32 = 0,
-        drg_autoclear: TInt32 = 0,
-        phase_clear: TInt32 = 0,
-        internal_profile: TInt32 = 0,
-        ram_destination: TInt32 = 0,
-        ram_enable: TInt32 = 0,
-        manual_osk_external: TInt32 = 0,
-        osk_enable: TInt32 = 0,
-        select_auto_osk: TInt32 = 0,
-    ):
+    def set_cfr1(self,
+                 power_down: TInt32 = 0b0000,
+                 phase_autoclear: TInt32 = 0,
+                 drg_load_lrr: TInt32 = 0,
+                 drg_autoclear: TInt32 = 0,
+                 phase_clear: TInt32 = 0,
+                 internal_profile: TInt32 = 0,
+                 ram_destination: TInt32 = 0,
+                 ram_enable: TInt32 = 0,
+                 manual_osk_external: TInt32 = 0,
+                 osk_enable: TInt32 = 0,
+                 select_auto_osk: TInt32 = 0):    
         """Set CFR1. See the AD9910 datasheet for parameter meanings and sizes.
 
         This method does not pulse ``IO_UPDATE.``
@@ -473,34 +408,30 @@ class AD9910:
         :param osk_enable: Enable OSK mode.
         :param select_auto_osk: Select manual or automatic OSK mode.
         """
-        self.write32(
-            _AD9910_REG_CFR1,
-            (ram_enable << 31)
-            | (ram_destination << 29)
-            | (manual_osk_external << 23)
-            | (internal_profile << 17)
-            | (drg_load_lrr << 15)
-            | (drg_autoclear << 14)
-            | (phase_autoclear << 13)
-            | (phase_clear << 11)
-            | (osk_enable << 9)
-            | (select_auto_osk << 8)
-            | (power_down << 4)
-            | 2,
-        )  # SDIO input only, MSB first
+        self.write32(_AD9910_REG_CFR1,
+                     (ram_enable << 31) |
+                     (ram_destination << 29) |
+                     (manual_osk_external << 23) |
+                     (internal_profile << 17) |
+                     (drg_load_lrr << 15) |
+                     (drg_autoclear << 14) |
+                     (phase_autoclear << 13) |
+                     (phase_clear << 11) |
+                     (osk_enable << 9) |
+                     (select_auto_osk << 8) |
+                     (power_down << 4) |
+                     2)  # SDIO input only, MSB first        
 
     @kernel
-    def set_cfr2(
-        self,
-        asf_profile_enable: TInt32 = 1,
-        drg_destination: TInt32 = 0,
-        drg_enable: TInt32 = 0,
-        drg_nodwell_high: TInt32 = 0,
-        drg_nodwell_low: TInt32 = 0,
-        effective_ftw: TInt32 = 1,
-        sync_validation_disable: TInt32 = 0,
-        matched_latency_enable: TInt32 = 0,
-    ):
+    def set_cfr2(self, 
+                 asf_profile_enable: TInt32 = 1, 
+                 drg_destination: TInt32 = 0,
+                 drg_enable: TInt32 = 0, 
+                 drg_nodwell_high: TInt32 = 0,
+                 drg_nodwell_low: TInt32 = 0,
+                 effective_ftw: TInt32 = 1,
+                 sync_validation_disable: TInt32 = 0, 
+                 matched_latency_enable: TInt32 = 0):    
         """Set CFR2. See the AD9910 datasheet for parameter meanings and sizes.
 
         This method does not pulse ``IO_UPDATE``.
@@ -519,24 +450,22 @@ class AD9910:
             * matched_latency_enable = 0: in the order listed
             * matched_latency_enable = 1: simultaneously.
         """
-        self.write32(
-            _AD9910_REG_CFR2,
-            (asf_profile_enable << 24)
-            | (drg_destination << 20)
-            | (drg_enable << 19)
-            | (drg_nodwell_high << 18)
-            | (drg_nodwell_low << 17)
-            | (effective_ftw << 16)
-            | (matched_latency_enable << 7)
-            | (sync_validation_disable << 5),
-        )
+        self.write32(_AD9910_REG_CFR2,
+                     (asf_profile_enable << 24) |
+                     (drg_destination << 20) |
+                     (drg_enable << 19) |
+                     (drg_nodwell_high << 18) |
+                     (drg_nodwell_low << 17) |
+                     (effective_ftw << 16) |
+                     (matched_latency_enable << 7) |
+                     (sync_validation_disable << 5))        
 
     @kernel
     def init(self, blind: TBool = False):
         """Initialize and configure the DDS.
 
         Sets up SPI mode, confirms chip presence, powers down unused blocks,
-        configures the PLL, waits for PLL lock. Uses the ``IO_UPDATE``
+        configures the PLL, waits for PLL lock. Uses the ``IO_UPDATE`` 
         signal multiple times.
 
         :param blind: Do not read back DDS identity and do not wait for lock.
@@ -565,13 +494,9 @@ class AD9910:
         # sync timing validation disable (enabled later)
         self.set_cfr2(sync_validation_disable=1)
         self.cpld.io_update.pulse(1 * us)
-        cfr3 = (
-            0x0807C000
-            | (self.pll_vco << 24)
-            | (self.pll_cp << 19)
-            | (self.pll_en << 8)
-            | (self.pll_n << 1)
-        )
+        cfr3 = (0x0807c000 | (self.pll_vco << 24) |
+                (self.pll_cp << 19) | (self.pll_en << 8) |
+                (self.pll_n << 1))        
         self.write32(_AD9910_REG_CFR3, cfr3 | 0x400)  # PFD reset
         self.cpld.io_update.pulse(1 * us)
         if self.pll_en:
@@ -604,16 +529,11 @@ class AD9910:
         self.cpld.io_update.pulse(1 * us)
 
     @kernel
-    def set_mu(
-        self,
-        ftw: TInt32 = 0,
-        pow_: TInt32 = 0,
-        asf: TInt32 = 0x3FFF,
-        phase_mode: TInt32 = _PHASE_MODE_DEFAULT,
-        ref_time_mu: TInt64 = int64(-1),
-        profile: TInt32 = DEFAULT_PROFILE,
-        ram_destination: TInt32 = -1,
-    ) -> TInt32:
+    def set_mu(self, ftw: TInt32 = 0, pow_: TInt32 = 0, asf: TInt32 = 0x3FFF,
+               phase_mode: TInt32 = _PHASE_MODE_DEFAULT,
+               ref_time_mu: TInt64 = int64(-1),
+               profile: TInt32 = DEFAULT_PROFILE,
+               ram_destination: TInt32 = -1) -> TInt32:    
         """Set DDS data in machine units.
 
         This uses machine units (FTW, POW, ASF). The frequency tuning word
@@ -663,9 +583,8 @@ class AD9910:
                 dt = int32(now_mu()) - int32(ref_time_mu)
                 pow_ += dt * ftw * self.sysclk_per_mu >> 16
         if ram_destination == -1:
-            self.write64(
-                _AD9910_REG_PROFILE0 + profile, (asf << 16) | (pow_ & 0xFFFF), ftw
-            )
+            self.write64(_AD9910_REG_PROFILE0 + profile,
+                         (asf << 16) | (pow_ & 0xFFFF), ftw)            
         else:
             if not ram_destination == RAM_DEST_FTW:
                 self.set_ftw(ftw)
@@ -683,9 +602,8 @@ class AD9910:
         return pow_
 
     @kernel
-    def get_mu(
-        self, profile: TInt32 = DEFAULT_PROFILE
-    ) -> TTuple([TInt32, TInt32, TInt32]):
+    def get_mu(self, profile: TInt32 = DEFAULT_PROFILE
+               ) -> TTuple([TInt32, TInt32, TInt32]):    
         """Get the frequency tuning word, phase offset word,
         and amplitude scale factor.
 
@@ -704,16 +622,10 @@ class AD9910:
         return ftw, pow_, asf
 
     @kernel
-    def set_profile_ram(
-        self,
-        start: TInt32,
-        end: TInt32,
-        step: TInt32 = 1,
-        profile: TInt32 = _DEFAULT_PROFILE_RAM,
-        nodwell_high: TInt32 = 0,
-        zero_crossing: TInt32 = 0,
-        mode: TInt32 = 1,
-    ):
+    def set_profile_ram(self, start: TInt32, end: TInt32, step: TInt32 = 1,
+                        profile: TInt32 = _DEFAULT_PROFILE_RAM,
+                        nodwell_high: TInt32 = 0, zero_crossing: TInt32 = 0,
+                        mode: TInt32 = 1):    
         """Set the RAM profile settings. See also AD9910 datasheet.
 
         :param start: Profile start address in RAM (10-bit).
@@ -732,13 +644,8 @@ class AD9910:
             :const:`RAM_MODE_RAMPUP`)
         """
         hi = (step << 8) | (end >> 2)
-        lo = (
-            (end << 30)
-            | (start << 14)
-            | (nodwell_high << 5)
-            | (zero_crossing << 3)
-            | mode
-        )
+        lo = ((end << 30) | (start << 14) | (nodwell_high << 5) |
+              (zero_crossing << 3) | mode)        
         self.write64(_AD9910_REG_PROFILE0 + profile, hi, lo)
 
     @kernel
@@ -876,9 +783,8 @@ class AD9910:
             ram[i] = self.amplitude_to_asf(amplitude[i]) << 18
 
     @portable(flags={"fast-math"})
-    def turns_amplitude_to_ram(
-        self, turns: TList(TFloat), amplitude: TList(TFloat), ram: TList(TInt32)
-    ):
+    def turns_amplitude_to_ram(self, turns: TList(TFloat),
+                               amplitude: TList(TFloat), ram: TList(TInt32)):    
         """Convert phase and amplitude values to RAM profile data.
 
         To be used with :const:`RAM_DEST_POWASF`.
@@ -889,9 +795,8 @@ class AD9910:
             Suitable for :meth:`write_ram`.
         """
         for i in range(len(ram)):
-            ram[i] = (self.turns_to_pow(turns[i]) << 16) | self.amplitude_to_asf(
-                amplitude[i]
-            ) << 2
+            ram[i] = ((self.turns_to_pow(turns[i]) << 16) |
+                      self.amplitude_to_asf(amplitude[i]) << 2)            
 
     @kernel
     def set_frequency(self, frequency: TFloat):
@@ -948,16 +853,10 @@ class AD9910:
         return self.pow_to_turns(self.get_pow())
 
     @kernel
-    def set(
-        self,
-        frequency: TFloat = 0.0,
-        phase: TFloat = 0.0,
-        amplitude: TFloat = 1.0,
-        phase_mode: TInt32 = _PHASE_MODE_DEFAULT,
-        ref_time_mu: TInt64 = int64(-1),
-        profile: TInt32 = DEFAULT_PROFILE,
-        ram_destination: TInt32 = -1,
-    ) -> TFloat:
+    def set(self, frequency: TFloat = 0.0, phase: TFloat = 0.0,
+            amplitude: TFloat = 1.0, phase_mode: TInt32 = _PHASE_MODE_DEFAULT,
+            ref_time_mu: TInt64 = int64(-1), profile: TInt32 = DEFAULT_PROFILE,
+            ram_destination: TInt32 = -1) -> TFloat:    
         """Set DDS data in SI units.
 
         See also :meth:`AD9910.set_mu`.
@@ -971,22 +870,14 @@ class AD9910:
         :param ram_destination: RAM destination.
         :return: Resulting phase offset in turns
         """
-        return self.pow_to_turns(
-            self.set_mu(
-                self.frequency_to_ftw(frequency),
-                self.turns_to_pow(phase),
-                self.amplitude_to_asf(amplitude),
-                phase_mode,
-                ref_time_mu,
-                profile,
-                ram_destination,
-            )
-        )
+        return self.pow_to_turns(self.set_mu(
+            self.frequency_to_ftw(frequency), self.turns_to_pow(phase),
+            self.amplitude_to_asf(amplitude), phase_mode, ref_time_mu,
+            profile, ram_destination))        
 
     @kernel
-    def get(
-        self, profile: TInt32 = DEFAULT_PROFILE
-    ) -> TTuple([TFloat, TFloat, TFloat]):
+    def get(self, profile: TInt32 = DEFAULT_PROFILE
+            ) -> TTuple([TFloat, TFloat, TFloat]):    
         """Get the frequency, phase, and amplitude.
 
         See also :meth:`AD9910.get_mu`.
@@ -998,11 +889,8 @@ class AD9910:
         # Get values
         ftw, pow_, asf = self.get_mu(profile)
         # Convert and return
-        return (
-            self.ftw_to_frequency(ftw),
-            self.pow_to_turns(pow_),
-            self.asf_to_amplitude(asf),
-        )
+        return (self.ftw_to_frequency(ftw), self.pow_to_turns(pow_),
+                self.asf_to_amplitude(asf))        
 
     @kernel
     def set_att_mu(self, att: TInt32):
@@ -1041,7 +929,7 @@ class AD9910:
 
     @kernel
     def get_att(self) -> TFloat:
-        """Get digital step attenuator value in SI units. See also
+        """Get digital step attenuator value in SI units. See also 
         :meth:`CPLD.get_channel_att <artiq.coredevice.urukul.CPLD.get_channel_att>`.
 
         :return: Attenuation in dB.
@@ -1104,7 +992,10 @@ class AD9910:
         self.cpld.cfg_att_en(self.chip_select - 4, state)
 
     @kernel
-    def set_sync(self, in_delay: TInt32, window: TInt32, en_sync_gen: TInt32 = 0):
+    def set_sync(self, 
+                 in_delay: TInt32, 
+                 window: TInt32, 
+                 en_sync_gen: TInt32 = 0):    
         """Set the relevant parameters in the multi device synchronization
         register. See the AD9910 datasheet for details. The ``SYNC`` clock
         generator preset value is set to zero, and the ``SYNC_OUT`` generator is
@@ -1117,16 +1008,14 @@ class AD9910:
             (``SYNC_OUT``, cf. ``sync_sel == 1``). Should be left off for the normal
             use case, where the ``SYNC`` clock is supplied by the core device.
         """
-        self.write32(
-            _AD9910_REG_SYNC,
-            (window << 28)  # SYNC S/H validation delay
-            | (1 << 27)  # SYNC receiver enable
-            | (en_sync_gen << 26)  # SYNC generator enable
-            | (0 << 25)  # SYNC generator SYS rising edge
-            | (0 << 18)  # SYNC preset
-            | (0 << 11)  # SYNC output delay
-            | (in_delay << 3),
-        )  # SYNC receiver delay
+        self.write32(_AD9910_REG_SYNC,
+                     (window << 28) |  # SYNC S/H validation delay
+                     (1 << 27) |  # SYNC receiver enable
+                     (en_sync_gen << 26) |  # SYNC generator enable
+                     (0 << 25) |  # SYNC generator SYS rising edge
+                     (0 << 18) |  # SYNC preset
+                     (0 << 11) |  # SYNC output delay
+                     (in_delay << 3))  # SYNC receiver delay        
 
     @kernel
     def clear_smp_err(self):
@@ -1145,7 +1034,8 @@ class AD9910:
         self.cpld.io_update.pulse(1 * us)
 
     @kernel
-    def tune_sync_delay(self, search_seed: TInt32 = 15) -> TTuple([TInt32, TInt32]):
+    def tune_sync_delay(self,
+                        search_seed: TInt32 = 15) -> TTuple([TInt32, TInt32]):    
         """Find a stable ``SYNC_IN`` delay.
 
         This method first locates a valid ``SYNC_IN`` delay at zero validation
@@ -1201,9 +1091,8 @@ class AD9910:
         raise ValueError("no valid window/delay")
 
     @kernel
-    def measure_io_update_alignment(
-        self, delay_start: TInt64, delay_stop: TInt64
-    ) -> TInt32:
+    def measure_io_update_alignment(self, delay_start: TInt64,
+                                    delay_stop: TInt64) -> TInt32:    
         """Use the digital ramp generator to locate the alignment between
         ``IO_UPDATE`` and ``SYNC_CLK``.
 
@@ -1275,9 +1164,11 @@ class AD9910:
             for j in range(repeat):
                 t1[0] += self.measure_io_update_alignment(i, i + 1)
                 t1[1] += self.measure_io_update_alignment(i + 1, i + 2)
-            if (t1[0] == 0 and t1[1] == 0) or (t1[0] == repeat and t1[1] == repeat):
+            if ((t1[0] == 0 and t1[1] == 0) or
+                    (t1[0] == repeat and t1[1] == repeat)):                
                 # edge is not close to i + 1, can't interpret result
-                raise ValueError("no clear IO_UPDATE-SYNC_CLK alignment edge found")
+                raise ValueError(
+                    "no clear IO_UPDATE-SYNC_CLK alignment edge found")                
             else:
                 # the good delay is period//2 after the edge
                 return (i + 1 + period // 2) & (period - 1)

--- a/artiq/coredevice/ad9910.py
+++ b/artiq/coredevice/ad9910.py
@@ -437,18 +437,20 @@ class AD9910:
         This method does not pulse ``IO_UPDATE``.
 
         :param asf_profile_enable: Enable amplitude scale from single tone profiles.
-        :param drg_destination: Digital ramp destination.
+        :param drg_destination: Digital ramp destination. Determines the parameter to modulate:
+            * 0: Frequency
+            * 1: Phase
+            * 2: Amplitude
         :param drg_enable: Digital ramp enable.
         :param drg_nodwell_high: Digital ramp no-dwell high.
         :param drg_nodwell_low: Digital ramp no-dwell low.
         :param effective_ftw: Read effective FTW.
         :param sync_validation_disable: Disable the SYNC_SMP_ERR pin indicating
             (active high) detection of a synchronization pulse sampling error.
-        :param matched_latency_enable: Simultaneous application of amplitude,
-            phase, and frequency changes to the DDS arrive at the output
-
-            * matched_latency_enable = 0: in the order listed
-            * matched_latency_enable = 1: simultaneously.
+        :param matched_latency_enable: Control the application timing of amplitude,
+            phase, and frequency changes at the DDS output:
+            * 0: Changes are applied in the order listed.
+            * 1: Changes are applied simultaneously.
         """
         self.write32(_AD9910_REG_CFR2,
                      (asf_profile_enable << 24) |

--- a/artiq/coredevice/ad9910.py
+++ b/artiq/coredevice/ad9910.py
@@ -16,7 +16,7 @@ __all__ = [
     "PHASE_MODE_CONTINUOUS", "PHASE_MODE_ABSOLUTE", "PHASE_MODE_TRACKING",
     "RAM_DEST_FTW", "RAM_DEST_POW", "RAM_DEST_ASF", "RAM_DEST_POWASF",
     "RAM_MODE_DIRECTSWITCH", "RAM_MODE_RAMPUP", "RAM_MODE_BIDIR_RAMP",
-    "RAM_MODE_CONT_BIDIR_RAMP", "RAM_MODE_CONT_RAMPUP", 
+    "RAM_MODE_CONT_BIDIR_RAMP", "RAM_MODE_CONT_RAMPUP",
 ]
 
 _PHASE_MODE_DEFAULT = -1
@@ -32,12 +32,12 @@ _AD9910_REG_IO_UPDATE = 0x04
 _AD9910_REG_FTW = 0x07
 _AD9910_REG_POW = 0x08
 _AD9910_REG_ASF = 0x09
-_AD9910_REG_SYNC = 0x0A
-_AD9910_REG_RAMP_LIMIT = 0x0B
-_AD9910_REG_RAMP_STEP = 0x0C
-_AD9910_REG_RAMP_RATE = 0x0D
-_AD9910_REG_PROFILE0 = 0x0E
-_AD9910_REG_PROFILE1 = 0x0F
+_AD9910_REG_SYNC = 0x0a
+_AD9910_REG_RAMP_LIMIT = 0x0b
+_AD9910_REG_RAMP_STEP = 0x0c
+_AD9910_REG_RAMP_RATE = 0x0d
+_AD9910_REG_PROFILE0 = 0x0e
+_AD9910_REG_PROFILE1 = 0x0f
 _AD9910_REG_PROFILE2 = 0x10
 _AD9910_REG_PROFILE3 = 0x11
 _AD9910_REG_PROFILE4 = 0x12
@@ -90,10 +90,10 @@ class SyncDataEeprom:
         word = self.eeprom_device.read_i32(self.eeprom_offset) >> 16
         sync_delay_seed = word >> 8
         if sync_delay_seed >= 0:
-            io_update_delay = word & 0xFF
+            io_update_delay = word & 0xff
         else:
             io_update_delay = 0
-        if io_update_delay == 0xFF:  # unprogrammed EEPROM
+        if io_update_delay == 0xff:  # unprogrammed EEPROM
             io_update_delay = 0
         # With Numpy, type(int32(-1) >> 1) == int64
         self.sync_delay_seed = int32(sync_delay_seed)
@@ -238,7 +238,7 @@ class AD9910:
         """
         self.bus.set_config_mu(urukul.SPI_CONFIG | spi.SPI_END, 24,
                                urukul.SPIT_DDS_WR, self.chip_select)
-        self.bus.write((addr << 24) | ((data & 0xFFFF) << 8))
+        self.bus.write((addr << 24) | ((data & 0xffff) << 8))
 
     @kernel
     def write32(self, addr: TInt32, data: TInt32):
@@ -485,7 +485,7 @@ class AD9910:
         if not blind:
             # Use the AUX DAC setting to identify and confirm presence
             aux_dac = self.read32(_AD9910_REG_AUX_DAC)
-            if aux_dac & 0xFF != 0x7F:
+            if aux_dac & 0xff != 0x7f:
                 raise ValueError("Urukul AD9910 AUX_DAC mismatch")
             delay(50 * us)  # slack
         # Configure PLL settings and bring up PLL
@@ -529,7 +529,7 @@ class AD9910:
         self.cpld.io_update.pulse(1 * us)
 
     @kernel
-    def set_mu(self, ftw: TInt32 = 0, pow_: TInt32 = 0, asf: TInt32 = 0x3FFF,
+    def set_mu(self, ftw: TInt32 = 0, pow_: TInt32 = 0, asf: TInt32 = 0x3fff,
                phase_mode: TInt32 = _PHASE_MODE_DEFAULT,
                ref_time_mu: TInt64 = int64(-1),
                profile: TInt32 = DEFAULT_PROFILE,
@@ -584,7 +584,7 @@ class AD9910:
                 pow_ += dt * ftw * self.sysclk_per_mu >> 16
         if ram_destination == -1:
             self.write64(_AD9910_REG_PROFILE0 + profile,
-                         (asf << 16) | (pow_ & 0xFFFF), ftw)
+                         (asf << 16) | (pow_ & 0xffff), ftw)
         else:
             if not ram_destination == RAM_DEST_FTW:
                 self.set_ftw(ftw)
@@ -617,8 +617,8 @@ class AD9910:
         data = int64(self.read64(_AD9910_REG_PROFILE0 + profile))
         # Extract and return fields
         ftw = int32(data)
-        pow_ = int32((data >> 32) & 0xFFFF)
-        asf = int32((data >> 48) & 0x3FFF)
+        pow_ = int32((data >> 32) & 0xffff)
+        asf = int32((data >> 48) & 0x3fff)
         return ftw, pow_, asf
 
     @kernel
@@ -720,7 +720,7 @@ class AD9910:
     def turns_to_pow(self, turns: TFloat) -> TInt32:
         """Return the 16-bit phase offset word corresponding to the given phase
         in turns."""
-        return int32(round(turns * 0x10000)) & int32(0xFFFF)
+        return int32(round(turns * 0x10000)) & int32(0xffff)
 
     @portable(flags={"fast-math"})
     def pow_to_turns(self, pow_: TInt32) -> TFloat:
@@ -732,8 +732,8 @@ class AD9910:
     def amplitude_to_asf(self, amplitude: TFloat) -> TInt32:
         """Return 14-bit amplitude scale factor corresponding to given
         fractional amplitude."""
-        code = int32(round(amplitude * 0x3FFF))
-        if code < 0 or code > 0x3FFF:
+        code = int32(round(amplitude * 0x3fff))
+        if code < 0 or code > 0x3fff:
             raise ValueError("Invalid AD9910 fractional amplitude!")
         return code
 
@@ -741,7 +741,7 @@ class AD9910:
     def asf_to_amplitude(self, asf: TInt32) -> TFloat:
         """Return amplitude as a fraction of full scale corresponding to given
         amplitude scale factor."""
-        return asf / float(0x3FFF)
+        return asf / float(0x3fff)
 
     @portable(flags={"fast-math"})
     def frequency_to_ram(self, frequency: TList(TFloat), ram: TList(TInt32)):

--- a/artiq/coredevice/ad9910.py
+++ b/artiq/coredevice/ad9910.py
@@ -16,7 +16,7 @@ __all__ = [
     "PHASE_MODE_CONTINUOUS", "PHASE_MODE_ABSOLUTE", "PHASE_MODE_TRACKING",
     "RAM_DEST_FTW", "RAM_DEST_POW", "RAM_DEST_ASF", "RAM_DEST_POWASF",
     "RAM_MODE_DIRECTSWITCH", "RAM_MODE_RAMPUP", "RAM_MODE_BIDIR_RAMP",
-    "RAM_MODE_CONT_BIDIR_RAMP", "RAM_MODE_CONT_RAMPUP",    
+    "RAM_MODE_CONT_BIDIR_RAMP", "RAM_MODE_CONT_RAMPUP", 
 ]
 
 _PHASE_MODE_DEFAULT = -1
@@ -162,7 +162,7 @@ class AD9910:
             assert 12 <= pll_n <= 127
             assert 0 <= pll_vco <= 5
             vco_min, vco_max = [(370, 510), (420, 590), (500, 700),
-                                (600, 880), (700, 950), (820, 1150)][pll_vco]            
+                                (600, 880), (700, 950), (820, 1150)][pll_vco]
             assert vco_min <= sysclk / 1e6 <= vco_max
             assert 0 <= pll_cp <= 7
         else:
@@ -178,7 +178,7 @@ class AD9910:
         if isinstance(sync_delay_seed, str) or isinstance(io_update_delay, str):
             if sync_delay_seed != io_update_delay:
                 raise ValueError("When using EEPROM, sync_delay_seed must be "
-                                 "equal to io_update_delay")                
+                                 "equal to io_update_delay")
             self.sync_data = SyncDataEeprom(dmgr, self.core, sync_delay_seed)
         else:
             self.sync_data = SyncDataUser(self.core, sync_delay_seed,
@@ -238,7 +238,7 @@ class AD9910:
         """
         self.bus.set_config_mu(urukul.SPI_CONFIG | spi.SPI_END, 24,
                                urukul.SPIT_DDS_WR, self.chip_select)
-        self.bus.write((addr << 24) | ((data & 0xFFFF) << 8))        
+        self.bus.write((addr << 24) | ((data & 0xFFFF) << 8))
 
     @kernel
     def write32(self, addr: TInt32, data: TInt32):
@@ -248,10 +248,10 @@ class AD9910:
         :param data: Data to be written
         """
         self.bus.set_config_mu(urukul.SPI_CONFIG, 8,
-                               urukul.SPIT_DDS_WR, self.chip_select)        
+                               urukul.SPIT_DDS_WR, self.chip_select)
         self.bus.write(addr << 24)
         self.bus.set_config_mu(urukul.SPI_CONFIG | spi.SPI_END, 32,
-                               urukul.SPIT_DDS_WR, self.chip_select)        
+                               urukul.SPIT_DDS_WR, self.chip_select)
         self.bus.write(data)
 
     @kernel
@@ -261,11 +261,11 @@ class AD9910:
         :param addr: Register address
         """
         self.bus.set_config_mu(urukul.SPI_CONFIG, 8,
-                               urukul.SPIT_DDS_WR, self.chip_select)        
+                               urukul.SPIT_DDS_WR, self.chip_select)
         self.bus.write((addr | 0x80) << 24)
         self.bus.set_config_mu(
             urukul.SPI_CONFIG | spi.SPI_END | spi.SPI_INPUT,
-            16, urukul.SPIT_DDS_RD, self.chip_select)            
+            16, urukul.SPIT_DDS_RD, self.chip_select)
         self.bus.write(0)
         return self.bus.read()
 
@@ -276,7 +276,7 @@ class AD9910:
         :param addr: Register address
         """
         self.bus.set_config_mu(urukul.SPI_CONFIG, 8,
-                               urukul.SPIT_DDS_WR, self.chip_select)        
+                               urukul.SPIT_DDS_WR, self.chip_select)
         self.bus.write((addr | 0x80) << 24)
         self.bus.set_config_mu(
             urukul.SPI_CONFIG | spi.SPI_END | spi.SPI_INPUT,
@@ -293,15 +293,15 @@ class AD9910:
         """
         self.bus.set_config_mu(
             urukul.SPI_CONFIG, 8,
-            urukul.SPIT_DDS_WR, self.chip_select)            
+            urukul.SPIT_DDS_WR, self.chip_select)
         self.bus.write((addr | 0x80) << 24)
         self.bus.set_config_mu(
             urukul.SPI_CONFIG | spi.SPI_INPUT, 32,
-            urukul.SPIT_DDS_RD, self.chip_select)            
+            urukul.SPIT_DDS_RD, self.chip_select)
         self.bus.write(0)
         self.bus.set_config_mu(
             urukul.SPI_CONFIG | spi.SPI_END | spi.SPI_INPUT, 32,
-            urukul.SPIT_DDS_RD, self.chip_select)            
+            urukul.SPIT_DDS_RD, self.chip_select)
         self.bus.write(0)
         hi = self.bus.read()
         lo = self.bus.read()
@@ -316,13 +316,13 @@ class AD9910:
         :param data_low: Low (LSB) 32 data bits
         """
         self.bus.set_config_mu(urukul.SPI_CONFIG, 8,
-                               urukul.SPIT_DDS_WR, self.chip_select)        
+                               urukul.SPIT_DDS_WR, self.chip_select)
         self.bus.write(addr << 24)
         self.bus.set_config_mu(urukul.SPI_CONFIG, 32,
-                               urukul.SPIT_DDS_WR, self.chip_select)        
+                               urukul.SPIT_DDS_WR, self.chip_select)
         self.bus.write(data_high)
         self.bus.set_config_mu(urukul.SPI_CONFIG | spi.SPI_END, 32,
-                               urukul.SPIT_DDS_WR, self.chip_select)        
+                               urukul.SPIT_DDS_WR, self.chip_select)
         self.bus.write(data_low)
 
     @kernel
@@ -336,15 +336,15 @@ class AD9910:
 
         :param data: Data to be written to RAM.
         """
-        self.bus.set_config_mu(urukul.SPI_CONFIG, 32,
-                               urukul.SPIT_DDS_WR, self.chip_select)        
+        self.bus.set_config_mu(urukul.SPI_CONFIG, 8, urukul.SPIT_DDS_WR,
+                               self.chip_select)
         self.bus.write(_AD9910_REG_RAM << 24)
         self.bus.set_config_mu(urukul.SPI_CONFIG, 32,
-                               urukul.SPIT_DDS_WR, self.chip_select)        
+                               urukul.SPIT_DDS_WR, self.chip_select)
         for i in range(len(data) - 1):
             self.bus.write(data[i])
         self.bus.set_config_mu(urukul.SPI_CONFIG | spi.SPI_END, 32,
-                               urukul.SPIT_DDS_WR, self.chip_select)            
+                               urukul.SPIT_DDS_WR, self.chip_select)
         self.bus.write(data[len(data) - 1])
 
     @kernel
@@ -359,12 +359,12 @@ class AD9910:
         :param data: List to be filled with data read from RAM.
         """
         self.bus.set_config_mu(urukul.SPI_CONFIG, 8, urukul.SPIT_DDS_WR,
-                               self.chip_select)        
+                               self.chip_select)
         self.bus.write((_AD9910_REG_RAM | 0x80) << 24)
         n = len(data) - 1
         if n > 0:
             self.bus.set_config_mu(urukul.SPI_CONFIG | spi.SPI_INPUT, 32,
-                                   urukul.SPIT_DDS_RD, self.chip_select)            
+                                   urukul.SPIT_DDS_RD, self.chip_select)
         preload = min(n, 8)
         for i in range(n):
             self.bus.write(0)
@@ -372,7 +372,7 @@ class AD9910:
                 data[i - preload] = self.bus.read()
         self.bus.set_config_mu(
             urukul.SPI_CONFIG | spi.SPI_INPUT | spi.SPI_END, 32,
-            urukul.SPIT_DDS_RD, self.chip_select)            
+            urukul.SPIT_DDS_RD, self.chip_select)
         self.bus.write(0)
         for i in range(preload + 1):
             data[(n - preload) + i] = self.bus.read()
@@ -389,7 +389,7 @@ class AD9910:
                  ram_enable: TInt32 = 0,
                  manual_osk_external: TInt32 = 0,
                  osk_enable: TInt32 = 0,
-                 select_auto_osk: TInt32 = 0):    
+                 select_auto_osk: TInt32 = 0):
         """Set CFR1. See the AD9910 datasheet for parameter meanings and sizes.
 
         This method does not pulse ``IO_UPDATE.``
@@ -420,7 +420,7 @@ class AD9910:
                      (osk_enable << 9) |
                      (select_auto_osk << 8) |
                      (power_down << 4) |
-                     2)  # SDIO input only, MSB first        
+                     2)  # SDIO input only, MSB first
 
     @kernel
     def set_cfr2(self, 
@@ -431,7 +431,7 @@ class AD9910:
                  drg_nodwell_low: TInt32 = 0,
                  effective_ftw: TInt32 = 1,
                  sync_validation_disable: TInt32 = 0, 
-                 matched_latency_enable: TInt32 = 0):    
+                 matched_latency_enable: TInt32 = 0):
         """Set CFR2. See the AD9910 datasheet for parameter meanings and sizes.
 
         This method does not pulse ``IO_UPDATE``.
@@ -458,7 +458,7 @@ class AD9910:
                      (drg_nodwell_low << 17) |
                      (effective_ftw << 16) |
                      (matched_latency_enable << 7) |
-                     (sync_validation_disable << 5))        
+                     (sync_validation_disable << 5))
 
     @kernel
     def init(self, blind: TBool = False):
@@ -496,7 +496,7 @@ class AD9910:
         self.cpld.io_update.pulse(1 * us)
         cfr3 = (0x0807c000 | (self.pll_vco << 24) |
                 (self.pll_cp << 19) | (self.pll_en << 8) |
-                (self.pll_n << 1))        
+                (self.pll_n << 1))
         self.write32(_AD9910_REG_CFR3, cfr3 | 0x400)  # PFD reset
         self.cpld.io_update.pulse(1 * us)
         if self.pll_en:
@@ -533,7 +533,7 @@ class AD9910:
                phase_mode: TInt32 = _PHASE_MODE_DEFAULT,
                ref_time_mu: TInt64 = int64(-1),
                profile: TInt32 = DEFAULT_PROFILE,
-               ram_destination: TInt32 = -1) -> TInt32:    
+               ram_destination: TInt32 = -1) -> TInt32:
         """Set DDS data in machine units.
 
         This uses machine units (FTW, POW, ASF). The frequency tuning word
@@ -584,7 +584,7 @@ class AD9910:
                 pow_ += dt * ftw * self.sysclk_per_mu >> 16
         if ram_destination == -1:
             self.write64(_AD9910_REG_PROFILE0 + profile,
-                         (asf << 16) | (pow_ & 0xFFFF), ftw)            
+                         (asf << 16) | (pow_ & 0xFFFF), ftw)
         else:
             if not ram_destination == RAM_DEST_FTW:
                 self.set_ftw(ftw)
@@ -603,7 +603,7 @@ class AD9910:
 
     @kernel
     def get_mu(self, profile: TInt32 = DEFAULT_PROFILE
-               ) -> TTuple([TInt32, TInt32, TInt32]):    
+               ) -> TTuple([TInt32, TInt32, TInt32]):
         """Get the frequency tuning word, phase offset word,
         and amplitude scale factor.
 
@@ -625,7 +625,7 @@ class AD9910:
     def set_profile_ram(self, start: TInt32, end: TInt32, step: TInt32 = 1,
                         profile: TInt32 = _DEFAULT_PROFILE_RAM,
                         nodwell_high: TInt32 = 0, zero_crossing: TInt32 = 0,
-                        mode: TInt32 = 1):    
+                        mode: TInt32 = 1):
         """Set the RAM profile settings. See also AD9910 datasheet.
 
         :param start: Profile start address in RAM (10-bit).
@@ -645,7 +645,7 @@ class AD9910:
         """
         hi = (step << 8) | (end >> 2)
         lo = ((end << 30) | (start << 14) | (nodwell_high << 5) |
-              (zero_crossing << 3) | mode)        
+              (zero_crossing << 3) | mode)
         self.write64(_AD9910_REG_PROFILE0 + profile, hi, lo)
 
     @kernel
@@ -784,7 +784,7 @@ class AD9910:
 
     @portable(flags={"fast-math"})
     def turns_amplitude_to_ram(self, turns: TList(TFloat),
-                               amplitude: TList(TFloat), ram: TList(TInt32)):    
+                               amplitude: TList(TFloat), ram: TList(TInt32)):
         """Convert phase and amplitude values to RAM profile data.
 
         To be used with :const:`RAM_DEST_POWASF`.
@@ -796,7 +796,7 @@ class AD9910:
         """
         for i in range(len(ram)):
             ram[i] = ((self.turns_to_pow(turns[i]) << 16) |
-                      self.amplitude_to_asf(amplitude[i]) << 2)            
+                      self.amplitude_to_asf(amplitude[i]) << 2)
 
     @kernel
     def set_frequency(self, frequency: TFloat):
@@ -856,7 +856,7 @@ class AD9910:
     def set(self, frequency: TFloat = 0.0, phase: TFloat = 0.0,
             amplitude: TFloat = 1.0, phase_mode: TInt32 = _PHASE_MODE_DEFAULT,
             ref_time_mu: TInt64 = int64(-1), profile: TInt32 = DEFAULT_PROFILE,
-            ram_destination: TInt32 = -1) -> TFloat:    
+            ram_destination: TInt32 = -1) -> TFloat:
         """Set DDS data in SI units.
 
         See also :meth:`AD9910.set_mu`.
@@ -873,11 +873,11 @@ class AD9910:
         return self.pow_to_turns(self.set_mu(
             self.frequency_to_ftw(frequency), self.turns_to_pow(phase),
             self.amplitude_to_asf(amplitude), phase_mode, ref_time_mu,
-            profile, ram_destination))        
+            profile, ram_destination))
 
     @kernel
     def get(self, profile: TInt32 = DEFAULT_PROFILE
-            ) -> TTuple([TFloat, TFloat, TFloat]):    
+            ) -> TTuple([TFloat, TFloat, TFloat]):
         """Get the frequency, phase, and amplitude.
 
         See also :meth:`AD9910.get_mu`.
@@ -890,7 +890,7 @@ class AD9910:
         ftw, pow_, asf = self.get_mu(profile)
         # Convert and return
         return (self.ftw_to_frequency(ftw), self.pow_to_turns(pow_),
-                self.asf_to_amplitude(asf))        
+                self.asf_to_amplitude(asf))
 
     @kernel
     def set_att_mu(self, att: TInt32):
@@ -995,7 +995,7 @@ class AD9910:
     def set_sync(self, 
                  in_delay: TInt32, 
                  window: TInt32, 
-                 en_sync_gen: TInt32 = 0):    
+                 en_sync_gen: TInt32 = 0):
         """Set the relevant parameters in the multi device synchronization
         register. See the AD9910 datasheet for details. The ``SYNC`` clock
         generator preset value is set to zero, and the ``SYNC_OUT`` generator is
@@ -1015,7 +1015,7 @@ class AD9910:
                      (0 << 25) |  # SYNC generator SYS rising edge
                      (0 << 18) |  # SYNC preset
                      (0 << 11) |  # SYNC output delay
-                     (in_delay << 3))  # SYNC receiver delay        
+                     (in_delay << 3))  # SYNC receiver delay
 
     @kernel
     def clear_smp_err(self):
@@ -1035,7 +1035,7 @@ class AD9910:
 
     @kernel
     def tune_sync_delay(self,
-                        search_seed: TInt32 = 15) -> TTuple([TInt32, TInt32]):    
+                        search_seed: TInt32 = 15) -> TTuple([TInt32, TInt32]):
         """Find a stable ``SYNC_IN`` delay.
 
         This method first locates a valid ``SYNC_IN`` delay at zero validation
@@ -1092,7 +1092,7 @@ class AD9910:
 
     @kernel
     def measure_io_update_alignment(self, delay_start: TInt64,
-                                    delay_stop: TInt64) -> TInt32:    
+                                    delay_stop: TInt64) -> TInt32:
         """Use the digital ramp generator to locate the alignment between
         ``IO_UPDATE`` and ``SYNC_CLK``.
 
@@ -1165,10 +1165,10 @@ class AD9910:
                 t1[0] += self.measure_io_update_alignment(i, i + 1)
                 t1[1] += self.measure_io_update_alignment(i + 1, i + 2)
             if ((t1[0] == 0 and t1[1] == 0) or
-                    (t1[0] == repeat and t1[1] == repeat)):                
+                    (t1[0] == repeat and t1[1] == repeat)):
                 # edge is not close to i + 1, can't interpret result
                 raise ValueError(
-                    "no clear IO_UPDATE-SYNC_CLK alignment edge found")                
+                    "no clear IO_UPDATE-SYNC_CLK alignment edge found")
             else:
                 # the good delay is period//2 after the edge
                 return (i + 1 + period // 2) & (period - 1)

--- a/artiq/coredevice/urukul.py
+++ b/artiq/coredevice/urukul.py
@@ -8,16 +8,10 @@ from artiq.language.core import at_mu, delay, kernel, now_mu, portable
 from artiq.language.types import TBool, TFloat, TInt32, TInt64
 from artiq.language.units import ms, us
 
-SPI_CONFIG = (
-    0 * spi.SPI_OFFLINE
-    | 0 * spi.SPI_END
-    | 0 * spi.SPI_INPUT
-    | 1 * spi.SPI_CS_POLARITY
-    | 0 * spi.SPI_CLK_POLARITY
-    | 0 * spi.SPI_CLK_PHASE
-    | 0 * spi.SPI_LSB_FIRST
-    | 0 * spi.SPI_HALF_DUPLEX
-)
+SPI_CONFIG = (0 * spi.SPI_OFFLINE | 0 * spi.SPI_END |
+              0 * spi.SPI_INPUT | 1 * spi.SPI_CS_POLARITY |
+              0 * spi.SPI_CLK_POLARITY | 0 * spi.SPI_CLK_PHASE |
+              0 * spi.SPI_LSB_FIRST | 0 * spi.SPI_HALF_DUPLEX)
 
 # SPI clock write and read dividers
 SPIT_CFG_WR = 2
@@ -693,23 +687,11 @@ class CPLD:
 
     kernel_invariants = {"refclk", "bus", "core", "io_update", "clk_div"}
 
-    def __init__(
-        self,
-        dmgr,
-        spi_device,
-        io_update_device=None,
-        dds_reset_device=None,
-        sync_device=None,
-        sync_sel=0,
-        clk_sel=0,
-        clk_div=0,
-        rf_sw=0,
-        refclk=125e6,
-        att=0x00000000,
-        sync_div=None,
-        proto_rev=0x08,
-        core_device="core",
-    ):
+    def __init__(self, dmgr, spi_device, io_update_device=None,
+                 dds_reset_device=None, sync_device=None,
+                 sync_sel=0, clk_sel=0, clk_div=0, rf_sw=0,
+                 refclk=125e6, att=0x00000000, sync_div=None,
+                 proto_rev=0x08, core_device="core"):
 
         self.core = dmgr.get(core_device)
         self.refclk = refclk
@@ -901,13 +883,14 @@ class CPLD:
         self.set_all_att_mu(a)
 
     @kernel
-    def set_all_att_mu(self, att_reg: TInt32):
+    def set_all_att_mu(self, att_reg: TInt32): 
         """Set all four digital step attenuators (in machine units).
         See also :meth:`set_att_mu`.
 
         :param att_reg: Attenuator setting string (32-bit)
         """
-        self.bus.set_config_mu(SPI_CONFIG | spi.SPI_END, 32, SPIT_ATT_WR, CS_ATT)
+        self.bus.set_config_mu(SPI_CONFIG | spi.SPI_END, 32,
+                               SPIT_ATT_WR, CS_ATT)
         self.bus.write(att_reg)
         self.att_reg = att_reg
 
@@ -935,9 +918,11 @@ class CPLD:
 
         :return: 32-bit attenuator settings
         """
-        self.bus.set_config_mu(SPI_CONFIG | spi.SPI_INPUT, 32, SPIT_ATT_RD, CS_ATT)
+        self.bus.set_config_mu(SPI_CONFIG | spi.SPI_INPUT, 32,
+                               SPIT_ATT_RD, CS_ATT)
         self.bus.write(0)  # shift in zeros, shift out current value
-        self.bus.set_config_mu(SPI_CONFIG | spi.SPI_END, 32, SPIT_ATT_WR, CS_ATT)
+        self.bus.set_config_mu(SPI_CONFIG | spi.SPI_END, 32,
+                               SPIT_ATT_WR, CS_ATT)
         delay(10 * us)
         self.att_reg = self.bus.read()
         self.bus.write(self.att_reg)  # shift in current value again and latch

--- a/artiq/test/coredevice/test_ad9910_waveform.py
+++ b/artiq/test/coredevice/test_ad9910_waveform.py
@@ -1,0 +1,678 @@
+from functools import wraps
+
+import artiq.coredevice.spi2 as spi
+from artiq.coredevice.ad9910 import (
+    _AD9910_REG_ASF,
+    _AD9910_REG_RAMP_LIMIT,
+    _AD9910_REG_RAMP_RATE,
+    _AD9910_REG_RAMP_STEP,
+)
+from artiq.coredevice.urukul import STA_PROTO_REV_8, STA_PROTO_REV_9
+from artiq.experiment import *
+from artiq.test.hardware_testbench import ExperimentCase
+
+###############################################################################
+## NOTE: These test are intended to create waveforms from AD9910 Urukul boards
+## (all protocol revisions, see tests below) used with an oscilloscope.
+## Set your oscilloscope to:
+##
+## Time division: 2 ns
+## Voltage division: 500 mV
+##
+## These settings work with a nominal 100 MHz waveform.
+## You will need to play with your trigger level setting for some of the tests.
+##
+## If you change FREQ (see below) to something else, adjust your oscilloscope
+## settings to accomodate.
+###############################################################################
+
+FREQ = 100 * MHz
+AMP = 1.0
+ATT = 1.0
+
+# Set to desired devices
+CPLD = "urukul0_cpld"
+DDS1 = "urukul0_ch0"
+DDS2 = "urukul0_ch3"
+
+
+class AD9910WaveformExp(EnvExperiment):
+    def build(self, runner, io_update_device=True):
+        self.setattr_device("core")
+        self.cpld = self.get_device(CPLD)
+        self.dds1 = self.get_device(DDS1)
+        self.dds2 = self.get_device(DDS2)
+        self.runner = runner
+        self.io_update_device = io_update_device
+
+    def run(self):
+        getattr(self, self.runner)()
+
+    @kernel
+    def instantiate(self):
+        pass
+
+    @kernel
+    def init(self):
+        self.core.break_realtime()
+        self.cpld.init()
+        self.dds1.init()
+        self.dds2.init()
+
+    @kernel
+    def single_tone(self):
+        self.core.reset()
+        self.cpld.init()
+
+        # Set ATT_EN
+        if self.cpld.proto_rev == STA_PROTO_REV_9:
+            self.dds1.cfg_att_en(True)
+            self.dds2.cfg_att_en(True)
+        if not self.io_update_device:
+            # Set MASK_NU to trigger CFG.IO_UPDATE
+            self.dds1.cfg_mask_nu(True)
+            self.dds2.cfg_mask_nu(True)
+
+        self.dds1.init()
+        self.dds2.init()
+
+        delay(10 * ms)
+
+        self.dds1.set(FREQ, amplitude=AMP)
+        self.dds2.set(FREQ, amplitude=AMP)
+
+        # Switch on waveforms
+        self.dds1.cfg_sw(True)
+        self.dds2.cfg_sw(True)
+
+        self.dds1.set_att(ATT)
+        self.dds2.set_att(ATT)
+
+        delay(5 * s)
+
+        # Switch off waveforms
+        self.dds1.cfg_sw(False)
+        self.dds2.cfg_sw(False)
+
+        if not self.io_update_device:
+            # Unset MASK_NU to un-trigger CFG.IO_UPDATE
+            self.dds1.cfg_mask_nu(False)
+            self.dds2.cfg_mask_nu(False)
+
+        # UnSet ATT_EN
+        if self.cpld.proto_rev == STA_PROTO_REV_9:
+            self.dds1.cfg_att_en(False)
+            self.dds2.cfg_att_en(False)
+
+        self.core.wait_until_mu(now_mu())
+
+    @kernel
+    def toggle_profile(self):
+        self.core.reset()
+        self.cpld.init()
+
+        if not self.io_update_device:
+            # Set MASK_NU to trigger CFG.IO_UPDATE
+            self.dds1.cfg_mask_nu(True)
+            self.dds2.cfg_mask_nu(True)
+
+        self.dds1.init()
+        self.dds2.init()
+
+        delay(10 * ms)
+
+        ## SET SINGLE-TONE PROFILES
+        # Set Profile 7 (default)
+        self.dds1.set(FREQ, amplitude=AMP)
+        self.dds2.set(FREQ, amplitude=AMP)
+        # Set Profile 6 (default)
+        self.dds1.set(FREQ + 25 * MHz, amplitude=AMP, profile=6)
+        self.dds2.set(FREQ + 25 * MHz, amplitude=AMP, profile=6)
+        # Set Profile 5 (default)
+        self.dds1.set(FREQ + 50 * MHz, amplitude=AMP, profile=5)
+        self.dds2.set(FREQ + 50 * MHz, amplitude=AMP, profile=5)
+        # Set Profile 4 (default)
+        self.dds1.set(FREQ + 75 * MHz, amplitude=AMP, profile=4)
+        self.dds2.set(FREQ + 75 * MHz, amplitude=AMP, profile=4)
+
+        delay(1 * s)  # slack
+
+        # Set Profile 3 (default)
+        self.dds1.set(FREQ + FREQ, amplitude=AMP, profile=3)
+        self.dds2.set(FREQ + FREQ, amplitude=AMP, profile=3)
+        # Set Profile 2 (default)
+        self.dds1.set(FREQ + 125 * MHz, amplitude=AMP, profile=2)
+        self.dds2.set(FREQ + 125 * MHz, amplitude=AMP, profile=2)
+        # Set Profile 1 (default)
+        self.dds1.set(FREQ + 150 * MHz, amplitude=AMP, profile=1)
+        self.dds2.set(FREQ + 150 * MHz, amplitude=AMP, profile=1)
+        # Set Profile 0 (default)
+        self.dds1.set(FREQ + 175 * MHz, amplitude=AMP, profile=0)
+        self.dds2.set(FREQ + 175 * MHz, amplitude=AMP, profile=0)
+
+        # Switch on waveforms -- Profile 7 (default)
+        self.dds1.cfg_sw(True)
+        self.dds2.cfg_sw(True)
+        self.dds1.set_att(ATT)
+        self.dds2.set_att(ATT)
+        delay(2 * s)
+        # Switch off waveforms
+        self.dds1.cfg_sw(False)
+        self.dds2.cfg_sw(False)
+
+        # Iterate over Profiles 6 to 0
+        for i in range(6, -1, -1):
+            # Switch channels 0 and 3 to Profile i
+            self.cpld.set_profile(0, i)
+            # This is the main different between proto_rev's,
+            # one sets them all
+            # self.cpld.set_profile(3, i)
+            self.dds1.cfg_sw(True)
+            self.dds2.cfg_sw(True)
+            delay(2 * s)
+            # Switch off waveforms
+            self.dds1.cfg_sw(False)
+            self.dds2.cfg_sw(False)
+
+        if not self.io_update_device:
+            # Unset MASK_NU to un-trigger CFG.IO_UPDATE
+            self.dds1.cfg_mask_nu(False)
+            self.dds2.cfg_mask_nu(False)
+
+        self.core.wait_until_mu(now_mu())
+
+    @kernel
+    def toggle_profiles(self):
+        self.core.reset()
+        self.cpld.init()
+        # Set ATT_EN
+        self.dds1.cfg_att_en(True)
+        self.dds2.cfg_att_en(True)
+        if not self.io_update_device:
+            # Set MASK_NU to trigger CFG.IO_UPDATE
+            self.dds1.cfg_mask_nu(True)
+            self.dds2.cfg_mask_nu(True)
+
+        self.dds1.init()
+        self.dds2.init()
+
+        delay(10 * ms)
+
+        ## SET SINGLE-TONE PROFILES
+        # Set Profile 7 (default)
+        self.dds1.set(FREQ, amplitude=AMP)
+        self.dds2.set(FREQ, amplitude=AMP)
+        # Set Profile 6 (default)
+        self.dds1.set(FREQ + 25 * MHz, amplitude=AMP, profile=6)
+        self.dds2.set(FREQ + 25 * MHz, amplitude=AMP, profile=6)
+        # Set Profile 5 (default)
+        self.dds1.set(FREQ + 50 * MHz, amplitude=AMP, profile=5)
+        self.dds2.set(FREQ + 50 * MHz, amplitude=AMP, profile=5)
+        # Set Profile 4 (default)
+        self.dds1.set(FREQ + 75 * MHz, amplitude=AMP, profile=4)
+        self.dds2.set(FREQ + 75 * MHz, amplitude=AMP, profile=4)
+
+        delay(1 * s)  # slack
+
+        # Set Profile 3 (default)
+        self.dds1.set(FREQ + FREQ, amplitude=AMP, profile=3)
+        self.dds2.set(FREQ + FREQ, amplitude=AMP, profile=3)
+        # Set Profile 2 (default)
+        self.dds1.set(FREQ + 125 * MHz, amplitude=AMP, profile=2)
+        self.dds2.set(FREQ + 125 * MHz, amplitude=AMP, profile=2)
+        # Set Profile 1 (default)
+        self.dds1.set(FREQ + 150 * MHz, amplitude=AMP, profile=1)
+        self.dds2.set(FREQ + 150 * MHz, amplitude=AMP, profile=1)
+        # Set Profile 0 (default)
+        self.dds1.set(FREQ + 175 * MHz, amplitude=AMP, profile=0)
+        self.dds2.set(FREQ + 175 * MHz, amplitude=AMP, profile=0)
+
+        # Switch on waveforms -- Profile 7 (default)
+        self.dds1.cfg_sw(True)
+        self.dds2.cfg_sw(True)
+        self.dds1.set_att(ATT)
+        self.dds2.set_att(ATT)
+        delay(2 * s)
+        # Switch off waveforms
+        self.dds1.cfg_sw(False)
+        self.dds2.cfg_sw(False)
+
+        # Iterate over Profiles 6 to 0
+        for i in range(6, -1, -1):
+            # Switch channels 0 and 3 to Profile i
+            self.cpld.set_profile(0, i)
+            self.cpld.set_profile(3, i)
+            self.dds1.cfg_sw(True)
+            self.dds2.cfg_sw(True)
+            delay(2 * s)
+            # Switch off waveforms
+            self.dds1.cfg_sw(False)
+            self.dds2.cfg_sw(False)
+
+        if not self.io_update_device:
+            # Unset MASK_NU to un-trigger CFG.IO_UPDATE
+            self.dds1.cfg_mask_nu(False)
+            self.dds2.cfg_mask_nu(False)
+
+        # UnSet ATT_EN
+        self.dds1.cfg_att_en(False)
+        self.dds2.cfg_att_en(False)
+
+        self.core.wait_until_mu(now_mu())
+
+    @kernel
+    def osk(self):
+        self.core.reset()
+        self.cpld.init()
+        # Set ATT_EN
+        self.dds1.cfg_att_en(True)
+        if not self.io_update_device:
+            # Set MASK_NU to trigger CFG.IO_UPDATE
+            self.dds1.cfg_mask_nu(True)
+
+        self.dds1.init()
+
+        delay(10 * ms)
+
+        self.dds1.set(FREQ, amplitude=AMP)
+        self.dds1.set_cfr1(manual_osk_external=1, osk_enable=1)
+        self.dds1.cpld.io_update.pulse(1 * ms)
+        self.dds1.set_asf(0x3FFF)
+        self.dds1.cpld.io_update.pulse(1 * ms)
+
+        # Switch on waveform, then set attenuation
+        self.dds1.cfg_sw(True)
+        self.dds1.set_att(ATT)
+        for _ in range(5):
+            # Toggle output via OSK
+            self.dds1.cfg_osk(True)
+            delay(1 * s)
+            self.dds1.cfg_osk(False)
+            delay(1 * s)
+        # Switch off waveform
+        self.dds1.cfg_sw(False)
+
+        if not self.io_update_device:
+            # Unset MASK_NU to un-trigger CFG.IO_UPDATE
+            self.dds1.cfg_mask_nu(False)
+
+        # UnSet ATT_EN
+        self.dds1.cfg_att_en(False)
+
+        self.core.wait_until_mu(now_mu())
+
+    @kernel
+    def osk_auto(self):
+        self.core.reset()
+        self.cpld.init()
+        # Set ATT_EN
+        self.dds1.cfg_att_en(True)
+        if not self.io_update_device:
+            # Set MASK_NU to trigger CFG.IO_UPDATE
+            self.dds1.cfg_mask_nu(True)
+
+        self.dds1.init()
+
+        delay(10 * ms)
+
+        self.dds1.set(FREQ, amplitude=AMP)
+        self.dds1.set_cfr1(osk_enable=1, select_auto_osk=1)
+        self.dds1.cpld.io_update.pulse(1 * ms)
+        self.dds1.write32(_AD9910_REG_ASF, 0xFFFF << 16 | 0x3FFF << 2 | 0b11)
+        self.dds1.cpld.io_update.pulse(1 * ms)
+
+        # Switch on waveform, then set attenuation
+        self.dds1.cfg_sw(True)
+        self.dds1.set_att(ATT)
+        for _ in range(5):
+            self.dds1.cfg_osk(True)
+            delay(1 * s)
+            self.dds1.cfg_osk(False)
+            delay(1 * s)
+        # Switch off waveform
+        self.dds1.cfg_sw(False)
+
+        if not self.io_update_device:
+            # Unset MASK_NU to un-trigger CFG.IO_UPDATE
+            self.dds1.cfg_mask_nu(False)
+
+        # UnSet ATT_EN
+        self.dds1.cfg_att_en(False)
+
+        self.core.wait_until_mu(now_mu())
+
+    @kernel
+    def drg_normal(self):
+        self.core.reset()
+        self.cpld.init()
+        # Set ATT_EN
+        self.dds1.cfg_att_en(True)
+        if not self.io_update_device:
+            # Set MASK_NU to trigger CFG.IO_UPDATE
+            self.dds1.cfg_mask_nu(True)
+
+        self.dds1.init()
+
+        delay(10 * ms)
+
+        self.dds1.frequency_to_ftw(FREQ)
+        # cfr2 21:20 destination, 19 drg enable, no-dwell high, no-dwell low,
+        self.dds1.set(FREQ, amplitude=AMP)
+        self.dds1.set_cfr2(drg_enable=1)
+        self.dds1.cpld.io_update.pulse(1 * ms)
+        self.dds1.write64(
+            _AD9910_REG_RAMP_LIMIT,
+            self.dds1.frequency_to_ftw(FREQ + 30 * MHz),
+            self.dds1.frequency_to_ftw(FREQ - 30 * MHz),
+        )
+        # The larger the values, the slower the update happens
+        self.dds1.write32(_AD9910_REG_RAMP_RATE, 0x004F004F)
+        # The smaller the value it is, the smaller the frequency step
+        self.dds1.write64(_AD9910_REG_RAMP_STEP, 0xF0, 0xF0)
+        self.dds1.cpld.io_update.pulse(1 * ms)
+
+        # Switch on waveform, then set attenuation
+        self.dds1.cfg_sw(True)
+        self.dds1.set_att(ATT)
+        for _ in range(10):
+            self.dds1.cfg_drctl(True)
+            delay(0.5 * s)
+            self.dds1.cfg_drctl(False)
+            delay(0.5 * s)
+        # Switch off waveform
+        self.dds1.cfg_sw(False)
+
+        if not self.io_update_device:
+            # Unset MASK_NU to un-trigger CFG.IO_UPDATE
+            self.dds1.cfg_mask_nu(False)
+
+        # UnSet ATT_EN
+        self.dds1.cfg_att_en(False)
+
+        self.core.wait_until_mu(now_mu())
+
+    @kernel
+    def drg_normal_with_hold(self):
+        self.core.reset()
+        self.cpld.init()
+        # Set ATT_EN
+        self.dds1.cfg_att_en(True)
+        if not self.io_update_device:
+            # Set MASK_NU to trigger CFG.IO_UPDATE
+            self.dds1.cfg_mask_nu(True)
+
+        self.dds1.init()
+
+        delay(10 * ms)
+
+        self.dds1.frequency_to_ftw(FREQ)
+        # cfr2 21:20 destination, 19 drg enable, no-dwell high, no-dwell low,
+        self.dds1.set(FREQ, amplitude=AMP)
+        self.dds1.set_cfr2(drg_enable=1)
+        self.dds1.cpld.io_update.pulse(1 * ms)
+        self.dds1.write64(
+            _AD9910_REG_RAMP_LIMIT,
+            self.dds1.frequency_to_ftw(FREQ + 30 * MHz),
+            self.dds1.frequency_to_ftw(FREQ - 30 * MHz),
+        )
+        # The larger the values, the slower the update happens
+        self.dds1.write32(_AD9910_REG_RAMP_RATE, 0x004F004F)
+        # The smaller the value it is, the smaller the frequency step
+        self.dds1.write64(_AD9910_REG_RAMP_STEP, 0xF0, 0xF0)
+        self.dds1.cpld.io_update.pulse(1 * ms)
+
+        # Switch on waveform, then set attenuation
+        self.dds1.cfg_sw(True)
+        self.dds1.set_att(ATT)
+        for _ in range(10):
+            self.dds1.cfg_drctl(True)
+            delay(0.25 * s)
+            self.dds1.cfg_drhold(True)
+            delay(0.25)
+            self.dds1.cfg_drhold(False)
+            delay(0.25)
+            self.dds1.cfg_drctl(False)
+            delay(0.25)
+            self.dds1.cfg_drhold(True)
+            delay(0.25)
+            self.dds1.cfg_drhold(False)
+            delay(0.25)
+        # Switch off waveform
+        self.dds1.cfg_sw(False)
+
+        if not self.io_update_device:
+            # Unset MASK_NU to un-trigger CFG.IO_UPDATE
+            self.dds1.cfg_mask_nu(False)
+
+        # UnSet ATT_EN
+        self.dds1.cfg_att_en(False)
+
+        self.core.wait_until_mu(now_mu())
+
+    @kernel
+    def drg_nodwell(self):
+        self.core.reset()
+        self.cpld.init()
+        # Set ATT_EN
+        self.dds1.cfg_att_en(True)
+        if not self.io_update_device:
+            # Set MASK_NU to trigger CFG.IO_UPDATE
+            self.dds1.cfg_mask_nu(True)
+
+        self.dds1.init()
+
+        delay(10 * ms)
+
+        self.dds1.frequency_to_ftw(FREQ)
+        # cfr2 21:20 destination, 19 drg enable, no-dwell high, no-dwell low,
+        self.dds1.set(FREQ, amplitude=AMP)
+        self.dds1.set_cfr2(drg_enable=1, drg_nodwell_high=1, drg_nodwell_low=1)
+        self.dds1.cpld.io_update.pulse(1 * ms)
+        self.dds1.write64(
+            _AD9910_REG_RAMP_LIMIT,
+            self.dds1.frequency_to_ftw(FREQ + 30 * MHz),
+            self.dds1.frequency_to_ftw(FREQ - 30 * MHz),
+        )
+        # The larger the values, the slower the update happens
+        self.dds1.write32(_AD9910_REG_RAMP_RATE, 0x004F004F)
+        # The smaller the value it is, the smaller the frequency step
+        self.dds1.write64(_AD9910_REG_RAMP_STEP, 0xF0, 0xF0)
+        self.dds1.cpld.io_update.pulse(1 * ms)
+
+        # Switch on waveform, then set attenuation
+        self.dds1.cfg_sw(True)
+        self.dds1.set_att(ATT)
+
+        delay(10 * s)
+        # Switch off waveform
+        self.dds1.cfg_sw(False)
+
+        if not self.io_update_device:
+            # Unset MASK_NU to un-trigger CFG.IO_UPDATE
+            self.dds1.cfg_mask_nu(False)
+
+        # UnSet ATT_EN
+        self.dds1.cfg_att_en(False)
+
+        self.core.wait_until_mu(now_mu())
+
+    @kernel
+    def att_single_tone(self):
+        self.core.reset()
+        self.cpld.init()
+        # Set ATT_EN
+        self.dds1.cfg_att_en(True)
+        self.dds2.cfg_att_en(True)
+        if not self.io_update_device:
+            # Set MASK_NU to trigger CFG.IO_UPDATE
+            self.dds1.cfg_mask_nu(True)
+            self.dds2.cfg_mask_nu(True)
+
+        self.dds1.init()
+        self.dds2.init()
+
+        delay(10 * ms)
+
+        self.dds1.set(FREQ, amplitude=AMP)
+        self.dds2.set(FREQ, amplitude=AMP)
+
+        delay(1 * ms)
+
+        # Switch on waveforms
+        self.dds1.cfg_sw(True)
+        self.dds2.cfg_sw(True)
+
+        # This must be set AFTER cfg_sw set to True (why?)
+        self.dds1.set_att(0.0 * dB)
+        self.dds2.set_att(0.0 * dB)
+
+        delay(5 * s)
+
+        self.dds1.set_att(10.0)
+        self.dds2.set_att(10.0)
+
+        delay(5 * s)
+
+        self.dds1.set_att(20.0)
+        self.dds2.set_att(20.0)
+
+        delay(5 * s)
+
+        self.dds1.set_att(30.0)
+        self.dds2.set_att(30.0)
+
+        delay(5 * s)
+
+        # Switch off waveforms
+        self.dds1.cfg_sw(False)
+        self.dds2.cfg_sw(False)
+
+        if not self.io_update_device:
+            # Unset MASK_NU to un-trigger CFG.IO_UPDATE
+            self.dds1.cfg_mask_nu(False)
+            self.dds2.cfg_mask_nu(False)
+
+        # UnSet ATT_EN
+        self.dds1.cfg_att_en(False)
+        self.dds2.cfg_att_en(False)
+
+        self.core.wait_until_mu(now_mu())
+
+
+def io_update_device(required, proto_rev=None):
+    """
+    Decorator to mark whether a test requires 'io_update_device' to be set or unset
+    and optionally check the protocol version.
+    """
+
+    def decorator(test_func):
+        @wraps(test_func)
+        def wrapper(self, *args, **kwargs):
+            if hasattr(self.device_mgr, "get_desc"):
+                if (
+                    required
+                    and "io_update_device"
+                    not in self.device_mgr.get_desc(CPLD)["arguments"]
+                ):
+                    self.skipTest("This test requires 'io_update_device' to be set.")
+                if (
+                    not required
+                    and "io_update_device"
+                    in self.device_mgr.get_desc(CPLD)["arguments"]
+                ):
+                    self.skipTest("This test requires 'io_update_device' to be unset.")
+
+            if proto_rev is not None:
+                actual_proto_rev = self.device_mgr.get(CPLD).proto_rev
+                if actual_proto_rev != proto_rev:
+                    self.skipTest(
+                        f"This test requires proto_rev={proto_rev}, but the current proto_rev is {actual_proto_rev}."
+                    )
+
+            print(f"Running test: {test_func.__name__}")
+            return test_func(self, *args, **kwargs)
+
+        wrapper.requires_io_update_device = required
+        return wrapper
+
+    return decorator
+
+
+class AD9910Test(ExperimentCase):
+    def test_instantiate(self):
+        self.execute(AD9910WaveformExp, "instantiate")
+
+    def test_init(self):
+        self.execute(AD9910WaveformExp, "init")
+
+    @io_update_device(True)
+    def test_single_tone(self):
+        self.execute(AD9910WaveformExp, "single_tone")
+
+    @io_update_device(False)
+    def test_single_tone_no_io_update_device(self):
+        self.execute(AD9910WaveformExp, "single_tone", io_update_device=False)
+
+    @io_update_device(True, proto_rev=STA_PROTO_REV_8)
+    def test_toggle_profile(self):
+        self.execute(AD9910WaveformExp, "toggle_profile")
+
+    @io_update_device(False, proto_rev=STA_PROTO_REV_8)
+    def test_toggle_profile_no_io_update_device(self):
+        self.execute(AD9910WaveformExp, "toggle_profile", io_update_device=False)
+
+    @io_update_device(True, proto_rev=STA_PROTO_REV_9)
+    def test_toggle_profiles(self):
+        self.execute(AD9910WaveformExp, "toggle_profiles")
+
+    @io_update_device(False, proto_rev=STA_PROTO_REV_9)
+    def test_toggle_profiles_no_io_update_device(self):
+        self.execute(AD9910WaveformExp, "toggle_profiles", io_update_device=False)
+
+    @io_update_device(True, proto_rev=STA_PROTO_REV_9)
+    def test_osk(self):
+        self.execute(AD9910WaveformExp, "osk")
+
+    @io_update_device(False, proto_rev=STA_PROTO_REV_9)
+    def test_osk_no_io_update_device(self):
+        self.execute(AD9910WaveformExp, "osk", io_update_device=False)
+
+    @io_update_device(True, proto_rev=STA_PROTO_REV_9)
+    def test_osk_auto(self):
+        self.execute(AD9910WaveformExp, "osk_auto")
+
+    @io_update_device(False, proto_rev=STA_PROTO_REV_9)
+    def test_osk_auto_no_io_update_device(self):
+        self.execute(AD9910WaveformExp, "osk_auto", io_update_device=False)
+
+    @io_update_device(True, proto_rev=STA_PROTO_REV_9)
+    def test_drg_normal(self):
+        self.execute(AD9910WaveformExp, "drg_normal")
+
+    @io_update_device(False, proto_rev=STA_PROTO_REV_9)
+    def test_drg_normal_no_io_update_device(self):
+        self.execute(AD9910WaveformExp, "drg_normal", io_update_device=False)
+
+    @io_update_device(True, proto_rev=STA_PROTO_REV_9)
+    def test_drg_normal_with_hold(self):
+        self.execute(AD9910WaveformExp, "drg_normal_with_hold")
+
+    @io_update_device(False, proto_rev=STA_PROTO_REV_9)
+    def test_drg_normal_with_hold_no_io_update_device(self):
+        self.execute(AD9910WaveformExp, "drg_normal_with_hold", io_update_device=False)
+
+    @io_update_device(True, proto_rev=STA_PROTO_REV_9)
+    def test_drg_nodwell(self):
+        self.execute(AD9910WaveformExp, "drg_nodwell")
+
+    @io_update_device(False, proto_rev=STA_PROTO_REV_9)
+    def test_drg_nodwell_no_io_update_device(self):
+        self.execute(AD9910WaveformExp, "drg_nodwell", io_update_device=False)
+
+    @io_update_device(True, proto_rev=STA_PROTO_REV_9)
+    def test_att_single_tone(self):
+        self.execute(AD9910WaveformExp, "att_single_tone")
+
+    @io_update_device(False, proto_rev=STA_PROTO_REV_9)
+    def test_att_single_tone_no_io_update_device(self):
+        self.execute(AD9910WaveformExp, "att_single_tone", io_update_device=False)

--- a/artiq/test/coredevice/test_ad9910_waveform.py
+++ b/artiq/test/coredevice/test_ad9910_waveform.py
@@ -11,39 +11,56 @@ from artiq.coredevice.urukul import STA_PROTO_REV_8, STA_PROTO_REV_9
 from artiq.experiment import *
 from artiq.test.hardware_testbench import ExperimentCase
 
-###############################################################################
+###################################################################################
 ## NOTE: These test are intended to create waveforms from AD9910 Urukul boards
-## (all protocol revisions, see tests below) used with an oscilloscope.
+## (all protocol revisions, see tests below) used with a dual-channel oscilloscope.
+##
 ## Set your oscilloscope to:
 ##
 ## Time division: 2 ns
 ## Voltage division: 500 mV
 ##
-## These settings work with a nominal 100 MHz waveform.
+## The settings below work with a nominal 100 MHz waveform.  Set trigger to DDS1.
 ## You will need to play with your trigger level setting for some of the tests.
 ##
 ## If you change FREQ (see below) to something else, adjust your oscilloscope
 ## settings to accomodate.
-###############################################################################
+###################################################################################
 
 FREQ = 100 * MHz
 AMP = 1.0
 ATT = 1.0
 
 # Set to desired devices
-CPLD = "urukul0_cpld"
-DDS1 = "urukul0_ch0"
-DDS2 = "urukul0_ch3"
+CPLD = "urukul1_cpld"
+DDS1 = "urukul1_ch0"
+DDS2 = "urukul1_ch3"
 
 
 class AD9910WaveformExp(EnvExperiment):
-    def build(self, runner, io_update_device=True):
+    def build(
+        self,
+        runner,
+        io_update_device=True,
+        multiple_profiles=True,
+        osk_manual=True,
+        drg_destination=0x0,
+        use_dds2=False,
+        with_hold=False,
+        nodwell=0,
+    ):
         self.setattr_device("core")
         self.cpld = self.get_device(CPLD)
         self.dds1 = self.get_device(DDS1)
         self.dds2 = self.get_device(DDS2)
         self.runner = runner
         self.io_update_device = io_update_device
+        self.multiple_profiles = multiple_profiles
+        self.osk_manual = osk_manual
+        self.drg_destination = drg_destination
+        self.use_dds2 = use_dds2
+        self.with_hold = with_hold
+        self.nodwell = nodwell
 
     def run(self):
         getattr(self, self.runner)()
@@ -107,81 +124,6 @@ class AD9910WaveformExp(EnvExperiment):
         self.core.wait_until_mu(now_mu())
 
     @kernel
-    def toggle_profile(self):
-        self.core.reset()
-        self.cpld.init()
-
-        if not self.io_update_device:
-            # Set MASK_NU to trigger CFG.IO_UPDATE
-            self.dds1.cfg_mask_nu(True)
-            self.dds2.cfg_mask_nu(True)
-
-        self.dds1.init()
-        self.dds2.init()
-
-        delay(10 * ms)
-
-        ## SET SINGLE-TONE PROFILES
-        # Set Profile 7 (default)
-        self.dds1.set(FREQ, amplitude=AMP)
-        self.dds2.set(FREQ, amplitude=AMP)
-        # Set Profile 6 (default)
-        self.dds1.set(FREQ + 25 * MHz, amplitude=AMP, profile=6)
-        self.dds2.set(FREQ + 25 * MHz, amplitude=AMP, profile=6)
-        # Set Profile 5 (default)
-        self.dds1.set(FREQ + 50 * MHz, amplitude=AMP, profile=5)
-        self.dds2.set(FREQ + 50 * MHz, amplitude=AMP, profile=5)
-        # Set Profile 4 (default)
-        self.dds1.set(FREQ + 75 * MHz, amplitude=AMP, profile=4)
-        self.dds2.set(FREQ + 75 * MHz, amplitude=AMP, profile=4)
-
-        delay(1 * s)  # slack
-
-        # Set Profile 3 (default)
-        self.dds1.set(FREQ + FREQ, amplitude=AMP, profile=3)
-        self.dds2.set(FREQ + FREQ, amplitude=AMP, profile=3)
-        # Set Profile 2 (default)
-        self.dds1.set(FREQ + 125 * MHz, amplitude=AMP, profile=2)
-        self.dds2.set(FREQ + 125 * MHz, amplitude=AMP, profile=2)
-        # Set Profile 1 (default)
-        self.dds1.set(FREQ + 150 * MHz, amplitude=AMP, profile=1)
-        self.dds2.set(FREQ + 150 * MHz, amplitude=AMP, profile=1)
-        # Set Profile 0 (default)
-        self.dds1.set(FREQ + 175 * MHz, amplitude=AMP, profile=0)
-        self.dds2.set(FREQ + 175 * MHz, amplitude=AMP, profile=0)
-
-        # Switch on waveforms -- Profile 7 (default)
-        self.dds1.cfg_sw(True)
-        self.dds2.cfg_sw(True)
-        self.dds1.set_att(ATT)
-        self.dds2.set_att(ATT)
-        delay(2 * s)
-        # Switch off waveforms
-        self.dds1.cfg_sw(False)
-        self.dds2.cfg_sw(False)
-
-        # Iterate over Profiles 6 to 0
-        for i in range(6, -1, -1):
-            # Switch channels 0 and 3 to Profile i
-            self.cpld.set_profile(0, i)
-            # This is the main different between proto_rev's,
-            # one sets them all
-            # self.cpld.set_profile(3, i)
-            self.dds1.cfg_sw(True)
-            self.dds2.cfg_sw(True)
-            delay(2 * s)
-            # Switch off waveforms
-            self.dds1.cfg_sw(False)
-            self.dds2.cfg_sw(False)
-
-        if not self.io_update_device:
-            # Unset MASK_NU to un-trigger CFG.IO_UPDATE
-            self.dds1.cfg_mask_nu(False)
-            self.dds2.cfg_mask_nu(False)
-
-        self.core.wait_until_mu(now_mu())
-
-    @kernel
     def toggle_profiles(self):
         self.core.reset()
         self.cpld.init()
@@ -199,33 +141,23 @@ class AD9910WaveformExp(EnvExperiment):
         delay(10 * ms)
 
         ## SET SINGLE-TONE PROFILES
-        # Set Profile 7 (default)
-        self.dds1.set(FREQ, amplitude=AMP)
-        self.dds2.set(FREQ, amplitude=AMP)
-        # Set Profile 6 (default)
-        self.dds1.set(FREQ + 25 * MHz, amplitude=AMP, profile=6)
-        self.dds2.set(FREQ + 25 * MHz, amplitude=AMP, profile=6)
-        # Set Profile 5 (default)
-        self.dds1.set(FREQ + 50 * MHz, amplitude=AMP, profile=5)
-        self.dds2.set(FREQ + 50 * MHz, amplitude=AMP, profile=5)
-        # Set Profile 4 (default)
-        self.dds1.set(FREQ + 75 * MHz, amplitude=AMP, profile=4)
-        self.dds2.set(FREQ + 75 * MHz, amplitude=AMP, profile=4)
-
-        delay(1 * s)  # slack
-
-        # Set Profile 3 (default)
-        self.dds1.set(FREQ + FREQ, amplitude=AMP, profile=3)
-        self.dds2.set(FREQ + FREQ, amplitude=AMP, profile=3)
-        # Set Profile 2 (default)
-        self.dds1.set(FREQ + 125 * MHz, amplitude=AMP, profile=2)
-        self.dds2.set(FREQ + 125 * MHz, amplitude=AMP, profile=2)
-        # Set Profile 1 (default)
-        self.dds1.set(FREQ + 150 * MHz, amplitude=AMP, profile=1)
-        self.dds2.set(FREQ + 150 * MHz, amplitude=AMP, profile=1)
-        # Set Profile 0 (default)
-        self.dds1.set(FREQ + 175 * MHz, amplitude=AMP, profile=0)
-        self.dds2.set(FREQ + 175 * MHz, amplitude=AMP, profile=0)
+        # Set profiles from 7 to 0
+        frequencies = [
+            0.0,
+            25 * MHz,
+            50 * MHz,
+            75 * MHz,
+            100 * MHz,
+            125 * MHz,
+            150 * MHz,
+            175 * MHz,
+        ]
+        for i in range(6, -1, -1):
+            freq_offset = frequencies[i]
+            profile = 7 - i
+            self.dds1.set(FREQ + freq_offset, amplitude=AMP, profile=profile)
+            self.dds2.set(FREQ + freq_offset, amplitude=AMP, profile=profile)
+            delay(0.5 * s)  # slack
 
         # Switch on waveforms -- Profile 7 (default)
         self.dds1.cfg_sw(True)
@@ -239,9 +171,11 @@ class AD9910WaveformExp(EnvExperiment):
 
         # Iterate over Profiles 6 to 0
         for i in range(6, -1, -1):
-            # Switch channels 0 and 3 to Profile i
+            # Switch channels to Profile i
             self.cpld.set_profile(0, i)
-            self.cpld.set_profile(3, i)
+            if self.multiple_profiles:
+                self.cpld.set_profile(3, i)
+
             self.dds1.cfg_sw(True)
             self.dds2.cfg_sw(True)
             delay(2 * s)
@@ -275,9 +209,13 @@ class AD9910WaveformExp(EnvExperiment):
         delay(10 * ms)
 
         self.dds1.set(FREQ, amplitude=AMP)
-        self.dds1.set_cfr1(manual_osk_external=1, osk_enable=1)
-        self.dds1.cpld.io_update.pulse(1 * ms)
-        self.dds1.set_asf(0x3FFF)
+
+        if self.osk_manual:
+            self.dds1.set_cfr1(manual_osk_external=1, osk_enable=1)
+        else:
+            self.dds1.write32(_AD9910_REG_ASF, 0xFFFF << 16 | 0x3FFF << 2 | 0b11)
+            self.dds1.set_cfr1(osk_enable=1, select_auto_osk=1)
+
         self.dds1.cpld.io_update.pulse(1 * ms)
 
         # Switch on waveform, then set attenuation
@@ -302,197 +240,109 @@ class AD9910WaveformExp(EnvExperiment):
         self.core.wait_until_mu(now_mu())
 
     @kernel
-    def osk_auto(self):
+    def drg(self):
         self.core.reset()
         self.cpld.init()
+
         # Set ATT_EN
         self.dds1.cfg_att_en(True)
+        if self.use_dds2:
+            self.dds2.cfg_att_en(True)
+
         if not self.io_update_device:
             # Set MASK_NU to trigger CFG.IO_UPDATE
             self.dds1.cfg_mask_nu(True)
+            if self.use_dds2:
+                self.dds2.cfg_mask_nu(True)
 
         self.dds1.init()
+        if self.use_dds2:
+            self.dds2.init()
 
         delay(10 * ms)
 
+        # Set initial frequency and amplitude
         self.dds1.set(FREQ, amplitude=AMP)
-        self.dds1.set_cfr1(osk_enable=1, select_auto_osk=1)
-        self.dds1.cpld.io_update.pulse(1 * ms)
-        self.dds1.write32(_AD9910_REG_ASF, 0xFFFF << 16 | 0x3FFF << 2 | 0b11)
-        self.dds1.cpld.io_update.pulse(1 * ms)
+        if self.use_dds2:
+            self.dds2.set(FREQ, amplitude=AMP)
 
-        # Switch on waveform, then set attenuation
-        self.dds1.cfg_sw(True)
-        self.dds1.set_att(ATT)
-        for _ in range(5):
-            self.dds1.cfg_osk(True)
-            delay(1 * s)
-            self.dds1.cfg_osk(False)
-            delay(1 * s)
-        # Switch off waveform
-        self.dds1.cfg_sw(False)
+        # Configure DRG
+        if self.drg_destination == 0x0:  # Frequency
+            ramp_limit_high = self.dds1.frequency_to_ftw(FREQ + 30 * MHz)
+            ramp_limit_low = self.dds1.frequency_to_ftw(FREQ - 30 * MHz)
+            ramp_rate = 0x004F004F
+            ramp_step = 0xF0
+            pulse_duration = 1 * s if not self.with_hold else 0.25 * s
+        elif self.drg_destination == 0x1:  # Phase
+            ramp_limit_high = 0xFFFFFFFF
+            ramp_limit_low = 0
+            ramp_rate = 0xC350C350
+            ramp_step = 0xD1B71
+            pulse_duration = 2 * s if not self.with_hold else 0.25 * s
+        else:  # Amplitude
+            ramp_limit_high = 0xFFFFFFFF
+            ramp_limit_low = 0
+            ramp_rate = 0xC350C350
+            ramp_step = 0xD1B71
+            pulse_duration = 2 * s if not self.with_hold else 0.4 * s
 
-        if not self.io_update_device:
-            # Unset MASK_NU to un-trigger CFG.IO_UPDATE
-            self.dds1.cfg_mask_nu(False)
+        self.dds1.write64(_AD9910_REG_RAMP_LIMIT, ramp_limit_high, ramp_limit_low)
+        self.dds1.write32(_AD9910_REG_RAMP_RATE, ramp_rate)
+        self.dds1.write64(_AD9910_REG_RAMP_STEP, ramp_step, ramp_step)
 
-        # UnSet ATT_EN
-        self.dds1.cfg_att_en(False)
-
-        self.core.wait_until_mu(now_mu())
-
-    @kernel
-    def drg_normal(self):
-        self.core.reset()
-        self.cpld.init()
-        # Set ATT_EN
-        self.dds1.cfg_att_en(True)
-        if not self.io_update_device:
-            # Set MASK_NU to trigger CFG.IO_UPDATE
-            self.dds1.cfg_mask_nu(True)
-
-        self.dds1.init()
-
-        delay(10 * ms)
-
-        self.dds1.frequency_to_ftw(FREQ)
-        # cfr2 21:20 destination, 19 drg enable, no-dwell high, no-dwell low,
-        self.dds1.set(FREQ, amplitude=AMP)
-        self.dds1.set_cfr2(drg_enable=1)
-        self.dds1.cpld.io_update.pulse(1 * ms)
-        self.dds1.write64(
-            _AD9910_REG_RAMP_LIMIT,
-            self.dds1.frequency_to_ftw(FREQ + 30 * MHz),
-            self.dds1.frequency_to_ftw(FREQ - 30 * MHz),
+        self.dds1.set_cfr2(
+            drg_enable=1,
+            drg_destination=self.drg_destination,
+            drg_nodwell_high=self.nodwell,
+            drg_nodwell_low=self.nodwell,
         )
-        # The larger the values, the slower the update happens
-        self.dds1.write32(_AD9910_REG_RAMP_RATE, 0x004F004F)
-        # The smaller the value it is, the smaller the frequency step
-        self.dds1.write64(_AD9910_REG_RAMP_STEP, 0xF0, 0xF0)
         self.dds1.cpld.io_update.pulse(1 * ms)
 
-        # Switch on waveform, then set attenuation
+        # Enable waveform and set attenuation
         self.dds1.cfg_sw(True)
         self.dds1.set_att(ATT)
-        for _ in range(10):
-            self.dds1.cfg_drctl(True)
-            delay(0.5 * s)
-            self.dds1.cfg_drctl(False)
-            delay(0.5 * s)
-        # Switch off waveform
+        if self.use_dds2:
+            self.dds2.cfg_sw(True)
+            self.dds2.set_att(ATT)
+
+        if not self.nodwell:
+            for _ in range(5):
+                if self.with_hold:
+                    self.dds1.cfg_drctl(True)
+                    delay(pulse_duration)
+                    self.dds1.cfg_drhold(True)
+                    delay(pulse_duration)
+                    self.dds1.cfg_drhold(False)
+                    delay(pulse_duration)
+                    self.dds1.cfg_drctl(False)
+                    delay(pulse_duration)
+                    self.dds1.cfg_drhold(True)
+                    delay(pulse_duration)
+                    self.dds1.cfg_drhold(False)
+                    delay(pulse_duration)
+                else:
+                    self.dds1.cfg_drctl(True)
+                    delay(pulse_duration)
+                    self.dds1.cfg_drctl(False)
+                    delay(pulse_duration)
+        else:
+            delay(10 * s)
+
+        # Disable waveform
         self.dds1.cfg_sw(False)
+        if self.use_dds2:
+            self.dds2.cfg_sw(False)
 
         if not self.io_update_device:
             # Unset MASK_NU to un-trigger CFG.IO_UPDATE
             self.dds1.cfg_mask_nu(False)
+            if self.use_dds2:
+                self.dds2.cfg_mask_nu(False)
 
-        # UnSet ATT_EN
+        # Unset ATT_EN
         self.dds1.cfg_att_en(False)
-
-        self.core.wait_until_mu(now_mu())
-
-    @kernel
-    def drg_normal_with_hold(self):
-        self.core.reset()
-        self.cpld.init()
-        # Set ATT_EN
-        self.dds1.cfg_att_en(True)
-        if not self.io_update_device:
-            # Set MASK_NU to trigger CFG.IO_UPDATE
-            self.dds1.cfg_mask_nu(True)
-
-        self.dds1.init()
-
-        delay(10 * ms)
-
-        self.dds1.frequency_to_ftw(FREQ)
-        # cfr2 21:20 destination, 19 drg enable, no-dwell high, no-dwell low,
-        self.dds1.set(FREQ, amplitude=AMP)
-        self.dds1.set_cfr2(drg_enable=1)
-        self.dds1.cpld.io_update.pulse(1 * ms)
-        self.dds1.write64(
-            _AD9910_REG_RAMP_LIMIT,
-            self.dds1.frequency_to_ftw(FREQ + 30 * MHz),
-            self.dds1.frequency_to_ftw(FREQ - 30 * MHz),
-        )
-        # The larger the values, the slower the update happens
-        self.dds1.write32(_AD9910_REG_RAMP_RATE, 0x004F004F)
-        # The smaller the value it is, the smaller the frequency step
-        self.dds1.write64(_AD9910_REG_RAMP_STEP, 0xF0, 0xF0)
-        self.dds1.cpld.io_update.pulse(1 * ms)
-
-        # Switch on waveform, then set attenuation
-        self.dds1.cfg_sw(True)
-        self.dds1.set_att(ATT)
-        for _ in range(10):
-            self.dds1.cfg_drctl(True)
-            delay(0.25 * s)
-            self.dds1.cfg_drhold(True)
-            delay(0.25)
-            self.dds1.cfg_drhold(False)
-            delay(0.25)
-            self.dds1.cfg_drctl(False)
-            delay(0.25)
-            self.dds1.cfg_drhold(True)
-            delay(0.25)
-            self.dds1.cfg_drhold(False)
-            delay(0.25)
-        # Switch off waveform
-        self.dds1.cfg_sw(False)
-
-        if not self.io_update_device:
-            # Unset MASK_NU to un-trigger CFG.IO_UPDATE
-            self.dds1.cfg_mask_nu(False)
-
-        # UnSet ATT_EN
-        self.dds1.cfg_att_en(False)
-
-        self.core.wait_until_mu(now_mu())
-
-    @kernel
-    def drg_nodwell(self):
-        self.core.reset()
-        self.cpld.init()
-        # Set ATT_EN
-        self.dds1.cfg_att_en(True)
-        if not self.io_update_device:
-            # Set MASK_NU to trigger CFG.IO_UPDATE
-            self.dds1.cfg_mask_nu(True)
-
-        self.dds1.init()
-
-        delay(10 * ms)
-
-        self.dds1.frequency_to_ftw(FREQ)
-        # cfr2 21:20 destination, 19 drg enable, no-dwell high, no-dwell low,
-        self.dds1.set(FREQ, amplitude=AMP)
-        self.dds1.set_cfr2(drg_enable=1, drg_nodwell_high=1, drg_nodwell_low=1)
-        self.dds1.cpld.io_update.pulse(1 * ms)
-        self.dds1.write64(
-            _AD9910_REG_RAMP_LIMIT,
-            self.dds1.frequency_to_ftw(FREQ + 30 * MHz),
-            self.dds1.frequency_to_ftw(FREQ - 30 * MHz),
-        )
-        # The larger the values, the slower the update happens
-        self.dds1.write32(_AD9910_REG_RAMP_RATE, 0x004F004F)
-        # The smaller the value it is, the smaller the frequency step
-        self.dds1.write64(_AD9910_REG_RAMP_STEP, 0xF0, 0xF0)
-        self.dds1.cpld.io_update.pulse(1 * ms)
-
-        # Switch on waveform, then set attenuation
-        self.dds1.cfg_sw(True)
-        self.dds1.set_att(ATT)
-
-        delay(10 * s)
-        # Switch off waveform
-        self.dds1.cfg_sw(False)
-
-        if not self.io_update_device:
-            # Unset MASK_NU to un-trigger CFG.IO_UPDATE
-            self.dds1.cfg_mask_nu(False)
-
-        # UnSet ATT_EN
-        self.dds1.cfg_att_en(False)
+        if self.use_dds2:
+            self.dds2.cfg_att_en(False)
 
         self.core.wait_until_mu(now_mu())
 
@@ -614,12 +464,17 @@ class AD9910Test(ExperimentCase):
         self.execute(AD9910WaveformExp, "single_tone", io_update_device=False)
 
     @io_update_device(True, proto_rev=STA_PROTO_REV_8)
-    def test_toggle_profile(self):
-        self.execute(AD9910WaveformExp, "toggle_profile")
+    def test_toggle_profiles(self):
+        self.execute(AD9910WaveformExp, "toggle_profiles", multiple_profiles=False)
 
     @io_update_device(False, proto_rev=STA_PROTO_REV_8)
-    def test_toggle_profile_no_io_update_device(self):
-        self.execute(AD9910WaveformExp, "toggle_profile", io_update_device=False)
+    def test_toggle_profiles_no_io_update_device(self):
+        self.execute(
+            AD9910WaveformExp,
+            "toggle_profiles",
+            io_update_device=False,
+            multiple_profiles=False,
+        )
 
     @io_update_device(True, proto_rev=STA_PROTO_REV_9)
     def test_toggle_profiles(self):
@@ -630,44 +485,134 @@ class AD9910Test(ExperimentCase):
         self.execute(AD9910WaveformExp, "toggle_profiles", io_update_device=False)
 
     @io_update_device(True, proto_rev=STA_PROTO_REV_9)
-    def test_osk(self):
+    def test_osk_manual(self):
         self.execute(AD9910WaveformExp, "osk")
 
     @io_update_device(False, proto_rev=STA_PROTO_REV_9)
-    def test_osk_no_io_update_device(self):
+    def test_osk_manual_no_io_update_device(self):
         self.execute(AD9910WaveformExp, "osk", io_update_device=False)
 
     @io_update_device(True, proto_rev=STA_PROTO_REV_9)
     def test_osk_auto(self):
-        self.execute(AD9910WaveformExp, "osk_auto")
+        self.execute(AD9910WaveformExp, "osk", osk_manual=False)
 
     @io_update_device(False, proto_rev=STA_PROTO_REV_9)
     def test_osk_auto_no_io_update_device(self):
-        self.execute(AD9910WaveformExp, "osk_auto", io_update_device=False)
+        self.execute(AD9910WaveformExp, "osk", io_update_device=False, osk_manual=False)
 
     @io_update_device(True, proto_rev=STA_PROTO_REV_9)
-    def test_drg_normal(self):
-        self.execute(AD9910WaveformExp, "drg_normal")
-
-    @io_update_device(False, proto_rev=STA_PROTO_REV_9)
-    def test_drg_normal_no_io_update_device(self):
-        self.execute(AD9910WaveformExp, "drg_normal", io_update_device=False)
+    def test_drg_normal_frequency(self):
+        self.execute(AD9910WaveformExp, "drg")
 
     @io_update_device(True, proto_rev=STA_PROTO_REV_9)
-    def test_drg_normal_with_hold(self):
-        self.execute(AD9910WaveformExp, "drg_normal_with_hold")
-
-    @io_update_device(False, proto_rev=STA_PROTO_REV_9)
-    def test_drg_normal_with_hold_no_io_update_device(self):
-        self.execute(AD9910WaveformExp, "drg_normal_with_hold", io_update_device=False)
+    def test_drg_normal_phase(self):
+        self.execute(AD9910WaveformExp, "drg", drg_destination=0x1, use_dds2=True)
 
     @io_update_device(True, proto_rev=STA_PROTO_REV_9)
-    def test_drg_nodwell(self):
-        self.execute(AD9910WaveformExp, "drg_nodwell")
+    def test_drg_normal_amplitude(self):
+        self.execute(AD9910WaveformExp, "drg", drg_destination=0x2)
 
     @io_update_device(False, proto_rev=STA_PROTO_REV_9)
-    def test_drg_nodwell_no_io_update_device(self):
-        self.execute(AD9910WaveformExp, "drg_nodwell", io_update_device=False)
+    def test_drg_normal_frequency_no_io_update_device(self):
+        self.execute(AD9910WaveformExp, "drg", io_update_device=False)
+
+    @io_update_device(False, proto_rev=STA_PROTO_REV_9)
+    def test_drg_normal_phase_no_io_update_device(self):
+        self.execute(
+            AD9910WaveformExp,
+            "drg",
+            io_update_device=False,
+            drg_destination=0x1,
+            use_dds2=True,
+        )
+
+    @io_update_device(False, proto_rev=STA_PROTO_REV_9)
+    def test_drg_normal_amplitude_no_io_update_device(self):
+        self.execute(
+            AD9910WaveformExp, "drg", io_update_device=False, drg_destination=0x2
+        )
+
+    @io_update_device(True, proto_rev=STA_PROTO_REV_9)
+    def test_drg_normal_with_hold_frequency(self):
+        self.execute(AD9910WaveformExp, "drg", with_hold=True)
+
+    @io_update_device(True, proto_rev=STA_PROTO_REV_9)
+    def test_drg_normal_with_hold_phase(self):
+        self.execute(
+            AD9910WaveformExp,
+            "drg",
+            drg_destination=0x1,
+            use_dds2=True,
+            with_hold=True,
+        )
+
+    @io_update_device(True, proto_rev=STA_PROTO_REV_9)
+    def test_drg_normal_with_hold_amplitude(self):
+        self.execute(AD9910WaveformExp, "drg", drg_destination=0x2, with_hold=True)
+
+    @io_update_device(False, proto_rev=STA_PROTO_REV_9)
+    def test_drg_normal_with_hold_frequency_no_io_update_device(self):
+        self.execute(AD9910WaveformExp, "drg", io_update_device=False, with_hold=True)
+
+    @io_update_device(False, proto_rev=STA_PROTO_REV_9)
+    def test_drg_normal_with_hold_phase_no_io_update_device(self):
+        self.execute(
+            AD9910WaveformExp,
+            "drg",
+            io_update_device=False,
+            drg_destination=0x1,
+            use_dds2=True,
+            with_hold=True,
+        )
+
+    @io_update_device(False, proto_rev=STA_PROTO_REV_9)
+    def test_drg_normal_with_hold_amplitude_no_io_update_device(self):
+        self.execute(
+            AD9910WaveformExp,
+            "drg",
+            io_update_device=False,
+            drg_destination=0x2,
+            with_hold=True,
+        )
+
+    @io_update_device(True, proto_rev=STA_PROTO_REV_9)
+    def test_drg_nodwell_frequency(self):
+        self.execute(AD9910WaveformExp, "drg", nodwell=1)
+
+    @io_update_device(True, proto_rev=STA_PROTO_REV_9)
+    def test_drg_nodwell_phase(self):
+        self.execute(
+            AD9910WaveformExp, "drg", drg_destination=0x1, use_dds2=True, nodwell=1
+        )
+
+    @io_update_device(True, proto_rev=STA_PROTO_REV_9)
+    def test_drg_nodwell_amplitude(self):
+        self.execute(AD9910WaveformExp, "drg", drg_destination=0x2, nodwell=1)
+
+    @io_update_device(False, proto_rev=STA_PROTO_REV_9)
+    def test_drg_nodwell_frequency_no_io_update_device(self):
+        self.execute(AD9910WaveformExp, "drg", io_update_device=False, nodwell=1)
+
+    @io_update_device(False, proto_rev=STA_PROTO_REV_9)
+    def test_drg_nodwell_phase_no_io_update_device(self):
+        self.execute(
+            AD9910WaveformExp,
+            "drg",
+            io_update_device=False,
+            drg_destination=0x1,
+            use_dds2=True,
+            nodwell=1,
+        )
+
+    @io_update_device(False, proto_rev=STA_PROTO_REV_9)
+    def test_drg_nodwell_amplitude_no_io_update_device(self):
+        self.execute(
+            AD9910WaveformExp,
+            "drg",
+            io_update_device=False,
+            drg_destination=0x2,
+            nodwell=1,
+        )
 
     @io_update_device(True, proto_rev=STA_PROTO_REV_9)
     def test_att_single_tone(self):

--- a/artiq/test/coredevice/test_urukul.py
+++ b/artiq/test/coredevice/test_urukul.py
@@ -1,12 +1,14 @@
-from artiq.coredevice import urukul
+from artiq.coredevice.urukul import STA_PROTO_REV_9, urukul_sta_rf_sw
 from artiq.experiment import *
 from artiq.test.hardware_testbench import ExperimentCase
+
+CPLD = "urukul_cpld"
 
 
 class UrukulExp(EnvExperiment):
     def build(self, runner):
         self.setattr_device("core")
-        self.dev = self.get_device("urukul_cpld")
+        self.dev = self.get_device(CPLD)
         self.runner = runner
 
     def run(self):
@@ -73,27 +75,24 @@ class UrukulExp(EnvExperiment):
 
     @kernel
     def att_enables(self):
-        if self.dev.proto_rev == urukul.STA_PROTO_REV_9:
-            self.core.break_realtime()
-            self.dev.init()
-            self.dev.cfg_att_en(0, False)
-            self.dev.cfg_att_en(2, True)
-            self.dev.cfg_att_en(3, True)
-            self.dev.cfg_att_en_all(0b1010)
+        self.core.break_realtime()
+        self.dev.init()
+        self.dev.cfg_att_en(0, False)
+        self.dev.cfg_att_en(2, True)
+        self.dev.cfg_att_en(3, True)
+        self.dev.cfg_att_en_all(0b1010)
 
     @kernel
     def att_enable_speed(self):
-        if self.dev.proto_rev == urukul.STA_PROTO_REV_9:
-            self.core.break_realtime()
-            self.dev.init()
-            n = 10
-            t0 = self.core.get_rtio_counter_mu()
-            for i in range(n):
-                self.dev.cfg_att_en(1, bool(i & 1))
-            self.set_dataset(
-                "dt", self.core.mu_to_seconds(self.core.get_rtio_counter_mu() - t0) / n
-            )
-        self.set_dataset("dt", None)
+        self.core.break_realtime()
+        self.dev.init()
+        n = 10
+        t0 = self.core.get_rtio_counter_mu()
+        for i in range(n):
+            self.dev.cfg_att_en(1, bool(i & 1))
+        self.set_dataset(
+            "dt", self.core.mu_to_seconds(self.core.get_rtio_counter_mu() - t0) / n
+        )
 
     @kernel
     def att(self):
@@ -165,99 +164,87 @@ class UrukulExp(EnvExperiment):
 
     @kernel
     def osk(self):
-        if self.dev.proto_rev == urukul.STA_PROTO_REV_9:
-            self.core.break_realtime()
-            self.dev.init()
-            self.dev.cfg_osk(0, False)
-            self.dev.cfg_osk(2, True)
-            self.dev.cfg_osk(3, True)
-            self.dev.cfg_osk_all(0b1010)
+        self.core.break_realtime()
+        self.dev.init()
+        self.dev.cfg_osk(0, False)
+        self.dev.cfg_osk(2, True)
+        self.dev.cfg_osk(3, True)
+        self.dev.cfg_osk_all(0b1010)
 
     @kernel
     def osk_speed(self):
-        if self.dev.proto_rev == urukul.STA_PROTO_REV_9:
-            self.core.break_realtime()
-            self.dev.init()
-            n = 10
-            t0 = self.core.get_rtio_counter_mu()
-            for i in range(n):
-                self.dev.cfg_osk(1, bool(i & 1))
-            self.set_dataset(
-                "dt", self.core.mu_to_seconds(self.core.get_rtio_counter_mu() - t0) / n
-            )
-        self.set_dataset("dt", None)
+        self.core.break_realtime()
+        self.dev.init()
+        n = 10
+        t0 = self.core.get_rtio_counter_mu()
+        for i in range(n):
+            self.dev.cfg_osk(1, bool(i & 1))
+        self.set_dataset(
+            "dt", self.core.mu_to_seconds(self.core.get_rtio_counter_mu() - t0) / n
+        )
 
     @kernel
     def drctl(self):
-        if self.dev.proto_rev == urukul.STA_PROTO_REV_9:
-            self.core.break_realtime()
-            self.dev.init()
-            self.dev.cfg_drctl(0, False)
-            self.dev.cfg_drctl(1, True)
-            self.dev.cfg_drctl(3, True)
-            self.dev.cfg_drctl_all(0b1010)
+        self.core.break_realtime()
+        self.dev.init()
+        self.dev.cfg_drctl(0, False)
+        self.dev.cfg_drctl(1, True)
+        self.dev.cfg_drctl(3, True)
+        self.dev.cfg_drctl_all(0b1010)
 
     @kernel
     def drctl_speed(self):
-        if self.dev.proto_rev == urukul.STA_PROTO_REV_9:
-            self.core.break_realtime()
-            self.dev.init()
-            n = 10
-            t0 = self.core.get_rtio_counter_mu()
-            for i in range(n):
-                self.dev.cfg_drctl(2, bool(i & 1))
-            self.set_dataset(
-                "dt", self.core.mu_to_seconds(self.core.get_rtio_counter_mu() - t0) / n
-            )
-        self.set_dataset("dt", None)
+        self.core.break_realtime()
+        self.dev.init()
+        n = 10
+        t0 = self.core.get_rtio_counter_mu()
+        for i in range(n):
+            self.dev.cfg_drctl(2, bool(i & 1))
+        self.set_dataset(
+            "dt", self.core.mu_to_seconds(self.core.get_rtio_counter_mu() - t0) / n
+        )
 
     @kernel
     def drhold(self):
-        if self.dev.proto_rev == urukul.STA_PROTO_REV_9:
-            self.core.break_realtime()
-            self.dev.init()
-            self.dev.cfg_drhold(0, False)
-            self.dev.cfg_drhold(2, True)
-            self.dev.cfg_drhold(3, True)
-            self.dev.cfg_drhold_all(0b1010)
+        self.core.break_realtime()
+        self.dev.init()
+        self.dev.cfg_drhold(0, False)
+        self.dev.cfg_drhold(2, True)
+        self.dev.cfg_drhold(3, True)
+        self.dev.cfg_drhold_all(0b1010)
 
     @kernel
     def drhold_speed(self):
-        if self.dev.proto_rev == urukul.STA_PROTO_REV_9:
-            self.core.break_realtime()
-            self.dev.init()
-            n = 10
-            t0 = self.core.get_rtio_counter_mu()
-            for i in range(n):
-                self.dev.cfg_drhold(1, bool(i & 1))
-            self.set_dataset(
-                "dt", self.core.mu_to_seconds(self.core.get_rtio_counter_mu() - t0) / n
-            )
-        self.set_dataset("dt", None)
+        self.core.break_realtime()
+        self.dev.init()
+        n = 10
+        t0 = self.core.get_rtio_counter_mu()
+        for i in range(n):
+            self.dev.cfg_drhold(1, bool(i & 1))
+        self.set_dataset(
+            "dt", self.core.mu_to_seconds(self.core.get_rtio_counter_mu() - t0) / n
+        )
 
     @kernel
     def mask_nu(self):
-        if self.dev.proto_rev == urukul.STA_PROTO_REV_9:
-            self.core.break_realtime()
-            self.dev.init()
-            self.dev.cfg_mask_nu(0, False)
-            self.dev.cfg_mask_nu(1, True)
-            self.dev.cfg_mask_nu(3, True)
-            self.dev.cfg_mask_nu_all(0b1010)
+        self.core.break_realtime()
+        self.dev.init()
+        self.dev.cfg_mask_nu(0, False)
+        self.dev.cfg_mask_nu(1, True)
+        self.dev.cfg_mask_nu(3, True)
+        self.dev.cfg_mask_nu_all(0b1010)
 
     @kernel
     def mask_nu_speed(self):
-        if self.dev.proto_rev == urukul.STA_PROTO_REV_9:
-            self.core.break_realtime()
-            self.dev.init()
-            n = 10
-            t0 = self.core.get_rtio_counter_mu()
-            for i in range(n):
-                self.dev.cfg_mask_nu(2, bool(i & 1))
-            self.set_dataset(
-                "dt", self.core.mu_to_seconds(self.core.get_rtio_counter_mu() - t0) / n
-            )
-        self.set_dataset("dt", None)
+        self.core.break_realtime()
+        self.dev.init()
+        n = 10
+        t0 = self.core.get_rtio_counter_mu()
+        for i in range(n):
+            self.dev.cfg_mask_nu(2, bool(i & 1))
+        self.set_dataset(
+            "dt", self.core.mu_to_seconds(self.core.get_rtio_counter_mu() - t0) / n
+        )
 
     # Note, cfg_io_update is tested in test_ad9910.py
     @kernel
@@ -281,14 +268,13 @@ class UrukulExp(EnvExperiment):
 
     @kernel
     def cfg_profile(self):
-        if self.dev.proto_rev == urukul.STA_PROTO_REV_9:
-            self.core.break_realtime()
-            self.dev.init()
-            self.dev.set_profile(0, 7)
-            self.dev.set_profile(1, 0)
-            self.dev.set_profile(2, 3)
-            self.dev.set_profile(3, 5)
-            self.dev.cfg_drctl_all(0b1111)
+        self.core.break_realtime()
+        self.dev.init()
+        self.dev.set_profile(0, 7)
+        self.dev.set_profile(1, 0)
+        self.dev.set_profile(2, 3)
+        self.dev.set_profile(3, 5)
+        self.dev.cfg_drctl_all(0b1111)
 
 
 class UrukulTest(ExperimentCase):
@@ -320,17 +306,18 @@ class UrukulTest(ExperimentCase):
 
     def test_switches_readback(self):
         self.execute(UrukulExp, "switches_readback")
-        sw_get = urukul.urukul_sta_rf_sw(self.dataset_mgr.get("sta_get"))
+        sw_get = urukul_sta_rf_sw(self.dataset_mgr.get("sta_get"))
         sw_set = self.dataset_mgr.get("sw_set")
         self.assertEqual(sw_get, sw_set)
 
     def test_att_enables(self):
-        self.execute(UrukulExp, "att_enables")
+        if self.device_mgr.get(CPLD).proto_rev == STA_PROTO_REV_9:
+            self.execute(UrukulExp, "att_enables")
 
     def test_att_enable_speed(self):
-        self.execute(UrukulExp, "att_enable_speed")
-        dt = self.dataset_mgr.get("dt")
-        if dt:
+        if self.device_mgr.get(CPLD).proto_rev == STA_PROTO_REV_9:
+            self.execute(UrukulExp, "att_enable_speed")
+            dt = self.dataset_mgr.get("dt")
             print(dt)
             self.assertLess(dt, 5 * us)
 
@@ -362,42 +349,46 @@ class UrukulTest(ExperimentCase):
         self.assertLess(dt, 5 * us)
 
     def test_osk(self):
-        self.execute(UrukulExp, "osk")
+        if self.device_mgr.get(CPLD).proto_rev == STA_PROTO_REV_9:
+            self.execute(UrukulExp, "osk")
 
     def test_osk_speed(self):
-        self.execute(UrukulExp, "osk_speed")
-        dt = self.dataset_mgr.get("dt")
-        if dt:
+        if self.device_mgr.get(CPLD).proto_rev == STA_PROTO_REV_9:
+            self.execute(UrukulExp, "osk_speed")
+            dt = self.dataset_mgr.get("dt")
             print(dt)
             self.assertLess(dt, 5 * us)
 
     def test_drctl(self):
-        self.execute(UrukulExp, "drctl")
+        if self.device_mgr.get(CPLD).proto_rev == STA_PROTO_REV_9:
+            self.execute(UrukulExp, "drctl")
 
     def test_drctl_speed(self):
-        self.execute(UrukulExp, "drctl_speed")
-        dt = self.dataset_mgr.get("dt")
-        if dt:
+        if self.device_mgr.get(CPLD).proto_rev == STA_PROTO_REV_9:
+            self.execute(UrukulExp, "drctl_speed")
+            dt = self.dataset_mgr.get("dt")
             print(dt)
             self.assertLess(dt, 5 * us)
 
     def test_drhold(self):
-        self.execute(UrukulExp, "drhold")
+        if self.device_mgr.get(CPLD).proto_rev == STA_PROTO_REV_9:
+            self.execute(UrukulExp, "drhold")
 
     def test_drhold_speed(self):
-        self.execute(UrukulExp, "drhold_speed")
-        dt = self.dataset_mgr.get("dt")
-        if dt:
+        if self.device_mgr.get(CPLD).proto_rev == STA_PROTO_REV_9:
+            self.execute(UrukulExp, "drhold_speed")
+            dt = self.dataset_mgr.get("dt")
             print(dt)
             self.assertLess(dt, 5 * us)
 
     def test_mask_nu(self):
-        self.execute(UrukulExp, "mask_nu")
+        if self.device_mgr.get(CPLD).proto_rev == STA_PROTO_REV_9:
+            self.execute(UrukulExp, "mask_nu")
 
     def test_mask_nu_speed(self):
-        self.execute(UrukulExp, "mask_nu_speed")
-        dt = self.dataset_mgr.get("dt")
-        if dt:
+        if self.device_mgr.get(CPLD).proto_rev == STA_PROTO_REV_9:
+            self.execute(UrukulExp, "mask_nu_speed")
+            dt = self.dataset_mgr.get("dt")
             print(dt)
             self.assertLess(dt, 5 * us)
 

--- a/artiq/test/coredevice/test_urukul.py
+++ b/artiq/test/coredevice/test_urukul.py
@@ -59,9 +59,8 @@ class UrukulExp(EnvExperiment):
         t0 = self.core.get_rtio_counter_mu()
         for i in range(n):
             self.dev.cfg_sw(2, bool(i & 1))
-        self.set_dataset(
-            "dt", self.core.mu_to_seconds(self.core.get_rtio_counter_mu() - t0) / n
-        )
+        self.set_dataset("dt", self.core.mu_to_seconds(
+            self.core.get_rtio_counter_mu() - t0) / n)
 
     @kernel
     def switches_readback(self):
@@ -90,9 +89,8 @@ class UrukulExp(EnvExperiment):
         t0 = self.core.get_rtio_counter_mu()
         for i in range(n):
             self.dev.cfg_att_en(1, bool(i & 1))
-        self.set_dataset(
-            "dt", self.core.mu_to_seconds(self.core.get_rtio_counter_mu() - t0) / n
-        )
+        self.set_dataset("dt", self.core.mu_to_seconds(
+            self.core.get_rtio_counter_mu() - t0) / n)
 
     @kernel
     def att(self):
@@ -135,7 +133,8 @@ class UrukulExp(EnvExperiment):
         self.dev.init()
         # clear backing state
         self.dev.att_reg = 0
-        att_set = [int32(0x21), int32(0x43), int32(0x65), int32(0x87)]
+        att_set = [int32(0x21), int32(0x43), 
+                   int32(0x65), int32(0x87)]
         # set individual attenuators
         for i in range(len(att_set)):
             self.dev.set_att_mu(i, att_set[i])
@@ -158,9 +157,8 @@ class UrukulExp(EnvExperiment):
         t0 = self.core.get_rtio_counter_mu()
         for i in range(n):
             self.dev.set_att(3, 30 * dB)
-        self.set_dataset(
-            "dt", self.core.mu_to_seconds(self.core.get_rtio_counter_mu() - t0) / n
-        )
+        self.set_dataset("dt", self.core.mu_to_seconds(
+            self.core.get_rtio_counter_mu() - t0) / n)
 
     @kernel
     def osk(self):
@@ -179,9 +177,8 @@ class UrukulExp(EnvExperiment):
         t0 = self.core.get_rtio_counter_mu()
         for i in range(n):
             self.dev.cfg_osk(1, bool(i & 1))
-        self.set_dataset(
-            "dt", self.core.mu_to_seconds(self.core.get_rtio_counter_mu() - t0) / n
-        )
+        self.set_dataset("dt", self.core.mu_to_seconds(
+            self.core.get_rtio_counter_mu() - t0) / n)
 
     @kernel
     def drctl(self):
@@ -200,9 +197,8 @@ class UrukulExp(EnvExperiment):
         t0 = self.core.get_rtio_counter_mu()
         for i in range(n):
             self.dev.cfg_drctl(2, bool(i & 1))
-        self.set_dataset(
-            "dt", self.core.mu_to_seconds(self.core.get_rtio_counter_mu() - t0) / n
-        )
+        self.set_dataset("dt", self.core.mu_to_seconds(
+            self.core.get_rtio_counter_mu() - t0) / n)
 
     @kernel
     def drhold(self):
@@ -221,9 +217,8 @@ class UrukulExp(EnvExperiment):
         t0 = self.core.get_rtio_counter_mu()
         for i in range(n):
             self.dev.cfg_drhold(1, bool(i & 1))
-        self.set_dataset(
-            "dt", self.core.mu_to_seconds(self.core.get_rtio_counter_mu() - t0) / n
-        )
+        self.set_dataset("dt", self.core.mu_to_seconds(
+            self.core.get_rtio_counter_mu() - t0) / n)
 
     @kernel
     def mask_nu(self):
@@ -242,9 +237,8 @@ class UrukulExp(EnvExperiment):
         t0 = self.core.get_rtio_counter_mu()
         for i in range(n):
             self.dev.cfg_mask_nu(2, bool(i & 1))
-        self.set_dataset(
-            "dt", self.core.mu_to_seconds(self.core.get_rtio_counter_mu() - t0) / n
-        )
+        self.set_dataset("dt", self.core.mu_to_seconds(
+            self.core.get_rtio_counter_mu() - t0) / n)
 
     # Note, cfg_io_update is tested in test_ad9910.py
     @kernel
@@ -339,7 +333,7 @@ class UrukulTest(ExperimentCase):
         self.assertListEqual(att_set, self.dataset_mgr.get("att_get"))
         att_reg = self.dataset_mgr.get("att_reg")
         for att in att_set:
-            self.assertEqual(att, att_reg & 0xFF)
+            self.assertEqual(att, att_reg & 0xff)
             att_reg >>= 8
 
     def test_att_speed(self):

--- a/artiq/test/coredevice/test_urukul.py
+++ b/artiq/test/coredevice/test_urukul.py
@@ -6,7 +6,7 @@ from artiq.test.hardware_testbench import ExperimentCase
 class UrukulExp(EnvExperiment):
     def build(self, runner):
         self.setattr_device("core")
-        self.dev = self.get_device("urukul1_cpld")
+        self.dev = self.get_device("urukul_cpld")
         self.runner = runner
 
     def run(self):


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

This PR adds coredevice driver capabilities and tests for new Urukul CPLD functionaly (see related issue).

such as:

1. Decoupling the individual DDS channels.
2. Individual DDS Channel:
   * PROFILE
   * IO_UPDATE
   * OSK
   * DRCTRL
   * DRHOLD
   * ATT_EN
3. Digital Ramp Generator (DRG)
4. Backward compatible Urukul coredevice driver that can work between protocol revision 8 and new editions.

### Related Issue

https://github.com/quartiq/urukul/issues/7

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.