### PR TITLE
kc705: Define the main clock for vivado

### DIFF
--- a/artiq/gateware/targets/kc705.py
+++ b/artiq/gateware/targets/kc705.py
@@ -128,6 +128,7 @@ class _StandaloneBase(MiniSoC, AMPSoC):
             Instance("BUFG", i_I=cdr_clk, o_O=cdr_clk_buf)
         ]
 
+        self.platform.add_period_constraint(cdr_clk_out, 8.)
         self.crg.configure(cdr_clk_buf)
 
         self.submodules += SMAClkinForward(self.platform)


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
Clock switch in MiSoC needs to set false path constraints on the main clock. This PR defines this clock on vivado level, such that false paths constraints can be assigned to it.

## Test
Before this patch, there are these critical warning messages when building the `nist_clock` standalone variant.
```
WARNING: [Vivado 12-1008] No clocks found for command 'get_clocks -include_generated_clocks -of [get_nets main_cdr_clk_buf]'. [/build/artiq_kc705/nist_clock/gateware/top.xdc:1034]
Resolution: Verify the create_clock command was called to create the clock object before it is referenced.
INFO: [Vivado 12-626] No clocks found. Please use 'create_clock' or 'create_generated_clock' command to create clocks. [/build/artiq_kc705/nist_clock/gateware/top.xdc:1034]
CRITICAL WARNING: [Vivado 12-4739] set_clock_groups:No valid object(s) found for '-group [get_clocks -of_objects [get_nets main_cdr_clk_buf]]'. [/build/artiq_kc705/nist_clock/gateware/top.xdc:1034]
Resolution: Check if the specified object(s) exists in the current design. If it does, ensure that the correct design hierarchy was specified for the object. If you are working with clocks, make sure create_clock was used to create the clock object before it is referenced.
CRITICAL WARNING: [Vivado 12-4739] set_clock_groups:No valid object(s) found for '-group '. [/build/artiq_kc705/nist_clock/gateware/top.xdc:1034]
Resolution: Check if the specified object(s) exists in the current design. If it does, ensure that the correct design hierarchy was specified for the object. If you are working with clocks, make sure create_clock was used to create the clock object before it is referenced.
CRITICAL WARNING: [Vivado 12-5201] set_clock_groups: cannot set the clock group when only one non-empty group remains. [/build/artiq_kc705/nist_clock/gateware/top.xdc:1034]
```

These critical warnings disappeared after this patch.

### Related Issue
#2093

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Close/update issues.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
