### PR TITLE
test_rtio: close CommMgmt socket on test skip

### DIFF
--- a/artiq/test/coredevice/test_rtio.py
+++ b/artiq/test/coredevice/test_rtio.py
@@ -502,11 +502,13 @@ class CoredeviceTest(ExperimentCase):
     def execute_and_test_in_log(self, experiment, string):
         core_addr = self.device_mgr.get_desc("core")["arguments"]["host"]
         mgmt = CommMgmt(core_addr)
-        mgmt.clear_log()
-        self.execute(experiment)
-        log = mgmt.get_log()
-        self.assertIn(string, log)
-        mgmt.close()
+        try:
+            mgmt.clear_log()
+            self.execute(experiment)
+            log = mgmt.get_log()
+            self.assertIn(string, log)
+        finally:
+            mgmt.close()
 
     def test_sequence_error(self):
         self.execute_and_test_in_log(SequenceError, "RTIO sequence error")


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

`execute_and_test_in_log` doesn't call `mgmt.close()` if the test is skipped or failed, leading to `ResourceWarning: unclosed <socket.socket ... >`.

Proposal: 
Close the socket with a `finally` block.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps 

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
Tests no longer emit resource warnings when being skipped and pass normally when not skipped. Test failure was simulated with a `raise` in the `try` block and no resource warning was emitted.
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
