### PR TITLE
Add the missing pieces of #2694

### DIFF
--- a/artiq/firmware/libboard_artiq/si5324.rs
+++ b/artiq/firmware/libboard_artiq/si5324.rs
@@ -127,7 +127,10 @@ fn write_no_ack_value(reg: u8, val: u8) -> Result<()> {
             err => err.into()
         }
     )?;
-    i2c::write(BUSNO, val).unwrap();
+    match i2c::write(BUSNO, val) {
+        Ok(()) | Err(i2c::Error::Nack) => Ok(()),
+        err => err
+    }?;
     i2c::stop(BUSNO).unwrap();
     Ok(())
 }

--- a/artiq/firmware/libboard_artiq/spi.rs
+++ b/artiq/firmware/libboard_artiq/spi.rs
@@ -4,6 +4,15 @@ pub enum Error {
     OtherError,
 }
 
+impl From<Error> for &str {
+    fn from(err: Error) -> &'static str {
+        match err {
+            Error::NoSPI => "SPI not supported",
+            Error::InvalidBus => "Invalid SPI bus",
+            Error::OtherError => "other error",
+        }
+    }
+}
 
 #[cfg(has_converter_spi)]
 mod imp {


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
Fixes Kasli panics after failing to detect ACK after soft resetting, and EFC compilation error.
NACK is now an error, unwrapping the result would reject NACK.

Kasli runtime can be started and EFC firmware can be compiled.

### Related Issue
#2694

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
