### PR TITLE
Add explanation mark on tab title when there is new interactive argument

### DIFF
--- a/artiq/frontend/artiq_dashboard.py
+++ b/artiq/frontend/artiq_dashboard.py
@@ -245,7 +245,8 @@ def main():
 
     d_interactive_args = interactive_args.InteractiveArgsDock(
         sub_clients["interactive_args"],
-        rpc_clients["interactive_arg_db"]
+        rpc_clients["interactive_arg_db"],
+        main_window
     )
 
     d_schedule = schedule.ScheduleDock(


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Add explanation mark on tab title when there is new interactive argument.
Ideal solution would be to bold 'Interactive arguments' tab title to notify about new argument, but I did not find direct way to do it. I add explanation mark instead.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Add and check docstrings and comments
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Documentation Changes

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
