### PR TITLE
gui: fix misc bugs from pyqt6 move

### DIFF
--- a/artiq/gui/dndwidgets.py
+++ b/artiq/gui/dndwidgets.py
@@ -112,7 +112,7 @@ class DragDropFlowLayoutWidget(QtWidgets.QWidget):
 
     def _get_index(self, pos):
         for i in range(self.layout.count()):
-            if self.itemAt(i).geometry().contains(pos):
+            if self.itemAt(i).geometry().contains(pos.toPoint()):
                 return i
         return -1
 
@@ -129,7 +129,7 @@ class DragDropFlowLayoutWidget(QtWidgets.QWidget):
             pixmapi = QtWidgets.QApplication.style().standardIcon(
                 QtWidgets.QStyle.StandardPixmap.SP_FileIcon)
             drag.setPixmap(pixmapi.pixmap(32))
-            drag.exec_(QtCore.Qt.MoveAction)
+            drag.exec(QtCore.Qt.DropAction.MoveAction)
         event.accept()
 
     def dragEnterEvent(self, event):

--- a/artiq/gui/log.py
+++ b/artiq/gui/log.py
@@ -386,7 +386,7 @@ class LogDockManager:
         flags = (QtWidgets.QDockWidget.DockWidgetFeature.DockWidgetMovable |
                  QtWidgets.QDockWidget.DockWidgetFeature.DockWidgetFloatable)
         if len(self.docks) > 1:
-            flags |= QtWidgets.QDockWidget.DockWidgetClosable
+            flags |= QtWidgets.QDockWidget.DockWidgetFeature.DockWidgetClosable
         for dock in self.docks.values():
             dock.setFeatures(flags)
 

--- a/artiq/gui/tools.py
+++ b/artiq/gui/tools.py
@@ -32,7 +32,7 @@ class DoubleClickLineEdit(QtWidgets.QLineEdit):
 
     def keyPressEvent(self, event):
         key = event.key()
-        if key == QtCore.Qt.Key_Escape and not self.isReadOnly():
+        if key == QtCore.Qt.Key.Key_Escape and not self.isReadOnly():
             self.editingFinished.emit()
         else:
             QtWidgets.QLineEdit.keyPressEvent(self, event)


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Various easy GUI fixes overlooked when moving to PyQt6. 

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
Simple monkey testing before and after, broken behavior such as error messages or inability to drag and drop moninj widgets is fixed.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
