### PR TITLE
gtxinit: fix `AttributeError` for rx multilane

### DIFF
--- a/artiq/gateware/drtio/transceiver/gtx_7series_init.py
+++ b/artiq/gateware/drtio/transceiver/gtx_7series_init.py
@@ -59,7 +59,7 @@ class GTXInit(Module):
             MultiReg(self.Xxdlysresetdone, Xxdlysresetdone),
             MultiReg(self.Xxphaligndone, Xxphaligndone),
         ]
-        if mode != "single":
+        if mode != "single" and not rx:
             txphinitdone = Signal()
             self.specials += MultiReg(self.txphinitdone, txphinitdone)
 


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
fix the `AttributeError` when using `GTXInit` in rx `master` or `slave` mode  
```python
  File "/home/morgan/dev/artiq-zynq-coax/src/gateware/cxp_downconn.py", line 375, in __init__
    self.submodules.rx_init = rx_init = GTXInit(sys_clk_freq, True, mode=rx_mode)
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/7m55g8aly874vigbmn7hpcrl7ddka4p5-python3.12-artiq-9.9142+c1f2ff3.beta/lib/python3.12/site-packages/artiq/gateware/drtio/transceiver/gtx_7series_init.py", line 64, in __init__
    self.specials += MultiReg(self.txphinitdone, txphinitdone)
                              ^^^^^^^^^^^^^^^^^
  File "/nix/store/hc5nhbfwxcgrbgl3k285cy9iwsylqfss-python3-3.12.8-env/lib/python3.12/site-packages/migen/fhdl/module.py", line 136, in __getattr__
    raise AttributeError("'"+self.__class__.__name__+"' object has no attribute '"+name+"'")
AttributeError: 'GTXInit' object has no attribute 'txphinitdone'

```


## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.

