### PR TITLE
urukul: fix cfg shift when reading SR on proto_rev 9

### DIFF
--- a/artiq/coredevice/urukul.py
+++ b/artiq/coredevice/urukul.py
@@ -465,7 +465,7 @@ class ProtoRev9(CPLDVersion):
         :return: The status register value.
         """
         cpld.bus.set_config_mu(SPI_CONFIG, 24, SPIT_CFG_WR, CS_CFG)
-        cpld.bus.write(((cpld.cfg_reg >> 24) & 0xFFFFFF) << 8)
+        cpld.bus.write(((cpld.cfg_reg >> 28) & 0xFFFFFF) << 8)
         cpld.bus.set_config_mu(
             SPI_CONFIG | spi.SPI_END | spi.SPI_INPUT, 28, SPIT_CFG_RD, CS_CFG
         )


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
First word transmitted by reading the SR should be CFG >> 28, not CFG >> 24.
Sanity check: It should mirror `cfg_write()` since the first word of both methods consists of 24 bits (out of total 52).

### Related Issue
Introduced in #2657

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
