### PR TITLE
release-8: backport clock definitions and constraint adjustments

### DIFF
--- a/artiq/gateware/targets/kc705.py
+++ b/artiq/gateware/targets/kc705.py
@@ -127,6 +127,7 @@ class _StandaloneBase(MiniSoC, AMPSoC):
             Instance("BUFG", i_I=cdr_clk, o_O=cdr_clk_buf)
         ]
 
+        self.platform.add_period_constraint(cdr_clk_out, 8.)
         self.crg.configure(cdr_clk_buf)
 
         self.submodules += SMAClkinForward(self.platform)

--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
     "src-migen": {
       "flake": false,
       "locked": {
-        "lastModified": 1735131698,
-        "narHash": "sha256-P4vaF+9iVekRAC2/mc9G7IwI6baBpPAxiDQ8uye4sAs=",
+        "lastModified": 1738906518,
+        "narHash": "sha256-GproDJowtcgbccsT+I0mObzFhE483shcS8MSszKXwlc=",
         "owner": "m-labs",
         "repo": "migen",
-        "rev": "4c2ae8dfeea37f235b52acb8166f12acaaae4f7c",
+        "rev": "2828df54594673653a641ab551caf6c6b1bfeee5",
         "type": "github"
       },
       "original": {
@@ -124,11 +124,11 @@
     "src-misoc": {
       "flake": false,
       "locked": {
-        "lastModified": 1736416570,
-        "narHash": "sha256-tbcN/fzejZIaYbTbwk8Ir1glYevESqMinMeDB3z8oxg=",
+        "lastModified": 1739428011,
+        "narHash": "sha256-ymvkR6ldCp+Kj29YGnaVuoM9Vi2GNxaqPlK0DWOCcgQ=",
         "ref": "refs/heads/master",
-        "rev": "1f5318e9edc1085ac77e9b85b8f5e03371dba54c",
-        "revCount": 2464,
+        "rev": "47a3d8096dfae234599fd5406807cf2d92b6a351",
+        "revCount": 2473,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/m-labs/misoc.git"


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

This patch backports fixes that are already introduced to the `master` branch related to vivado unable to resolve certain signal names when adding false path constraints.

Warnings in #2093 and critical warnings stated in #2677 are resolved.

## Related Issue
Closes #2093

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Close/update issues.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
