### PR TITLE
doc: fix Sphinx errors 

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -34,8 +34,10 @@ ARTIQ-9 (Unreleased)
 * ``artiq.coredevice.fmcdio_vhdci_eem`` has been removed.
 * ``artiq.coredevice.urukul``, ``artiq.coredevice.ad9910``, and ``artiq.coredevice.ad9912``
   have been updated for new Urukul capabilities:
+
    - Digital Ramp Generation (DRG)
    - Individual DDS Channel control:
+
       * PROFILE
       * IO_UPDATE
       * OSK

--- a/artiq/coredevice/ad9910.py
+++ b/artiq/coredevice/ad9910.py
@@ -334,7 +334,7 @@ class AD9910:
         The profile to write to and the step, start, and end address
         need to be configured in advance and separately using
         :meth:`set_profile_ram` and the parent CPLD
-        :meth:`~artiq.coredevice.urukul.CPLD.set_profile`.
+        :meth:`~artiq.coredevice.urukul.ProtoRev9.set_profile`.
 
         :param data: Data to be written to RAM.
         """
@@ -356,7 +356,7 @@ class AD9910:
         The profile to read from and the step, start, and end address
         need to be configured before and separately using
         :meth:`set_profile_ram` and the parent CPLD 
-        :meth:`~artiq.coredevice.urukul.CPLD.set_profile`.
+        :meth:`~artiq.coredevice.urukul.ProtoRev9.set_profile`.
 
         :param data: List to be filled with data read from RAM.
         """

--- a/artiq/coredevice/urukul.py
+++ b/artiq/coredevice/urukul.py
@@ -501,8 +501,8 @@ class ProtoRev9(CPLDVersion):
     def set_profile(self, cpld, channel: TInt32, profile: TInt32):
         """Set the CFG.PROFILE[0:2] pins for the given channel.
 
-        :param profile: PROFILE pins in numeric representation (0-7).
         :param channel: Channel (0-3).
+        :param profile: PROFILE pins in numeric representation (0-7).
         """
         cfg = cpld.cfg_reg & ~(7 << (CFG_PROFILE + channel * 3))
         cfg |= (profile & 7) << (CFG_PROFILE + channel * 3)


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

Sphinx can't link a reference to the CPLD correctly since that `set_profile` doesn't have a docstring. We can either link to ProtoRev8 _or_ ProtoRev9, or just add that particular method to the ignore list, depending on which we think is more helpful, 

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
| ✓  | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Documentation Changes

- [x] Check, test, and update the documentation in [doc/](../doc/). Build documentation (`nix build .#artiq-manual-html; nix build .#artiq-manual-pdf`) to ensure no errors.

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
