### PR TITLE
urukul: cast RST shift to int64 for PROTO_REV 9

### DIFF
--- a/artiq/coredevice/urukul.py
+++ b/artiq/coredevice/urukul.py
@@ -483,7 +483,7 @@ class ProtoRev9(CPLDVersion):
         """
         cfg = cpld.cfg_reg
         # Don't pulse MASTER_RESET (m-labs/artiq#940)
-        cpld.cfg_reg = cfg | (0 << ProtoRev9.CFG_RST) | (1 << ProtoRev9.CFG_IO_RST)
+        cpld.cfg_reg = cfg | (int64(0) << ProtoRev9.CFG_RST) | (int64(1) << ProtoRev9.CFG_IO_RST)
         if blind:
             cpld.cfg_write(cpld.cfg_reg)
         elif urukul_sta_proto_rev(self.sta_read(cpld))!= STA_PROTO_REV_9:
@@ -498,8 +498,8 @@ class ProtoRev9(CPLDVersion):
     @kernel
     def io_rst(self, cpld):
         """Pulse IO_RST"""
-        cpld.cfg_write(cpld.cfg_reg | (1 << ProtoRev9.CFG_IO_RST))
-        cpld.cfg_write(cpld.cfg_reg & ~(1 << ProtoRev9.CFG_IO_RST))
+        cpld.cfg_write(cpld.cfg_reg | (int64(1) << int64(ProtoRev9.CFG_IO_RST)))
+        cpld.cfg_write(cpld.cfg_reg & ~(int64(1) << int64(ProtoRev9.CFG_IO_RST)))
 
     @kernel
     def set_profile(self, cpld, channel: TInt32, profile: TInt32):


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
Fix IO_RST/RST bit shift on PROTO_REV 9. While IO_RST fix is necessary, the RST fix is purely aesthetic and to help illustrating the comment on the previous line.

Both of these 2 bits will land beyond the lower 32 bits range. Hence, it should to be casted to int64 to avoid being discarded.

## Test
On PROTO_REV 9, `io_rst()` generates this trace:
```
Log channel: 45
DDS one-hot: True
OutputMessage(channel=0, timestamp=1373577683056, rtio_counter=1373577560448, address=1, data=16783112)
OutputMessage(channel=0, timestamp=1373577683064, rtio_counter=1373577561056, address=0, data=25165824)
OutputMessage(channel=0, timestamp=1373577683472, rtio_counter=1373577561456, address=1, data=16784138)
OutputMessage(channel=0, timestamp=1373577683480, rtio_counter=1373577561912, address=0, data=16773120)
OutputMessage(channel=0, timestamp=1373577683952, rtio_counter=1373577563648, address=1, data=16783112)
OutputMessage(channel=0, timestamp=1373577683960, rtio_counter=1373577564152, address=0, data=16777216)
OutputMessage(channel=0, timestamp=1373577684368, rtio_counter=1373577564432, address=1, data=16784138)
OutputMessage(channel=0, timestamp=1373577684376, rtio_counter=1373577564896, address=0, data=16773120)
StoppedMessage(rtio_counter=1374351632504)
```
Bit 23 of data `25165824` is asserted. It corresponds to bit 43 of the CFG, which stores the IO_RST bit.

`init(blind=True)` generates the same trace as `io_rst()`.
`init(blind=False)` generates the same trace as well, except an addition input message which reads back the status.

```
Log channel: 45
DDS one-hot: True
OutputMessage(channel=0, timestamp=2441002444944, rtio_counter=2441002322728, address=1, data=16783112)
OutputMessage(channel=0, timestamp=2441002444952, rtio_counter=2441002323600, address=0, data=25165824)
OutputMessage(channel=0, timestamp=2441002445360, rtio_counter=2441002324024, address=1, data=17701646)
OutputMessage(channel=0, timestamp=2441002445368, rtio_counter=2441002324536, address=0, data=16773120)
InputMessage(channel=0, timestamp=0, rtio_counter=2441002449056, data=34148096)
OutputMessage(channel=0, timestamp=2441002549088, rtio_counter=2441002450592, address=1, data=16783112)
OutputMessage(channel=0, timestamp=2441002549096, rtio_counter=2441002451592, address=0, data=16777216)
OutputMessage(channel=0, timestamp=2441002549504, rtio_counter=2441002451920, address=1, data=16784138)
OutputMessage(channel=0, timestamp=2441002549512, rtio_counter=2441002452424, address=0, data=16773120)
OutputMessage(channel=1, timestamp=2441002549984, rtio_counter=2441002454384, address=0, data=8)
StoppedMessage(rtio_counter=2442026721464)
```

### Related Issue
Closes #2739

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Close/update issues.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
