### PR TITLE
Update to numpy v2 to sync with MSYS2

### DIFF
--- a/artiq/tools.py
+++ b/artiq/tools.py
@@ -102,7 +102,7 @@ def short_format(v, metadata={}):
         return v_str
     elif np.issubdtype(t, np.bool_):
        return str(v)
-    elif np.issubdtype(t, np.unicode_):
+    elif np.issubdtype(t, np.str_):
         return "\"" + elide(v, 50) + "\""
     elif t is np.ndarray:
         v_t = np.divide(v, scale)


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

### Related Issue

Due to MSYS2 updating the numpy to the version 2, some of the objects were removed. Checked against https://numpy.org/devdocs/numpy_2_0_migration_guide.html#numpy-2-migration-guide 

```
Traceback (most recent call last):
  File "D:/MSYS2 with ARTIQ/clang64/lib/python3.12/site-packages/artiq/gui/models.py", line 413, in data
    return convert(key, self.backing_store[key],
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:/MSYS2 with ARTIQ/clang64/lib/python3.12/site-packages/artiq/dashboard/datasets.py", line 175, in convert
    return short_format(v[1], v[2])
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:/MSYS2 with ARTIQ/clang64/lib/python3.12/site-packages/artiq/tools.py", line 106, in short_format
    elif np.issubdtype(t, np.unicode_):
                          ^^^^^^^^^^^
  File "D:/MSYS2 with ARTIQ/clang64/lib/python3.12/site-packages/numpy/__init__.py", line 400, in __getattr__
    raise AttributeError(
AttributeError: `np.unicode_` was removed in the NumPy 2.0 release. Use `np.str_` instead.
```

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [ ] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.
- [ ] Close/update issues.
- [ ] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [ ] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [ ] Test your changes or have someone test them. Mention what was tested and how.
- [ ] Add and check docstrings and comments
- [ ] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)


### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
