### PR TITLE
nac3: Update AD9910 driver and unit tests

### DIFF
--- a/artiq/gateware/rtio/phy/dds.py
+++ b/artiq/gateware/rtio/phy/dds.py
@@ -8,9 +8,9 @@ from artiq.coredevice.urukul import (
     CS_CFG,
     CS_DDS_CH0,
     CS_DDS_MULTI,
-    STA_PROTO_REV_8,
+    # STA_PROTO_REV_8, NAC3TODO
     STA_PROTO_REV_9,
-    ProtoRev8,
+    # ProtoRev8, NAC3TODO
     ProtoRev9,
 )
 
@@ -114,10 +114,11 @@ class UrukulMonitor(Module):
             ]
 
     def is_io_update(self, proto_rev, flags):
-        if proto_rev == STA_PROTO_REV_8:
-            # shifted 8 bits left for 32-bit bus
-            reg_io_upd = (self.cs == CS_CFG) & self.current_data[8 + ProtoRev8.CFG_IO_UPDATE]
-        elif proto_rev == STA_PROTO_REV_9:
+        # NAC3TODO
+        # if proto_rev == STA_PROTO_REV_8:
+        #     # shifted 8 bits left for 32-bit bus
+        #     reg_io_upd = (self.cs == CS_CFG) & self.current_data[8 + ProtoRev8.CFG_IO_UPDATE]
+        if proto_rev == STA_PROTO_REV_9:
             # cfg_write for proto_rev 9 takes two transfers, CFG_IO_UPDATES are in the last one
             reg_io_upd = (self.cs == CS_CFG) & (flags & SPI_END) & (
                 self.current_data[4 + (ProtoRev9.CFG_IO_UPDATE - 32)] |


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

nac3: Update AD9910 driver and its associated unit tests for the new Urukul driver.

NOTE:

For some reason, on my hardware (v1.4 Urukul with latest Urukul CPLD gateware), the AD9910 driver cannot set the attenuators on the Urukul.  It would be nice if this could be tested on other hardware to see if this issue is repeatable.


## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |
| ✓  | :hammer: Refactoring  |

## Steps (Choose relevant, delete irrelevant before submitting)

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.
- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
