### PR TITLE
shortcuts: convert to scrollarea

### DIFF
--- a/artiq/dashboard/shortcuts.py
+++ b/artiq/dashboard/shortcuts.py
@@ -17,7 +17,10 @@ class ShortcutsDock(QtWidgets.QDockWidget):
         layout = QtWidgets.QGridLayout()
         top_widget = QtWidgets.QWidget()
         top_widget.setLayout(layout)
-        self.setWidget(top_widget)
+        scroll_area = QtWidgets.QScrollArea()
+        scroll_area.setWidget(top_widget)
+        scroll_area.setWidgetResizable(True)
+        self.setWidget(scroll_area)
         layout.setSpacing(5)
         layout.setContentsMargins(5, 5, 5, 5)
 
@@ -37,7 +40,7 @@ class ShortcutsDock(QtWidgets.QDockWidget):
 
             label = QtWidgets.QLabel()
             label.setSizePolicy(QtWidgets.QSizePolicy.Policy.Ignored,
-                                QtWidgets.QSizePolicy.Policy.Ignored)
+                                label.sizePolicy().verticalPolicy())
             layout.addWidget(label, row, 1)
 
             clear = QtWidgets.QToolButton()


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Currently, the 'Shortcuts' dock has the biggest minimum height. This is a bottleneck when the dock is tabbed with other docks, and prevents sizing it down further. 

This PR adds a `QScrollArea` to allow for a smaller minimum height.

Vertical size policy change for the experiment label is a drive-by, it did not need to be `Policy.Ignored` before and won't need to be now either.

![Screenshot From 2025-04-29 16-44-38](https://github.com/user-attachments/assets/a3649998-396d-4d93-b38a-00af168cdb1e)

*Tabbed docks can now be sized down to about half as much as before (no change width wise)*

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.

Adding shortcuts and running them works as before, state is kept between successive openings of the dashboard. Resizes to smaller height as expected with scrollbar showing.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
