### PR TITLE
NAC3: Enable dma

### DIFF
--- a/artiq/examples/kc705_nist_clock/repository/dma_blink.py
+++ b/artiq/examples/kc705_nist_clock/repository/dma_blink.py
@@ -1,9 +1,14 @@
 from artiq.experiment import *
+from artiq.coredevice.core import Core
+from artiq.coredevice.dma import CoreDMA
+from artiq.coredevice.ttl import TTLOut
 
-
-# NAC3TODO https://git.m-labs.hk/M-Labs/nac3/issues/75
-
+@nac3
 class DMABlink(EnvExperiment):
+    core: KernelInvariant[Core]
+    core_dma: KernelInvariant[CoreDMA]
+    led: KernelInvariant[TTLOut]
+
     def build(self):
         self.setattr_device("core")
         self.setattr_device("core_dma")
@@ -11,13 +16,14 @@ class DMABlink(EnvExperiment):
 
     @kernel
     def record(self):
-        with self.core_dma.record("blink"):
+        self.core_dma.prepare_record("blink")
+        with self.core_dma.recorder:
             for i in range(5):
-                self.led.pulse(100*ms)
-                delay(100*ms)
+                self.led.pulse(100.*ms)
+                self.core.delay(100.*ms)
             for i in range(5):
-                self.led.pulse(50*ms)
-                delay(50*ms)
+                self.led.pulse(50.*ms)
+                self.core.delay(50.*ms)
 
     @kernel
     def run(self):


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

With context managers implemented, DMA can finally run.

Kind of.

An object cannot be returned in NAC3 at the moment:
```
return value of type artiq.coredevice.dma.DMARecordContextManager must be a primitive or a tuple of primitives at /home/spaqin/m-labs/artiq/artiq/coredevice/dma.py:101:20
```

So I changed the ``record`` method a little bit to be somewhat usable, into ``prepare_record``, until that is fixed.

For testing, I ran the example on kc705.

### Related Issue

[nac3#338](https://git.m-labs.hk/M-Labs/nac3/issues/338)

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
