### PR TITLE
Fix exceptions test for zc706

### DIFF
--- a/artiq/test/coredevice/test_exceptions.py
+++ b/artiq/test/coredevice/test_exceptions.py
@@ -65,7 +65,7 @@ class KernelRTIOUnderflow(EnvExperiment):
 RTIO_UNDERFLOW_PATTERN = re.compile(
     r'''(?xs)RTIOUnderflow\(\d+\):\ RTIO\ underflow\ at\ (?=
         (?=.*\d+\s*mu\b)
-        (?=.*channel\s+0x[0-9A-Fa-f]+:led\d*)
+        (?=.*channel\s+0x[0-9A-Fa-f]+:(led\d*|unknown))
         (?=.*slack\s+-\d+\s*mu)
     ).+$
     ''',


### PR DESCRIPTION

# ARTIQ Pull Request

## Description of Changes

### Related Issue

https://nixbld.m-labs.hk/build/174145/nixlog/5

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
