### PR TITLE
cxp grabber: fix pixel unpacker bit ordering 

### DIFF
--- a/artiq/gateware/cxp_grabber/frame.py
+++ b/artiq/gateware/cxp_grabber/frame.py
@@ -303,8 +303,9 @@ class PixelUnpacker(Module):
 
         sink_cases = {}
         for i in range(ring_buf_size//sink_dw):
+            byte = [self.sink.data[i * 8 : (i + 1) * 8] for i in range(sink_dw // 8)]
             sink_cases[i] = [
-                ring_buf[sink_dw*i:sink_dw*(i+1)].eq(self.sink.data),
+                ring_buf[sink_dw*i:sink_dw*(i+1)].eq(Cat([b[::-1] for b in byte])),
             ]
         self.sync += If(self.sink.stb, Case(w_cnt, sink_cases))
 
@@ -314,7 +315,7 @@ class PixelUnpacker(Module):
             for j in range(4):
                 source_cases[i].append(
                     self.source.data[max_pixel_width * j : max_pixel_width * (j + 1)].eq(
-                        ring_buf[(source_dw * i) + (size * j) : (source_dw * i) + (size * (j + 1))]
+                        ring_buf[(source_dw * i) + (size * j) : (source_dw * i) + (size * (j + 1))][::-1]
                     )
                 )
 


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
### Summary
- fix pixel unpacker bit ordering to follow CXP specification
- fix pixel packet generator bit ordering to follow CXP specification

### Bit order difference between pre-patch and CXP specification (MONO10 as an example)
| Before patch   | CXP specification |
| -------- | ------- |
| ![pre_patch](https://github.com/user-attachments/assets/4de92d4e-8624-40db-bbf3-ec90b9d8797f)  | ![image](https://github.com/user-attachments/assets/f2b71a33-b9a9-40fe-b561-80d0d93c9853)  |



### boA2448-250cm MONO10 test
- tested in [`testimage1`](https://docs.baslerweb.com/test-patterns#test-image-1) mode and capturing with sensor 

| Before patch    | After patch |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/f7efe24d-9426-41a5-8e79-6b3601883b48)    | ![image](https://github.com/user-attachments/assets/2d33d6d7-0450-468b-af0e-efc0468a4a61)    |
| ![image](https://github.com/user-attachments/assets/8c93cec6-f850-4b37-bbbd-bde4674afdad)  | ![image](https://github.com/user-attachments/assets/f6cf6763-0d08-49cc-b0af-d8e1041ef03e) |

### boA2448-250cm MONO12 test
- tested in [`testimage1`](https://docs.baslerweb.com/test-patterns#test-image-1) mode and capturing with sensor 

| Before patch    | After patch |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/9acf0742-ade5-44ce-a69e-50c12dce0a98) | ![image](https://github.com/user-attachments/assets/0df3c53d-d511-4607-909a-069f3f7acab8)   |
| ![image](https://github.com/user-attachments/assets/77b59743-e45d-408e-b8e4-e36bbf1c536b) | ![image](https://github.com/user-attachments/assets/f70090fe-0255-43ea-ad9b-e5a868cd7aaf)    |


## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)


### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
