### PR TITLE
Backport byval removal to legacy compiler

### DIFF
--- a/artiq/compiler/transforms/llvm_ir_generator.py
+++ b/artiq/compiler/transforms/llvm_ir_generator.py
@@ -1524,13 +1524,7 @@ class LLVMIRGenerator:
 
         for i, arg in enumerate(insn.arguments()):
             llarg = self.map(arg)
-            if isinstance(llarg.type, (ll.LiteralStructType, ll.IdentifiedStructType)):
-                llslot = self.llbuilder.alloca(llarg.type)
-                self.llbuilder.store(llarg, llslot)
-                llargs.append(llslot)
-                llarg_attrs[i] = "byval"
-            else:
-                llargs.append(llarg)
+            llargs.append(llarg)
 
         llretty = self.llty_of_type(insn.type, for_return=True)
         is_sret = self.needs_sret(llretty)

--- a/artiq/firmware/ksupport/lib.rs
+++ b/artiq/firmware/ksupport/lib.rs
@@ -209,7 +209,7 @@ fn terminate(exceptions: &'static [Option<eh_artiq::Exception<'static>>],
     loop {}
 }
 
-extern fn cache_get<'a>(key: &CSlice<u8>) -> *const CSlice<'a, i32> {
+extern fn cache_get<'a>(key: CSlice<u8>) -> *const CSlice<'a, i32> {
     send(&CacheGetRequest {
         key:   str::from_utf8(key.as_ref()).unwrap()
     });
@@ -218,7 +218,7 @@ extern fn cache_get<'a>(key: &CSlice<u8>) -> *const CSlice<'a, i32> {
     })
 }
 
-extern "C-unwind" fn cache_put(key: &CSlice<u8>, list: &CSlice<i32>) {
+extern "C-unwind" fn cache_put(key: CSlice<u8>, list: &CSlice<i32>) {
     send(&CachePutRequest {
         key:   str::from_utf8(key.as_ref()).unwrap(),
         value: list.as_ref()
@@ -251,7 +251,7 @@ fn dma_record_flush() {
     }
 }
 
-extern "C-unwind" fn dma_record_start(name: &CSlice<u8>) {
+extern "C-unwind" fn dma_record_start(name: CSlice<u8>) {
     let name = str::from_utf8(name.as_ref()).unwrap();
 
     unsafe {
@@ -359,7 +359,7 @@ extern fn dma_record_output_wide(target: i32, words: &CSlice<i32>) {
     }
 }
 
-extern fn dma_erase(name: &CSlice<u8>) {
+extern fn dma_erase(name: CSlice<u8>) {
     let name = str::from_utf8(name.as_ref()).unwrap();
 
     send(&DmaEraseRequest { name: name });
@@ -372,7 +372,7 @@ struct DmaTrace {
     uses_ddma: bool,
 }
 
-extern "C-unwind" fn dma_retrieve(name: &CSlice<u8>) -> DmaTrace {
+extern "C-unwind" fn dma_retrieve(name: CSlice<u8>) -> DmaTrace {
     let name = str::from_utf8(name.as_ref()).unwrap();
 
     send(&DmaRetrieveRequest { name: name });


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
This PR is to implement byval attribute removal for syscalls to the legacy compiler.
The associated stack allocation and cloning has also been removed.

## Test
Passed `artiq.test` for both Kasli and Kasli-SoC.

### Related Issue
NAC3 PR.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)


### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
