### PR TITLE
Fix Compilation Error on Satellite Firmware

### DIFF
--- a/artiq/firmware/satman/kernel.rs
+++ b/artiq/firmware/satman/kernel.rs
@@ -1050,7 +1050,7 @@ fn process_kern_hwreq(request: &kern::Message, self_destination: u8) -> Result<b
         }
         &kern::I2cWriteRequest { busno, data } => {
             match i2c::write(busno as u8, data) {
-                Ok(()) => kern_send(
+                Ok(_) => kern_send(
                     &kern::I2cWriteReply { succeeded: true, ack: true }),
                 Err(i2c::Error::Nack) => kern_send(
                     &kern::I2cWriteReply { succeeded: true, ack: false }),

--- a/artiq/firmware/satman/main.rs
+++ b/artiq/firmware/satman/main.rs
@@ -321,7 +321,7 @@ fn process_aux_packet(dmamgr: &mut DmaManager, analyzer: &mut Analyzer, kernelmg
         drtioaux::Packet::I2cWriteRequest { destination: _destination, busno, data } => {
             forward!(router, _routing_table, _destination, *rank, *self_destination, _repeaters, &packet);
             match i2c::write(busno, data) {
-                Ok(()) => drtioaux::send(0,
+                Ok(_) => drtioaux::send(0,
                     &drtioaux::Packet::I2cWriteReply { succeeded: true, ack: true }),
                 Err(i2c::Error::Nack) => drtioaux::send(0,
                     &drtioaux::Packet::I2cWriteReply { succeeded: true, ack: false }),


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
On the latest commit, you cannot compile the satellite firmware due to the following error. Those are typos made in this [PR](https://github.com/m-labs/artiq/commit/90eb59c54dd5b969359d060d37e27c903697c6d1#diff-134a907826167a050821d34c94db3efe8db84b779160463f01f361caf9fadbaf).

```
error[E0308]: mismatched types
   --> satman/main.rs:324:20
    |
323 |             match i2c::write(busno, data) {
    |                   ----------------------- this expression has type `Result<bool, board_misoc::i2c::Error>`
324 |                 Ok(()) => drtioaux::send(0,
    |                    ^^ expected `bool`, found `()`

error[E0308]: mismatched types
    --> satman/kernel.rs:1053:20
     |
1052 |             match i2c::write(busno as u8, data) {
     |                   ----------------------------- this expression has type `Result<bool, board_misoc::i2c::Error>`
1053 |                 Ok(()) => kern_send(
     |                    ^^ expected `bool`, found `()`
```

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
