### PR TITLE
cxp_grabber driver doc: fix "note" formatting

### DIFF
--- a/artiq/coredevice/cxp_grabber.py
+++ b/artiq/coredevice/cxp_grabber.py
@@ -169,6 +169,7 @@ class CXPGrabber:
     def read32(self, address: TInt32) -> TInt32:
         """
         Read a 32-bit value from camera register
+
         .. note:: This is NOT a real time operation
 
         :param address: 32-bit register address to read from
@@ -180,6 +181,7 @@ class CXPGrabber:
     def write32(self, address: TInt32, value: TInt32):
         """
         Write a 32-bit value to camera register
+
         .. note:: This is NOT a real time operation
 
         :param address: 32-bit register address to be writen
@@ -192,6 +194,7 @@ class CXPGrabber:
         """
         Download the xml setting file to PC from the camera if available
         The file format can be .zip or .xml depending on the camera model
+
         .. note:: This is NOT a real time operation
 
         :param file_path: a relative path on PC


### PR DESCRIPTION

# ARTIQ Pull Request

## Description of Changes
- fix cxp_grabber drive doc `note` formatting

- before fix
![b4_img](https://github.com/user-attachments/assets/7d49961b-4b2e-49e7-b3e8-564f38197e02)
- after fix
![after_img](https://github.com/user-attachments/assets/c9e1ba02-06ce-4c97-bc8c-5f87bff7d1aa)

### Related Issue

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :scroll: Docs |


### Documentation Changes

- [x] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`nix build .#artiq-manual-html; nix build .#artiq-manual-pdf`) to ensure no errors.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
