### PR TITLE
Report non-kernel `__enter__`/`__exit__` methods

### DIFF
--- a/artiq/compiler/transforms/inferencer.py
+++ b/artiq/compiler/transforms/inferencer.py
@@ -1676,7 +1676,7 @@ class Inferencer(algorithm.Visitor):
 
                 if not types.is_function(typ):
                     diag = diagnostic.Diagnostic("error",
-                        "function '{attr}{attr_type}' must be a @kernel function",
+                        "function '{attr}{attr_type}' must be a @kernel",
                         {"attr": attr_name,
                          "attr_type": printer.name(typ)},
                         node.loc)

--- a/artiq/compiler/transforms/inferencer.py
+++ b/artiq/compiler/transforms/inferencer.py
@@ -1674,7 +1674,14 @@ class Inferencer(algorithm.Visitor):
                 else:
                     typ = typ.find()
 
-                if not (len(typ.args) == arity and len(typ.optargs) == 0):
+                if not types.is_function(typ):
+                    diag = diagnostic.Diagnostic("error",
+                        "function '{attr}{attr_type}' must be a @kernel function",
+                        {"attr": attr_name,
+                         "attr_type": printer.name(typ)},
+                        node.loc)
+                    self.engine.process(diag)
+                elif not (len(typ.args) == arity and len(typ.optargs) == 0):
                     diag = diagnostic.Diagnostic("error",
                         "function '{attr}{attr_type}' must accept "
                         "{arity} positional argument{s} and no optional arguments",

--- a/artiq/test/lit/embedding/error_with_rpc.py
+++ b/artiq/test/lit/embedding/error_with_rpc.py
@@ -1,0 +1,20 @@
+# RUN: %python -m artiq.compiler.testbench.embedding +diag %s 2>%t
+# RUN: OutputCheck %s --file-to-check=%t
+
+from artiq.experiment import kernel
+
+class contextmgr:
+    def __enter__(self):
+        pass
+
+    @kernel
+    def __exit__(self, n1, n2, n3):
+        pass
+
+c = contextmgr()
+
+@kernel
+def entrypoint():
+    # CHECK-L: ${LINE:+1}: error: function '__enter__[rpc2 #](...)->NoneType' must be a @kernel function
+    with c:
+        pass


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
Attempting to use Python's `with` syntax on a non-kernel class will crash the compiler, as it currently assumes `__enter__` and `__exit__` are kernel functions. This adds an additional check beforehand to flag this.

The error message itself is not great (RPC type signatures are ugly!), but it does point to the `with:` block, which in most cases makes the problem obvious. I'm open to suggestions here though!

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)
