### PR TITLE
cxp_grabber: add ROI Viewer support

### DIFF
--- a/artiq/gateware/rtio/phy/cxp_grabber.py
+++ b/artiq/gateware/rtio/phy/cxp_grabber.py
@@ -6,7 +6,7 @@ from misoc.cores.coaxpress.phy.low_speed_serdes import HostTXPHYs
 
 from artiq.gateware.rtio import rtlink
 from artiq.gateware.rtio.phy.grabber import Serializer, Synchronizer
-from artiq.gateware.cxp_grabber.core import CXPHostCore, ROI, StreamDecoder
+from artiq.gateware.cxp_grabber.core import CXPHostCore, ROI, ROIViewer, StreamDecoder
 
 
 class CXPGrabber(Module, AutoCSR):
@@ -55,6 +55,9 @@ class CXPGrabber(Module, AutoCSR):
 
         self.submodules.stream_decoder = stream_decoder = StreamDecoder(res_width)
         self.comb += core.rx.source.connect(stream_decoder.sink)
+
+        # ROI Viewer
+        self.submodules.roi_viewer = ROIViewer(stream_decoder.source_pixel4x)
 
         # ROI engines configuration and count gating
         cdr = ClockDomainsRenamer("cxp_gt_rx")


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

## Summary
- add a ROI Viewer that can buffer at most 4096 pixels (e.g. 64x64 or 2048x2 ROI) that user can download and view it on the PC 
- gateware
  - add `ROICropper` and `ROIViewer` 
  - connect `pixel_4x` to `ROIViewer` 
- coredevice
  - add  `start_roi_viewer` to setup the ROI coordinate and arm the Viewer
  - add `download_roi_viewer_frame` to download the frame to PC as [.pgm files](https://en.wikipedia.org/wiki/Netpbm#File_formats) 
    - used binary variant instead of ascii variant to save space (4.1kB vs 12.9kB for a 64x64 mono8 

## Testing
- use boA2448-250cm in [testimage1 mode](https://docs.baslerweb.com/test-patterns) and capture a 64x64 gradient image
- successful open the `testimage1.pgm` file in eog(GNOME Image Viewer), GIMP and Pinta

![image](https://github.com/user-attachments/assets/3ef2aa70-42bc-4311-9e93-915020ca5a2e)


## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments


### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
