### PR TITLE
cxp_grabber driver: add docs about roiviewer height limit & fix roiviewer coordinate order

### DIFF
--- a/artiq/coredevice/cxp_grabber.py
+++ b/artiq/coredevice/cxp_grabber.py
@@ -246,7 +246,7 @@ class CXPGrabber:
         """
         Defines the coordinates of ROI viewer and start the capture.
 
-        Unlike :exc:`setup_roi`, ROI viewer has a maximum size limit of 4096 pixels.
+        Unlike :exc:`setup_roi`, ROI viewer has a maximum  height limit of 1024 and total size limit of 4096 pixels.
 
         .. warning:: This is NOT a real-time operation.
         """


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Follow up from [artiq-zynq/374](https://git.m-labs.hk/M-Labs/artiq-zynq/pulls/374)
### Summary
- add docs about the roiviewer height limit
- fix roiviewer functions to use the usual ROI coordinate order


## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |
| ✓  | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Add and check docstrings and comments

