### PR TITLE
ad9910: fix HITL tests

### DIFF
--- a/artiq/test/coredevice/test_ad9910.py
+++ b/artiq/test/coredevice/test_ad9910.py
@@ -3,6 +3,7 @@ from numpy import int64
 from artiq.coredevice.ad9910 import (
     _AD9910_REG_FTW,
     _AD9910_REG_PROFILE0,
+    DEFAULT_PROFILE,
     RAM_DEST_FTW,
     RAM_MODE_RAMPUP,
 )
@@ -149,9 +150,9 @@ class AD9910Exp(EnvExperiment):
         self.dev.init()
         lo = 0x12345678
         hi = 0x09abcdef
-        self.dev.write64(_AD9910_REG_PROFILE0, hi, lo)
+        self.dev.write64(_AD9910_REG_PROFILE0 + DEFAULT_PROFILE, hi, lo)
         self.dev.io_update.pulse_mu(8)
-        read = self.dev.read64(_AD9910_REG_PROFILE0)
+        read = self.dev.read64(_AD9910_REG_PROFILE0 + DEFAULT_PROFILE)
         self.set_dataset("write", (int64(hi) << 32) | lo)
         self.set_dataset("read", read)
         if not self.io_update_device:

--- a/artiq/test/coredevice/test_ad9910.py
+++ b/artiq/test/coredevice/test_ad9910.py
@@ -609,4 +609,4 @@ class AD9910Test(ExperimentCase):
         turns = self.dataset_mgr.get("turns")
         for i in range(len(ram)):
             self.assertEqual((ram[i] >> 16) & 0xFFFF, exp.dev.turns_to_pow(turns[i]))
-            self.assertEqual(ram[i] & 0xFFFF, exp.dev.amplitude_to_asf(amplitude[i]))
+            self.assertEqual((ram[i] >> 2) & 0x3FFF, exp.dev.amplitude_to_asf(amplitude[i]))

--- a/artiq/test/coredevice/test_ad9910.py
+++ b/artiq/test/coredevice/test_ad9910.py
@@ -120,6 +120,7 @@ class AD9910Exp(EnvExperiment):
         self.dev.set_frequency(f)
         self.dev.set_phase(p)
         self.dev.set_amplitude(a)
+        self.dev.io_update.pulse_mu(8)
 
         self.core.break_realtime()
         ftw = self.dev.get_ftw()

--- a/artiq/test/coredevice/test_ad9910.py
+++ b/artiq/test/coredevice/test_ad9910.py
@@ -285,7 +285,7 @@ class AD9910Exp(EnvExperiment):
             self.dev.set_mu(ftw=i, profile=i)
         ftw = [0] * 8
         for i in range(8):
-            self.cpld.set_profile(0, i)
+            self.cpld.set_profile(self.dev.chip_select - 4, i)
             # If PROFILE is not alligned to SYNC_CLK a multi-bit change
             # doesn't transfer cleanly. Use IO_UPDATE to load the profile
             # again.
@@ -316,7 +316,7 @@ class AD9910Exp(EnvExperiment):
         self.dev.set_profile_ram(
             start=0, end=0 + n - 1, step=1,
             profile=0, mode=RAM_MODE_RAMPUP)
-        self.cpld.set_profile(0, 0)
+        self.cpld.set_profile(self.dev.chip_select - 4, 0)
         self.dev.io_update.pulse_mu(8)
         delay(1*ms)
         self.dev.write_ram(write)
@@ -353,12 +353,12 @@ class AD9910Exp(EnvExperiment):
             start=offset, end=offset + len(read) - 1, step=1,
             profile=1, mode=RAM_MODE_RAMPUP)
 
-        self.cpld.set_profile(0, 0)
+        self.cpld.set_profile(self.dev.chip_select - 4, 0)
         self.dev.io_update.pulse_mu(8)
         delay(1*ms)
         self.dev.write_ram(write)
         delay(1*ms)
-        self.cpld.set_profile(0, 1)
+        self.cpld.set_profile(self.dev.chip_select - 4, 1)
         self.dev.io_update.pulse_mu(8)
         self.dev.read_ram(read)
 
@@ -394,23 +394,23 @@ class AD9910Exp(EnvExperiment):
             start=200, end=200 + len(ftw1) - 1, step=1,
             profile=4, mode=RAM_MODE_RAMPUP)
 
-        self.cpld.set_profile(0, 3)
+        self.cpld.set_profile(self.dev.chip_select - 4, 3)
         self.dev.io_update.pulse_mu(8)
         self.dev.write_ram(ftw0)
 
-        self.cpld.set_profile(0, 4)
+        self.cpld.set_profile(self.dev.chip_select - 4, 4)
         self.dev.io_update.pulse_mu(8)
         self.dev.write_ram(ftw1)
 
         self.dev.set_cfr1(ram_enable=1, ram_destination=RAM_DEST_FTW)
         self.dev.io_update.pulse_mu(8)
 
-        self.cpld.set_profile(0, 3)
+        self.cpld.set_profile(self.dev.chip_select - 4, 3)
         self.dev.io_update.pulse_mu(8)
         ftw0r = self.dev.read32(_AD9910_REG_FTW)
         delay(100*us)
 
-        self.cpld.set_profile(0, 4)
+        self.cpld.set_profile(self.dev.chip_select - 4, 4)
         self.dev.io_update.pulse_mu(8)
         ftw1r = self.dev.read32(_AD9910_REG_FTW)
 
@@ -438,7 +438,7 @@ class AD9910Exp(EnvExperiment):
         self.dev.set_profile_ram(
             start=100, end=100 + len(ram) - 1, step=1,
             profile=6, mode=RAM_MODE_RAMPUP)
-        self.cpld.set_profile(0, 6)
+        self.cpld.set_profile(self.dev.chip_select - 4, 6)
         self.dev.io_update.pulse_mu(8)
         self.dev.write_ram(ram)
         self.dev.set_cfr1(ram_enable=1, ram_destination=RAM_DEST_FTW)

--- a/artiq/test/coredevice/test_ad9910_waveform.py
+++ b/artiq/test/coredevice/test_ad9910_waveform.py
@@ -70,7 +70,7 @@ def io_update_device(cpld, *required_values, proto_rev=None):
                         if actual_proto_rev != proto_rev:
                             self.skipTest(
                                 f"This test requires proto_rev={proto_rev}, "
-                                "but the current proto_rev is {actual_proto_rev}."
+                                f"but the current proto_rev is {actual_proto_rev}."
                             )
 
                     print(


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes
This includes several patches to use AD9910 features correctly. Some are legacy issues, some are consequences of the new proto_rev.

### Tests
Passed tests in `test_ad9910.py` on AD9910 `proto_rev` 8 and 9.

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.

### Code Changes

- [x] Test your changes or have someone test them. Mention what was tested and how.

### Git Logistics

- [x] Split your contribution into logically separate changes (`git rebase --interactive`). Merge/squash/fixup commits that just fix or amend previous commits. Remove unintended changes & cleanup. See [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
- [x] Write short & meaningful commit messages. Review each commit for messages (`git show`). Format:
  ```
  topic: description. < 50 characters total.
  
  Longer description. < 70 characters per line
  ```

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.
