### PR TITLE
Urukul Test: skip unit tests that don't have a device in the device_db

### DIFF
--- a/artiq/test/coredevice/test_urukul.py
+++ b/artiq/test/coredevice/test_urukul.py
@@ -266,6 +266,12 @@ class UrukulExp(EnvExperiment):
 
 
 class UrukulTest(ExperimentCase):
+    def get_or_skip(self, device_name):
+        try:
+            return self.device_mgr.get(device_name)
+        except Exception:
+            self.skipTest(f"Failed to get device '{device_name}'")
+
     def test_instantiate(self):
         self.execute(UrukulExp, "instantiate")
 
@@ -299,11 +305,11 @@ class UrukulTest(ExperimentCase):
         self.assertEqual(sw_get, sw_set)
 
     def test_att_enables(self):
-        if self.device_mgr.get(CPLD).proto_rev == STA_PROTO_REV_9:
+        if self.get_or_skip(CPLD).proto_rev == STA_PROTO_REV_9:
             self.execute(UrukulExp, "att_enables")
 
     def test_att_enable_speed(self):
-        if self.device_mgr.get(CPLD).proto_rev == STA_PROTO_REV_9:
+        if self.get_or_skip(CPLD).proto_rev == STA_PROTO_REV_9:
             self.execute(UrukulExp, "att_enable_speed")
             dt = self.dataset_mgr.get("dt")
             print(dt)
@@ -337,44 +343,44 @@ class UrukulTest(ExperimentCase):
         self.assertLess(dt, 5 * us)
 
     def test_osk(self):
-        if self.device_mgr.get(CPLD).proto_rev == STA_PROTO_REV_9:
+        if self.get_or_skip(CPLD).proto_rev == STA_PROTO_REV_9:
             self.execute(UrukulExp, "osk")
 
     def test_osk_speed(self):
-        if self.device_mgr.get(CPLD).proto_rev == STA_PROTO_REV_9:
+        if self.get_or_skip(CPLD).proto_rev == STA_PROTO_REV_9:
             self.execute(UrukulExp, "osk_speed")
             dt = self.dataset_mgr.get("dt")
             print(dt)
             self.assertLess(dt, 5 * us)
 
     def test_drctl(self):
-        if self.device_mgr.get(CPLD).proto_rev == STA_PROTO_REV_9:
+        if self.get_or_skip(CPLD).proto_rev == STA_PROTO_REV_9:
             self.execute(UrukulExp, "drctl")
 
     def test_drctl_speed(self):
-        if self.device_mgr.get(CPLD).proto_rev == STA_PROTO_REV_9:
+        if self.get_or_skip(CPLD).proto_rev == STA_PROTO_REV_9:
             self.execute(UrukulExp, "drctl_speed")
             dt = self.dataset_mgr.get("dt")
             print(dt)
             self.assertLess(dt, 5 * us)
 
     def test_drhold(self):
-        if self.device_mgr.get(CPLD).proto_rev == STA_PROTO_REV_9:
+        if self.get_or_skip(CPLD).proto_rev == STA_PROTO_REV_9:
             self.execute(UrukulExp, "drhold")
 
     def test_drhold_speed(self):
-        if self.device_mgr.get(CPLD).proto_rev == STA_PROTO_REV_9:
+        if self.get_or_skip(CPLD).proto_rev == STA_PROTO_REV_9:
             self.execute(UrukulExp, "drhold_speed")
             dt = self.dataset_mgr.get("dt")
             print(dt)
             self.assertLess(dt, 5 * us)
 
     def test_mask_nu(self):
-        if self.device_mgr.get(CPLD).proto_rev == STA_PROTO_REV_9:
+        if self.get_or_skip(CPLD).proto_rev == STA_PROTO_REV_9:
             self.execute(UrukulExp, "mask_nu")
 
     def test_mask_nu_speed(self):
-        if self.device_mgr.get(CPLD).proto_rev == STA_PROTO_REV_9:
+        if self.get_or_skip(CPLD).proto_rev == STA_PROTO_REV_9:
             self.execute(UrukulExp, "mask_nu_speed")
             dt = self.dataset_mgr.get("dt")
             print(dt)


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Skip Urukul unit tests that don't have a device in the device_db

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
