### PR TITLE
urukul: revert cfg_reg update reordering

### DIFF
--- a/artiq/coredevice/urukul.py
+++ b/artiq/coredevice/urukul.py
@@ -303,11 +303,13 @@ class ProtoRev8(CPLDVersion):
         Resets the DDS I/O interface.
         Does not pulse the DDS ``MASTER_RESET`` as that confuses the AD9910.
         """
-        if not blind and urukul_sta_proto_rev(self.sta_read(cpld)) != STA_PROTO_REV_8:
-            raise ValueError("Urukul proto_rev mismatch")
         cfg = cpld.cfg_reg
         # Don't pulse MASTER_RESET (m-labs/artiq#940)
         cpld.cfg_reg = cfg | (0 << ProtoRev8.CFG_RST) | (1 << ProtoRev8.CFG_IO_RST)
+        if blind:
+            cpld.cfg_write(cpld.cfg_reg)
+        elif urukul_sta_proto_rev(self.sta_read(cpld))!= STA_PROTO_REV_8:
+            raise ValueError("Urukul proto_rev mismatch")
         delay(100 * us)  # reset, slack
         cpld.cfg_write(cfg)
         if cpld.sync_div:
@@ -479,11 +481,13 @@ class ProtoRev9(CPLDVersion):
         Resets the DDS I/O interface.
         Does not pulse the DDS ``MASTER_RESET`` as that confuses the AD9910.
         """
-        if not blind and urukul_sta_proto_rev(self.sta_read(cpld))!= STA_PROTO_REV_9:
-            raise ValueError("Urukul proto_rev mismatch")
         cfg = cpld.cfg_reg
         # Don't pulse MASTER_RESET (m-labs/artiq#940)
         cpld.cfg_reg = cfg | (0 << ProtoRev9.CFG_RST) | (1 << ProtoRev9.CFG_IO_RST)
+        if blind:
+            cpld.cfg_write(cpld.cfg_reg)
+        elif urukul_sta_proto_rev(self.sta_read(cpld))!= STA_PROTO_REV_9:
+            raise ValueError("Urukul proto_rev mismatch")
         delay(100 * us)  # reset, slack
         cpld.cfg_write(cfg)
         if cpld.sync_div:


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
Revert unintended `init()` sequence changes introduced by #2657.

Note the intricacies of `cfg_reg` and `sta_read`. The behavior of `sta_read` is to write `cfg_reg` and report the SPI readback of the shift register in the same SPI transfer.

## Test
### PROTO_REV 8
`init(blind=True)`:
```
Log channel: 10
DDS one-hot: True
OutputMessage(channel=0, timestamp=115683870112, rtio_counter=115683746704, address=1, data=16783114)
OutputMessage(channel=0, timestamp=115683870120, rtio_counter=115683747840, address=0, data=805765120)
OutputMessage(channel=0, timestamp=115683970528, rtio_counter=115683749512, address=1, data=16783114)
OutputMessage(channel=0, timestamp=115683970536, rtio_counter=115683750256, address=0, data=537329664)
OutputMessage(channel=1, timestamp=115683970944, rtio_counter=115683751440, address=0, data=8)
StoppedMessage(rtio_counter=116486227848)
```
`init(blind=False)`:
```
Log channel: 10
DDS one-hot: True
OutputMessage(channel=0, timestamp=63589198712, rtio_counter=63589076416, address=1, data=17700622)
OutputMessage(channel=0, timestamp=63589198720, rtio_counter=63589077264, address=0, data=537329664)
InputMessage(channel=0, timestamp=0, rtio_counter=63589201896, data=524288)
OutputMessage(channel=0, timestamp=63589301928, rtio_counter=63589203424, address=1, data=16783114)
OutputMessage(channel=0, timestamp=63589301936, rtio_counter=63589203848, address=0, data=537329664)
OutputMessage(channel=1, timestamp=63589302336, rtio_counter=63589205472, address=0, data=8)
StoppedMessage(rtio_counter=64887062216)
```
### PROTO_REV 9
Before this patch `init(blind=True)` generated this coreanalyzer trace.
```
Log channel: 45
DDS one-hot: True
OutputMessage(channel=0, timestamp=457196630176, rtio_counter=457196407288, address=1, data=16783112)
OutputMessage(channel=0, timestamp=457196630184, rtio_counter=457196408432, address=0, data=16777216)
OutputMessage(channel=0, timestamp=457196630592, rtio_counter=457196408736, address=1, data=16784138)
OutputMessage(channel=0, timestamp=457196630600, rtio_counter=457196409344, address=0, data=16773120)
OutputMessage(channel=1, timestamp=457196631072, rtio_counter=457196410424, address=0, data=8)
StoppedMessage(rtio_counter=458084602728)
```
`init(blind=True)` now generates this coreanalyzer trace.
```
Log channel: 45
DDS one-hot: True
OutputMessage(channel=0, timestamp=666196599440, rtio_counter=666196477272, address=1, data=16783112)
OutputMessage(channel=0, timestamp=666196599448, rtio_counter=666196477960, address=0, data=16777216)
OutputMessage(channel=0, timestamp=666196599856, rtio_counter=666196478416, address=1, data=16784138)
OutputMessage(channel=0, timestamp=666196599864, rtio_counter=666196478928, address=0, data=16773120)
OutputMessage(channel=0, timestamp=666196600336, rtio_counter=666196480440, address=1, data=16783112)
OutputMessage(channel=0, timestamp=666196600344, rtio_counter=666196480952, address=0, data=16777216)
OutputMessage(channel=0, timestamp=666196600752, rtio_counter=666196481256, address=1, data=16784138)
OutputMessage(channel=0, timestamp=666196600760, rtio_counter=666196481752, address=0, data=16773120)
StoppedMessage(rtio_counter=667014152480)
```
`init(blind=False)` generates this trace.
```
Log channel: 45
DDS one-hot: True
OutputMessage(channel=0, timestamp=469381312736, rtio_counter=469381190448, address=1, data=16783112)
OutputMessage(channel=0, timestamp=469381312744, rtio_counter=469381191432, address=0, data=16777216)
OutputMessage(channel=0, timestamp=469381313152, rtio_counter=469381191920, address=1, data=17701646)
OutputMessage(channel=0, timestamp=469381313160, rtio_counter=469381192472, address=0, data=16773120)
InputMessage(channel=0, timestamp=0, rtio_counter=469381316848, data=593664)
OutputMessage(channel=0, timestamp=469381416880, rtio_counter=469381317840, address=1, data=16783112)
OutputMessage(channel=0, timestamp=469381416888, rtio_counter=469381318416, address=0, data=16777216)
OutputMessage(channel=0, timestamp=469381417296, rtio_counter=469381318720, address=1, data=16784138)
OutputMessage(channel=0, timestamp=469381417304, rtio_counter=469381319648, address=0, data=16773120)
OutputMessage(channel=1, timestamp=469381417776, rtio_counter=469381321376, address=0, data=8)
StoppedMessage(rtio_counter=470218559184)
```
**Note that this trace shows that the data is wrong.** This is intended. See "Related Issue".

### Related Issue
See #2739 for the issue. This only fixes the PROTO_REV 8 case.

Note that on PROTO_REV 9 IO_RST does not propagate. This has to do with a separate issue where bit-shifts > 32 will move out of the 32-bits range, thus becoming 0.

An explicit int64 cast is needed.

I expect a sizeable amount of ProtoRev9 driver to be affected by this, and will be addressed in a separate issue.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Close/update issues.

### Code Changes

- [x] Check, test, and update the [unittests in /artiq/test/](../artiq/test/) or [gateware simulations in /artiq/gateware/test](../artiq/gateware/test)

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
