### PR TITLE
artiq_flash: Add action to erase storage flash sectors

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -16,6 +16,7 @@ ARTIQ-9 (Unreleased)
    - Fastino monitoring with Moninj.
    - Zotino monitoring now displays the values in volts.
    - artiq_flash can now flash Phaser through a Digilent HS2 Programming cable.
+   - artiq_flash can now erase storage flash sectors specifically.
    - Support for the ultra-low-cost EBAZ4205 Zynq-7000 control card, with core device driver
      for the AD9834 DDS, tested with the ZonRi Technology Co., Ltd. AD9834-Module.
    - Configurable number of Grabber ROI engines through the ``roi_engine_count``


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
Currently, if you want to re-calibrate the DRTIO-over-EEM interface of a (non-kasli and non-kasli-soc) board, you can only do so by erasing all the flash sectors and then re-flashing all gateware, bootloader, storage and firmware. If you have changed the board's gateware or any clock related cables, you need to do so to avoid data corruption. This PR adds an action to erase only the storage flash sectors for DRTIO-over-EEM interface re-calibration.

This new feature will be useful for both development and crate assembly, which are prone to frequent gateware changes or cable changes.

This new feature is tested on the phaser. 
1. `artiq_flash erase_storage -t phaser` to erase the storage flash sectors.
2. `artiq_flash start` to reboot phaser.
3. The log shows that DRTIO-over-EEM interface is calibrated at bootup.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
