### PR TITLE
CoaXPress-SFP: add support for Kasli-SOC

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -8,6 +8,7 @@ ARTIQ-9 (Unreleased)
 
 * Hardware support:
    - CoaXPress grabber support on ZC706 with Hello-FPGA CXP 4R FMC card.
+   - CoaXPress grabber support on Kasli-SoC with CoaXPress-SFP adapter.
    - Improved SDRAM memory controller and DMA cores puts Kasli DMA performance on par with
      other platforms.
    - DRTIO repeater support across GT/EEM. This enables Shuttler support on DRTIO satellites.

--- a/artiq/coredevice/coredevice_generic.schema.json
+++ b/artiq/coredevice/coredevice_generic.schema.json
@@ -146,7 +146,7 @@
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": ["dio", "dio_spi", "urukul", "novogorny", "sampler", "suservo", "zotino", "grabber", "mirny", "fastino", "phaser", "hvamp", "shuttler"]
+                    "enum": ["dio", "dio_spi", "urukul", "novogorny", "sampler", "suservo", "zotino", "grabber", "mirny", "fastino", "phaser", "hvamp", "shuttler", "coaxpress_sfp"]
                 },
                 "board": {
                     "type": "string"
@@ -652,6 +652,26 @@
                         }
                     },
                     "required": ["ports"]
+                }
+            }, {
+                "title": "COAXPRESS_SFP",
+                "if": {
+                    "properties": {
+                        "type": {
+                            "const": "coaxpress_sfp"
+                        }
+                    }
+                },
+                "then": {
+                    "properties": {
+                        "roi_engine_count": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 32,
+                            "default": 16,
+                            "description": "Number of ROI engines."
+                        }
+                    }
                 }
             }]
         }

--- a/artiq/frontend/artiq_ddb_template.py
+++ b/artiq/frontend/artiq_ddb_template.py
@@ -749,6 +749,18 @@ class PeripheralManager:
                 spi=spi_name)
         return 0
 
+    def process_coaxpress_sfp(self, rtio_offset, peripheral):
+        self.gen("""
+            device_db["{name}"] = {{
+                "type": "local",
+                "module": "artiq.coredevice.cxp_grabber",
+                "class": "CXPGrabber",
+                "arguments": {{"channel": 0x{channel:06x}}}
+            }}""",
+            name=self.get_name("coaxpress_sfp"),
+            channel=rtio_offset)
+        return 3
+
     def process(self, rtio_offset, peripheral):
         processor = getattr(self, "process_"+str(peripheral["type"]))
         return processor(rtio_offset, peripheral)

--- a/artiq/gateware/targets/kasli.py
+++ b/artiq/gateware/targets/kasli.py
@@ -846,11 +846,18 @@ def main():
     else:
         raise ValueError("Invalid DRTIO role")
 
-    has_shuttler = any(peripheral["type"] == "shuttler" for peripheral in description["peripherals"])
+    has_coaxpress_sfp, has_shuttler = False, False
+    for peripheral in description["peripherals"]:
+        if peripheral["type"] == "coaxpress_sfp":
+            has_coaxpress_sfp = True
+        elif peripheral["type"] == "shuttler":
+            has_shuttler = True
     if has_shuttler and (description["drtio_role"] == "standalone"):
         raise ValueError("Shuttler requires DRTIO, please switch role to master")
     if description["enable_wrpll"] and description["hw_rev"] in ["v1.0", "v1.1"]:
         raise ValueError("Kasli {} does not support WRPLL".format(description["hw_rev"])) 
+    if has_coaxpress_sfp:
+        raise ValueError("Kasli doesn't support CoaXPress-SFP")
 
     soc = cls(description, gateware_identifier_str=args.gateware_identifier_str, **soc_kasli_argdict(args))
     args.variant = description["variant"]


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

### Summary
- use `asymmetric_gtx` in `cxp_grabber.py` (the rest of the GW change will be on artiq-zynq)
- add `coaxpress_sfp` to ddb template
- add `coaxpress_sfp` to json schema
  - add `roi_engine_count` option to keep inline with grabber PR (default to 16 and maximum at 32)
  - (`CXPGrabber` set  `roi_engine_count` default to 8 due to unmeet timing on the ZC706 FMC variant with 16 ROIs)
- raise error when trying to compile `kasli.py` with `coaxpress_sfp`
- update release note

### Test
- build Kasli-SOC with 16 and 32 ROIs pass the timing requirement
- Both 16 and 32 ROIs config with [CoaXPress-SFP](https://git.m-labs.hk/sinara-hw/CoaXPress-SFP) adapter can
  - successfully read&write camera registers
  - successfully download XML camera settings file
  - successfully capture a full image using ROI viewer
  - successfully count pixels using ROIs

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |
| ✓  | :scroll: Docs |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Update [RELEASE_NOTES.rst](../RELEASE_NOTES.rst) if there are noteworthy changes, especially if there are changes to existing APIs.


### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
