### PR TITLE
Notify about error/warnings #6

### DIFF
--- a/artiq/gui/log.py
+++ b/artiq/gui/log.py
@@ -203,8 +203,9 @@ class _Model(QtCore.QAbstractItemModel):
 
 class LogDock(QDockWidgetCloseDetect):
     def __init__(self, manager, name):
-        QDockWidgetCloseDetect.__init__(self, "Log")
+        QDockWidgetCloseDetect.__init__(self, "")
         self.setObjectName(name)
+        self.main_window = manager.main_window
 
         grid = LayoutWidget()
         self.setWidget(grid)
@@ -281,6 +282,81 @@ class LogDock(QDockWidgetCloseDetect):
 
         self.filter_freetext.returnPressed.connect(self.apply_text_filter)
         self.filter_level.currentIndexChanged.connect(self.apply_level_filter)
+
+        self.current_alert_color = None
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        QtCore.QTimer.singleShot(0, self._create_log_button)
+        QtCore.QTimer.singleShot(0, self._connect_to_tab_bar)
+
+    def _create_log_button(self):
+        # To make the tab style more managable we add button with text instead
+        # of the tab name
+        tabbar = self._find_tab_bar()
+        if tabbar is not None:
+            idx = self._tab_index(tabbar)
+            if idx is not None:
+                # Create a QLabel to serve as the tab's text.
+                label = QtWidgets.QLabel("Log")
+                label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+                tabbar.setTabButton(idx,
+                                    QtWidgets.QTabBar.ButtonPosition.LeftSide,
+                                    label)
+
+    def _connect_to_tab_bar(self):
+        # Locate the QTabBar in the main window and connect its currentChanged
+        # signal so that when this tab is selected the alert is cleared.
+        tabbar = self._find_tab_bar()
+        if tabbar is not None:
+            tabbar.currentChanged.connect(self._on_tab_changed)
+
+    def _find_tab_bar(self):
+        # Search for a QTabBar among main_window’s children.
+        tabbars = self.main_window.findChildren(QtWidgets.QTabBar)
+        for tabbar in tabbars:
+            for i in range(tabbar.count()):
+                if tabbar.tabText(i) == self.windowTitle():
+                    return tabbar
+        return None
+
+    def _tab_index(self, tabbar):
+        for i in range(tabbar.count()):
+            if tabbar.tabText(i) == self.windowTitle():
+                return i
+        return None
+
+    def _on_tab_changed(self, index):
+        tabbar = self._find_tab_bar()
+        if tabbar is None:
+            return
+        my_index = self._tab_index(tabbar)
+        if my_index is not None and my_index == index:
+            self.clear_alert()
+
+    def set_alert(self, color):
+        # Change the tab's color.
+        self.current_alert_color = color
+        tabbar = self._find_tab_bar()
+        if tabbar is not None:
+            idx = self._tab_index(tabbar)
+            if idx is not None:
+                label = tabbar.tabButton(
+                        idx, QtWidgets.QTabBar.ButtonPosition.LeftSide)
+                if isinstance(label, QtWidgets.QLabel):
+                    label.setStyleSheet("background-color: %s;" % color)
+
+    def clear_alert(self):
+        # Revert the tab's color.
+        self.current_alert_color = None
+        tabbar = self._find_tab_bar()
+        if tabbar is not None:
+            idx = self._tab_index(tabbar)
+            if idx is not None:
+                label = tabbar.tabButton(
+                        idx, QtWidgets.QTabBar.ButtonPosition.LeftSide)
+                if isinstance(label, QtWidgets.QLabel):
+                    label.setStyleSheet("background-color: transparent;")
 
     def apply_text_filter(self):
         self.proxy_model.setFilterRegularExpression(self.filter_freetext.text())
@@ -359,6 +435,16 @@ class LogDockManager:
     def append_message(self, msg):
         for dock in self.docks.values():
             dock.model.append(msg)
+            if dock._find_tab_bar() is not None:
+                # Find our tab index and the currently selected tab index.
+                tabbar = dock._find_tab_bar()
+                my_index = dock._tab_index(tabbar)
+                if my_index is None or my_index != tabbar.currentIndex():
+                    if msg[0] >= logging.ERROR:
+                        dock.set_alert("red")
+                    elif msg[0] >= logging.WARNING:
+                        if dock.current_alert_color != "red":
+                            dock.set_alert("yellow")
 
     def create_new_dock(self, add_to_area=True):
         n = 0


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Change the 'Log' tab color to yellow to notify about new warning and to red for errors and criticals.
The change is a hack.
I did not find any direct way to change the tab background color. I did not manage to make it work with stylesheets.
I imagine that there is some way to do it and would be grateful for some hint.
However, to make it work, I replaced the name of the tab with QLabel.
The behavior is ok, but it's not clean solution.

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
