### PR TITLE
Fix throwing non-embedded builtin exceptions

### DIFF
--- a/artiq/coredevice/comm_kernel.py
+++ b/artiq/coredevice/comm_kernel.py
@@ -617,10 +617,10 @@ class CommKernel:
                 self._write_int32(embedding_map.store_str(function))
             else:
                 exn_type = type(exn)
-                if exn_type in builtins.__dict__.values():
-                    name = "0:{}".format(exn_type.__qualname__)
-                elif hasattr(exn, "artiq_builtin"):
+                if hasattr(exn, "artiq_builtin"):
                     name = "0:{}.{}".format(exn_type.__module__, exn_type.__qualname__)
+                elif exn_type in exceptions.__dict__.values():
+                    name = "0:{}".format(exn_type.__qualname__)
                 else:
                     exn_id = embedding_map.store_object(exn_type)
                     name = "{}:{}.{}".format(exn_id,


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
`comm_kernel` currently encodes all (Python) builtin exceptions with an id of 0. However, lookup for these exceptions happens from the `artiq.coredevice.exceptions` module. This means if you try to throw a builtin exception not in the embedding map, then it crashes when receiving it on the host. This also prevents you catching these exceptions in kernel code.

We now encode only use an exn id of 0 if the exception is in the exceptions module (and thus already in the embedding map).

I believe this is a relatively recent regression — I noticed this while in the process of updating to latest ARTIQ. This was possibly introduced in #2526, but afraid I have not bisected this.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)
