### PR TITLE
satman: accept shuttler on satellite kasli

### DIFF
--- a/artiq/firmware/satman/main.rs
+++ b/artiq/firmware/satman/main.rs
@@ -647,7 +647,7 @@ fn process_aux_packet(dmamgr: &mut DmaManager, analyzer: &mut Analyzer, kernelmg
         drtioaux::Packet::CoreMgmtDropLinkAck { destination: _destination } => {
             forward!(router, _routing_table, _destination, *rank, *self_destination, _repeaters, &packet);
 
-            #[cfg(not(has_drtio_eem))]
+            #[cfg(not(soc_platform = "efc"))]
             unsafe {
                 csr::gt_drtio::txenable_write(0);
             }
@@ -949,7 +949,7 @@ fn startup() {
         io_expander.service().unwrap();
     }
 
-    #[cfg(not(has_drtio_eem))]
+    #[cfg(not(soc_platform = "efc"))]
     unsafe {
         csr::gt_drtio::txenable_write(0xffffffffu32 as _);
     }


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
Re-accept Shuttler as a peripheral for Kasli satellites. It reverts previous commit that disables GT DRTIO for devices that has EEM-based DRTIO.

The compilation gate becomes asymmetric because a non-EFC satellite may have both GT and EEM-based DRTIO interfaces.
- GT for upstream and non-EFC downstreams
- EEM for EFC downstream

### Related Issue

#2593, #2410
https://forum.m-labs.hk/d/911-kasli-drtio-satellite

### Tests
Built a Kasli v2.0 satellite device with a shuttler as its peripheral. Able to establish DRTIO link to the Kasli satellite and EFC.
Blinked EFC LEDs through DRTIO.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Close/update issues.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Git Logistics

- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
