### PR TITLE
moninj_proxy: improve signal handling

### DIFF
--- a/artiq/frontend/aqctl_moninj_proxy.py
+++ b/artiq/frontend/aqctl_moninj_proxy.py
@@ -5,8 +5,9 @@ import logging
 import asyncio
 import struct
 from enum import Enum
+import atexit
 
-from sipyco.tools import AsyncioServer, SignalHandler
+from sipyco.tools import AsyncioServer, SignalHandler, atexit_register_coroutine
 from sipyco.pc_rpc import Server
 from sipyco import common_args
 
@@ -201,40 +202,40 @@ def main():
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-    try:
-        signal_handler = SignalHandler()
-        signal_handler.setup()
-        try:
-            monitor_mux = MonitorMux()
-            comm_moninj = CommMonInj(monitor_mux.monitor_cb,
-                                     monitor_mux.injection_status_cb,
-                                     monitor_mux.disconnect_cb)
-            monitor_mux.comm_moninj = comm_moninj
-            loop.run_until_complete(comm_moninj.connect(args.core_addr))
-            try:
-                proxy_server = ProxyServer(monitor_mux)
-                loop.run_until_complete(proxy_server.start(bind_address, args.port_proxy))
-                try:
-                    server = Server({"moninj_proxy": PingTarget()}, None, True)
-                    loop.run_until_complete(server.start(bind_address, args.port_control))
-                    try:
-                        _, pending = loop.run_until_complete(asyncio.wait(
-                            [loop.create_task(signal_handler.wait_terminate()),
-                             loop.create_task(server.wait_terminate()),
-                             comm_moninj.wait_terminate()],
-                            return_when=asyncio.FIRST_COMPLETED))
-                        for task in pending:
-                            task.cancel()
-                    finally:
-                        loop.run_until_complete(server.stop())
-                finally:
-                    loop.run_until_complete(proxy_server.stop())
-            finally:
-                loop.run_until_complete(comm_moninj.close())
-        finally:
-            signal_handler.teardown()
-    finally:
-        loop.close()
+    atexit.register(loop.close)
+
+    signal_handler = SignalHandler()
+    signal_handler.setup()
+    atexit.register(signal_handler.teardown)
+
+    server = Server({"moninj_proxy": PingTarget()}, None, True)
+    loop.run_until_complete(server.start(bind_address, args.port_control))
+    atexit_register_coroutine(server.stop, loop=loop)
+
+    monitor_mux = MonitorMux()
+    comm_moninj = CommMonInj(monitor_mux.monitor_cb,
+                             monitor_mux.injection_status_cb,
+                             monitor_mux.disconnect_cb)
+    monitor_mux.comm_moninj = comm_moninj
+
+    proxy_server = ProxyServer(monitor_mux)
+
+    async def run_moninj_proxy():
+        await comm_moninj.connect(args.core_addr)
+        atexit_register_coroutine(comm_moninj.close, loop=loop)
+        await proxy_server.start(bind_address, args.port_proxy)
+        atexit_register_coroutine(proxy_server.stop, loop=loop)
+        await comm_moninj.wait_terminate()
+
+    done, pending = loop.run_until_complete(asyncio.wait(
+        [loop.create_task(run_moninj_proxy()),
+         loop.create_task(signal_handler.wait_terminate()),
+         loop.create_task(server.wait_terminate())],
+        return_when=asyncio.FIRST_COMPLETED))
+    for task in pending:
+        task.cancel()
+    for task in done:
+        task.result()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

When the core device is not connected `aqctl_moninj_proxy` does not run the `SignalHandler`, and as such does not terminate properly when asked to. This results in problems both when running the proxy directly and through the controller manager:

+ Unable to terminate the proxy immediately (ran the proxy by mistake, or with the wrong options).
+ Multiple warning messages from the controller manager as it has to kill the process, which takes it many seconds to attempt (it attempts a `terminate` call to the control server, then a SIGTERM before finally killing the process)

#### Proposal:
By running both the signal handler and the ping target / control server concurrently with `comm_moninj.connect` and `comm_moninj.wait_terminate` it ensures that the proxy can be cleanly terminated when no connection is established with the core device.

This patch does not apply cleanly to `release-8` due to `asyncio_tools` renaming to `tools`. I have prepared a separate PR for `release-8` to account for this.

## Type of Changes

|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Check the copyright situation of your changes and sign off your patches (`git commit --signoff`, see [copyright](../CONTRIBUTING.rst#copyright-and-sign-off)).

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.

Tested for correct behavior when:
+ disconnected
+ connected
+ establishing a connection after running proxy
+ disconnecting core device while running proxy 

Same tests were also run with the controller manager. The proxy terminates without throwing any additional exceptions aside from the expected ones caused by a lost connection. In the case of the controller manager, the proxy terminates cleanly through the control server `terminate` call  (does not need to SIGTERM).

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
