### PR TITLE
Update error_with_rpc to reflect changes in error message

### DIFF
--- a/artiq/test/lit/embedding/error_with_rpc.py
+++ b/artiq/test/lit/embedding/error_with_rpc.py
@@ -15,6 +15,6 @@ c = contextmgr()
 
 @kernel
 def entrypoint():
-    # CHECK-L: ${LINE:+1}: error: function '__enter__[rpc2 #](...)->NoneType' must be a @kernel function
+    # CHECK-L: ${LINE:+1}: error: function '__enter__[rpc2 #](...)->NoneType' must be a @kernel
     with c:
         pass


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
This fixes the error message in the `error_with_rpc` test (see #2660). In 005630ca93aac06cc96066d7cd5e4ed7a6e76960 I updated the error message, but failed to update the test — really sorry about that!

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
