### PR TITLE
Avoid quadratic behaviour in `_unify_attribute`

### DIFF
--- a/artiq/compiler/embedding.py
+++ b/artiq/compiler/embedding.py
@@ -274,6 +274,29 @@ class EmbeddingMap:
             ))
 
 
+class _ValueInfo:
+    __slots__ = ("objects", "unchecked_attributes")
+
+    """
+    A collection of all values of a particular type.
+
+    Attributes:
+
+    :attr:`objects`: A list of all objects and the location they were added from.
+    :attr:`unchecked_attributes`: The known attributes for this type, and a list of
+        values where we have not yet checked the attribute's presence.
+    """
+    def __init__(self):
+        self.objects: list[tuple[object, source.Range]] = []
+        self.unchecked_attributes: dict[str, list[tuple[object, source.Range]]] = {}
+
+    def append(self, val_and_loc):
+        self.objects.append(val_and_loc)
+
+        for attr_store in self.unchecked_attributes.values():
+            attr_store.append(val_and_loc)
+
+
 class ASTSynthesizer:
     def __init__(self, embedding_map, value_map, quote_function=None, expanded_from=None):
         self.source = ""
@@ -807,7 +830,13 @@ class StitchingInferencer(Inferencer):
         # that we can successfully serialize the value of the attribute we
         # are now adding at the code generation stage.
         object_type = value_node.type.find()
-        for object_value, object_loc in self.value_map[object_type]:
+        values: _ValueInfo = self.value_map[object_type]
+
+        # Take all objects whose attribute we haven't checked yet.
+        attribute_objects = values.unchecked_attributes.get(attr_name, values.objects)
+        values.unchecked_attributes[attr_name] = []
+
+        for object_value, object_loc in attribute_objects:
             attr_type_key = (id(object_value), attr_name)
             try:
                 attributes, attr_value_type = self.attr_type_cache[attr_type_key]
@@ -888,7 +917,7 @@ class Stitcher:
         self.functions = {}
 
         self.embedding_map = EmbeddingMap(old_embedding_map)
-        self.value_map = defaultdict(lambda: [])
+        self.value_map = defaultdict(_ValueInfo)
         self.definitely_changed = False
 
         self.destination = destination
@@ -946,7 +975,7 @@ class Stitcher:
                     # value is guaranteed to have it too.
                     continue
 
-                for value, loc in self.value_map[instance_type]:
+                for value, loc in self.value_map[instance_type].objects:
                     if hasattr(value, attribute):
                         continue
 


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
ARTIQ maintains a list of all known instances of a particular class, and after each attribute access, `_unify_attribute` is called to check all these instances have this attribute (and it's the right type).

While the attribute type computation is cached, this check is still $\mathcal{O}(nm)$ (with $n$ being the number of instances, and m the number of attribute lookups). For something like ndscan's `FloatParamHandle.get`, you can have a lot of both.

This commit changes `_unify_attribute` to only check the attributes of new instances. This provides a small (5%, after all, most time is still spent in codegen) boost to compile times of complex experiments.

### Related Issue
## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

All unit tests pass. Have compiled several large experiments, and no differences in type inference or compiler output.