### PR TITLE
experiments: expose repo backend root for use in dashboard via pc_rpc

### DIFF
--- a/artiq/master/experiments.py
+++ b/artiq/master/experiments.py
@@ -161,9 +161,7 @@ class ExperimentDB:
         return r
 
     def root(self):
-        wd, _, _ = self.repo_backend.request_rev(self.cur_rev)
-        self.repo_backend.release_rev(self.cur_rev)
-        return wd
+        return self.repo_backend.root
 
 class FilesystemBackend:
     def __init__(self, root):
@@ -195,6 +193,8 @@ class _GitCheckout:
 
 class GitBackend:
     def __init__(self, root):
+        self.root = os.path.abspath(root)
+
         # lazy import - make dependency optional
         import pygit2
 

--- a/artiq/master/experiments.py
+++ b/artiq/master/experiments.py
@@ -160,6 +160,10 @@ class ExperimentDB:
                 r.append(prefix + de.name)
         return r
 
+    def root(self):
+        wd, _, _ = self.repo_backend.request_rev(self.cur_rev)
+        self.repo_backend.release_rev(self.cur_rev)
+        return wd
 
 class FilesystemBackend:
     def __init__(self, root):


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes

I am currently writing an alternative dashboard in a separate git repository, which features experiment file text editing as the user selects an experiment from the explorer. Thus, the dashboard needs to know the root of the experiment repository. It may ask the `artiq_master` explicitly via the `pc_rpc` interface and `artiq_master` returns the desired string.

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
|   | :bug: Bug fix  |
| ✓  | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
