### PR TITLE
AD9910 Tests: Skip unit tests with no device in io_update_device decorator

### DIFF
--- a/artiq/test/coredevice/test_ad9910_waveform.py
+++ b/artiq/test/coredevice/test_ad9910_waveform.py
@@ -1,6 +1,5 @@
 from functools import wraps
 
-import artiq.coredevice.spi2 as spi
 from artiq.coredevice.ad9910 import (
     _AD9910_REG_ASF,
     _AD9910_REG_RAMP_LIMIT,
@@ -32,9 +31,9 @@ AMP = 1.0
 ATT = 1.0
 
 # Set to desired devices
-CPLD = "urukul1_cpld"
-DDS1 = "urukul1_ch0"
-DDS2 = "urukul1_ch3"
+CPLD = "urukul_cpld"
+DDS1 = "urukul_ch0"
+DDS2 = "urukul_ch3"
 
 
 def io_update_device(cpld, *required_values, proto_rev=None):
@@ -53,11 +52,12 @@ def io_update_device(cpld, *required_values, proto_rev=None):
         def wrapper(self, *args, **kwargs):
             for required in required_values:
                 with self.subTest(io_update_device=required):
-                    desc = (
-                        self.device_mgr.get_desc(cpld)
-                        if hasattr(self.device_mgr, "get_desc")
-                        else {}
-                    )
+                    try:
+                        desc = self.device_mgr.get_desc(cpld)
+                    except Exception:
+                        self.skipTest(
+                            "Failed to get description of device '{}'".format(cpld)
+                        )
                     io_update_present = "io_update_device" in desc.get("arguments", [])
 
                     if io_update_present != required:


### PR DESCRIPTION
Fixes Hydra tests that should be skipped-

https://nixbld.m-labs.hk/log/rsazsg62z3d4kcy6l6s26siq6sg9z6wa-kc705-hitl.drv

# ARTIQ Pull Request

## Description of Changes

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
