### PR TITLE
artiq_flash: Add phaser support

### DIFF
--- a/artiq/frontend/artiq_flash.py
+++ b/artiq/frontend/artiq_flash.py
@@ -216,7 +216,7 @@ class ProgrammerXC7(Programmer):
         Programmer.__init__(self, client, preinit_script)
         self._proxy = proxy
 
-        if board != "efc":
+        if board not in ["efc", "phaser"]:
             add_commands(self._board_script,
                 "source {boardfile}",
                 boardfile=self._transfer_script("board/{}.cfg".format(board)))
@@ -257,6 +257,13 @@ def main():
     config = {
         "kasli": {
             "programmer":   partial(ProgrammerXC7, board="kasli", proxy="bscan_spi_xc7a100t.bit"),
+            "gateware":     ("spi0", 0x000000),
+            "bootloader":   ("spi0", 0x400000),
+            "storage":      ("spi0", 0x440000),
+            "firmware":     ("spi0", 0x450000),
+        },
+        "phaser": {
+            "programmer":   partial(ProgrammerXC7, board="phaser", proxy="bscan_spi_xc7a100t.bit"),
             "gateware":     ("spi0", 0x000000),
             "bootloader":   ("spi0", 0x400000),
             "storage":      ("spi0", 0x440000),


### PR DESCRIPTION
<!--

Thank you for submitting a PR to ARTIQ!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

You can also read more about contributing to ARTIQ in this document:
https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#contributing-code

Based on https://raw.githubusercontent.com/PyCQA/pylint/master/.github/PULL_REQUEST_TEMPLATE.md
-->

# ARTIQ Pull Request

## Description of Changes
This PR adds support for flashing [Phaser](https://github.com/sinara-hw/Phaser).

Phaser JTAG header accepts Digilent HS2 Programming cable, which is the same as the EEM FMC Carrier.

## Steps to Test
Since Phaser gateware is not migrated to the artiq repo yet, there is no "bootloader" and "firmware" for Phaser. So, I test it by only flashing the gateware bitstream.
 
1. Compile Phaser [gateware](https://github.com/quartiq/phaser) and rename the bitstream file to `top.bit`
2. Run `artiq_flash gateware -d . -t phaser` to flash it.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
