### PR TITLE
gui/fuzzy_select: Fix Windows 11/macOS positioning; use available screen space

### DIFF
--- a/artiq/gui/fuzzy_select.py
+++ b/artiq/gui/fuzzy_select.py
@@ -85,9 +85,7 @@ class FuzzySelectWidget(LayoutWidget):
 
     def _popup_menu(self):
         # Display menu with search results beneath line edit.
-        menu_pos = self.line_edit.mapToGlobal(self.line_edit.pos())
-        menu_pos.setY(menu_pos.y() + self.line_edit.height())
-        self.menu.popup(menu_pos)
+        self.menu.popup(self.line_edit.mapToGlobal(self.line_edit.rect().bottomLeft()))
 
     def _ensure_menu(self):
         if self.menu:

--- a/artiq/gui/fuzzy_select.py
+++ b/artiq/gui/fuzzy_select.py
@@ -169,7 +169,10 @@ class FuzzySelectWidget(LayoutWidget):
         self.line_edit.installEventFilter(self.line_edit_up_down_filter)
 
         self.abort_when_menu_hidden = True
-        self.menu.show()
+        # Show menu again if it was hidden. As per the Qt docs, it is important to
+        # use popup() here instead of show(), which would indeed lead to wrong
+        # positioning on Windows 11.
+        self._popup_menu()
         if first_action:
             self.menu.setActiveAction(first_action)
             self.menu.setFocus()

--- a/artiq/gui/fuzzy_select.py
+++ b/artiq/gui/fuzzy_select.py
@@ -77,7 +77,11 @@ class FuzzySelectWidget(LayoutWidget):
     def _activate(self):
         self.update_when_text_changed = True
         if not self.menu:
-            self._update_menu()
+            # Make sure the geometry has been processed before showing the popup (in
+            # case the parent has just been created). With an immediate call, the
+            # _QuickOpenDialog() is menu shown slightly misaligned on macOS (though it
+            # appears fine on Windows 10/11).
+            QtCore.QTimer.singleShot(0, self._update_menu)
 
     def _popup_menu(self):
         # Display menu with search results beneath line edit.


### PR DESCRIPTION
- **gui/fuzzy_select: Fix quick open dialog positioning on macOS**
- **gui/fuzzy_select: QMenu.{show->popup}() to fix positioning on Windows 11**
- **gui/fuzzy_select: Fix/simplify menu coordinate calculation**
- **gui/fuzzy_select: Use available screen space for entries by default**

This fixes the positioning of the Quick Open options menu (and the
ndscan downstream uses) on Windows 11, where it was previously displayed
in the top-left corner of the screen (and not at all if not on the
primary screen).

It also solves a mild issue where the menu was shown too high for the
quick-open dialogue on macOS (for unclear reasons, possibly related
to animations).

The last commit adds a slight quality-of-life improvement to what is
a very heavily used feature in our workflow, by using the entire
available screen height for the menu rather than just a hardcoded
limit of 10 entries.
