### PR TITLE
Fix LLVM string codegen test for dropping `byval`

### DIFF
--- a/artiq/test/lit/embedding/syscall_arg_attrs.py
+++ b/artiq/test/lit/embedding/syscall_arg_attrs.py
@@ -4,21 +4,21 @@
 from artiq.language.core import *
 from artiq.language.types import *
 
-# Make sure `byval` and `sret` are specified both at the call site and the
+# Make sure `sret` is specified both at the call site and the
 # declaration. This isn't caught by the LLVM IR validator, but mismatches
 # lead to miscompilations (at least in LLVM 11).
 
 
 @kernel
 def entrypoint():
-    # CHECK: call void @accept_str\({ i8\*, i32 }\* nonnull byval
+    # CHECK: call void @accept_str\({ i8\*, i32 }
     accept_str("foo")
 
     # CHECK: call void @return_str\({ i8\*, i32 }\* nonnull sret
     return_str()
 
 
-# CHECK: declare void @accept_str\({ i8\*, i32 }\* byval\({ i8\*, i32 }\)\)
+# CHECK: declare void @accept_str\({ i8\*, i32 }\)
 @syscall
 def accept_str(name: TStr) -> TNone:
     pass


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
Associated LLVM codegen test for string passing.

But since we have removed `byval` altogether, it might be better to just remove the `accept_str` test. Unless we still want to check that string are passed as a struct.

### Test
Compiled `syscall_arg_attrs.py` into LLVM bytecode. `accept_str` is declared and invoked as such:
```
@S.foo.1 = private unnamed_addr constant [3 x i8] c"foo"
...
call void @accept_str({ i8*, i32 } { i8* getelementptr inbounds ([3 x i8], [3 x i8]* @S.foo.1, i32 0, i32 0), i32 3 }), !dbg !13
...
declare void @accept_str({ i8*, i32 }) local_unnamed_addr
```
No errors reported by `OutputCheck`.

### Related Issue
#2713

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Close/update issues.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
