### PR TITLE
i2c: stop the bus after received NACK

### DIFF
--- a/artiq/firmware/libboard_misoc/i2c.rs
+++ b/artiq/firmware/libboard_misoc/i2c.rs
@@ -223,10 +223,11 @@ mod imp {
         // mask in format of 1 << channel (or 0 for disabling output)
         // PCA9548 support only for now
         start(busno)?;
-        write(busno, address << 1)?;
-        write(busno, mask)?;
-        stop(busno)?;
-        Ok(())
+        let write_result = write(busno, address << 1)
+            .and_then( |_| write(busno, mask) );
+        let stop_result = stop(busno);
+
+        write_result.and(stop_result)
     }
 }
 

--- a/artiq/firmware/libboard_misoc/io_expander.rs
+++ b/artiq/firmware/libboard_misoc/io_expander.rs
@@ -151,11 +151,12 @@ impl IoExpander {
 
     fn write(&self, addr: u8, value: u8) -> Result<(), i2c::Error> {
         i2c::start(self.busno)?;
-        i2c::write(self.busno, self.address)?;
-        i2c::write(self.busno, addr)?;
-        i2c::write(self.busno, value)?;
-        i2c::stop(self.busno)?;
-        Ok(())
+        let write_result = i2c::write(self.busno, self.address)
+            .and_then( |_| i2c::write(self.busno, addr))
+            .and_then( |_| i2c::write(self.busno, value));
+
+        let stop_result = i2c::stop(self.busno);
+        write_result.and(stop_result)
     }
 
     fn check_ack(&self) -> Result<bool, i2c::Error> {


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Make sure that the i2c bus is stopped regardless of i2c errors.

### Related Issue

Closes #2710 

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |


## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
