### PR TITLE
cxp_grabber: fix pixel coordinate tracker

### DIFF
--- a/artiq/gateware/cxp_grabber/frame.py
+++ b/artiq/gateware/cxp_grabber/frame.py
@@ -404,7 +404,10 @@ class PixelCoordinateTracker(Module):
                     pix.x.eq(x_r),
                     pix.y.eq(y_r),
                     pix.gray.eq(self.sink.data[max_pixel_width*i:max_pixel_width*(i+1)]),
-                )
+                ),
+                If(pix.eof,
+                    pix.y.eq(self.y_size),
+                ),
             ]
 
 


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

### Summary
- the `ROI` and `ROIViewer` cannot set `y_good` to low when `y0 = y_size - 1` and `y1 = y_size` (i.e. capturing the last line of the frame). As `pix.y` never reach `y_size` after end of frame.
- fix this by setting `pix.y` as `y_size` after end of frame.

### Testing
- tested with boA2448-250cm
   - successfully capture last line of the frame using ROI viewer
   - successfully accumulate the counts in last line of the frame using ROI and testpattern [WHITE](https://docs.baslerweb.com/test-patterns#white)

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.


### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.



### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
