### PR TITLE
urukul: set default proto_rev to 9

### DIFF
--- a/artiq/coredevice/coredevice_generic.schema.json
+++ b/artiq/coredevice/coredevice_generic.schema.json
@@ -328,7 +328,7 @@
                         },
                         "proto_rev": {
                             "type": "integer",
-                            "default": 8
+                            "default": 9
                         },
                         "dds": {
                             "type": "string",

--- a/artiq/coredevice/urukul.py
+++ b/artiq/coredevice/urukul.py
@@ -666,7 +666,7 @@ class CPLD:
                  dds_reset_device=None, sync_device=None,
                  sync_sel=0, clk_sel=0, clk_div=0, rf_sw=0,
                  refclk=125e6, att=0x00000000, sync_div=None,
-                 proto_rev=0x08, core_device="core"):
+                 proto_rev=0x09, core_device="core"):
 
         self.core = dmgr.get(core_device)
         self.refclk = refclk


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
As title. The newer version of urukul is now selected when unspecified.

A `proto_rev=8` entry should be added to Urukul to use the legacy urukul gateware.

### Related Issue
#2732

### Test
Built gateware with urukul peripheral at `proto_rev=9` without specifying `proto_rev` in JSON.
`artiq_ddb_template` generates `proto_rev=9` when `proto_rev` is unspecified.
`print(cpld.proto_rev)` prints 8 when `proto_rev` is unspecified in `device_db.py`.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
