### PR TITLE
Invalidate I-cache after rebinding nac3ld-linked binaries

### DIFF
--- a/artiq/firmware/ksupport/lib.rs
+++ b/artiq/firmware/ksupport/lib.rs
@@ -264,6 +264,7 @@ extern "C-unwind" fn dma_record_start(name: &CSlice<u8>) {
                        dma_record_output as *const () as u32).unwrap();
         library.rebind(b"rtio_output_wide",
                        dma_record_output_wide as *const () as u32).unwrap();
+        board_misoc::cache::flush_cpu_icache();
 
         DMA_RECORDER.active = true;
         send(&DmaRecordStart(name));
@@ -283,6 +284,7 @@ extern "C-unwind" fn dma_record_stop(duration: i64, enable_ddma: bool) {
                        rtio::output as *const () as u32).unwrap();
         library.rebind(b"rtio_output_wide",
                        rtio::output_wide as *const () as u32).unwrap();
+        board_misoc::cache::flush_cpu_icache();
 
         DMA_RECORDER.active = false;
         send(&DmaRecordStop {


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
This PR invalidates the instruction cache after rebinding the library's relocation for entering/exiting the DMA context.
Only binaries that doesn't use procedural linkage table (PLT) requires this patch. In other words, only the nac3 branch.

This patch is not necessary for the legacy compiler.

## Relation to the PLT
With PLT, external function calls are generated through a jump to a part of the .plt code. Such part looks like this.
```risc-v
    auipc <temp>, <upper imm>
    lw    <temp>, <lower imm>(<temp>)
    jalr  <temp>, <temp>               # discard PC+4, keep the previous return address at ra
    nop                                # alignment
```
The actual address of these functions is put in the `.got.plt` section, separated from the executable code. When resolving dynamic linkage, the linker is instructed to resolve the `.got.plt` entries. Addresses are always updated and fetched through the D-cache. No coherence problem in this case.

Without a PLT, similar function calls are generated as such:
```risc-v
    auipc ra, <upper imm>
    jalr  <lower imm>(ra)    # implicitly write PC+4 to ra
```
Relocations are performed to `.text` itself by updating the immediates of the `auipc` and `lw` instructions through the D-cache. Without synchronization, such instruction's out-of-date copy may linger in the I-cache until its eviction.

Hence, a `fence.i` instruction should be inserted after rebinding to synchronize the I-cache.

### Related Issue

#2686
Context: https://github.com/m-labs/artiq/pull/2686#issuecomment-2673780762

Here are some simple scripts that would cause undesirable behavior on Kasli 2.0.
```python
    @kernel
    def run(self):
        for i in range(0x10):
            self.core.reset()
        self.core_dma.prepare_record("test_rtio")
        with self.core_dma.recorder:
            self.ttl_out.on()
```
The number of `self.core.reset()` is important.
This causes RTIOUnderflow similar to the test on Hydra, with timestamp=0 and slack being approximately `-rtio_counter`.

```python
    @kernel
    def run(self):
        self.core_dma.prepare_record("test_rtio")
        with self.core_dma.recorder:
            self.ttl_out.on()
        self.ttl_out.on()
```
`artiq_coreanalyzer` reports no RTIO events were submitted. No exceptions were raised.

### Test
The first example runs without exception. `artiq_coreanalyzer` reports no RTIO events were submitted. (Note the lack of `dma_playback`)
The second example reports RTIOUnderflow. Timestamp of the RTIO event does not change across invocations. (Due to [seamless handover](https://m-labs.hk/artiq/manual/rtio.html#seamless-handover))

Passes `artiq.test` on kc705 and kasli v2.0 with NAC3. Only RISC-V devices are tested.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Close/update issues.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Git Logistics

- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
