### PR TITLE
nac3: remove special case for importing content modules

### DIFF
--- a/artiq/coredevice/core.py
+++ b/artiq/coredevice/core.py
@@ -151,7 +151,6 @@ class Core:
                 core_language._registered_functions,
                 core_language._registered_classes,
                 core_language._special_ids,
-                core_language._registered_modules
             )
             self.analyzed = True
 

--- a/artiq/language/core.py
+++ b/artiq/language/core.py
@@ -56,7 +56,6 @@ def ceil64(x):
 # Delay NAC3 analysis until all referenced variables are supposed to exist on the CPython side.
 _registered_functions = dict()
 _registered_classes = dict()
-_registered_modules = set()
 
 def _register_function(fun):
     module = getmodule(fun)
@@ -67,11 +66,6 @@ def _register_class(cls):
     module = getmodule(cls)
     import_cache.add_module_to_cache(module)
     _registered_classes[cls] = module
-
-def register_content_module(module):
-    # for kernels sent by content, they have no modules
-    # thus their source must be analyzed instead
-    _registered_modules.add(module)
 
 
 def extern(function):

--- a/artiq/master/worker_impl.py
+++ b/artiq/master/worker_impl.py
@@ -13,7 +13,6 @@ import inspect
 import logging
 import traceback
 from collections import OrderedDict
-import importlib.util
 import linecache
 import threading
 
@@ -31,9 +30,7 @@ from artiq.master.worker_db import DeviceManager, DatasetManager, DummyDevice
 from artiq.language.environment import (
     is_public_experiment, TraceArgumentManager, ProcessArgumentManager
 )
-from artiq.language.core import (
-    register_content_module, set_watchdog_factory, TerminationRequested
-)
+from artiq.language.core import set_watchdog_factory, TerminationRequested
 from artiq.language import import_cache
 from artiq import __version__ as artiq_version
 
@@ -183,13 +180,7 @@ class StringLoader:
 
 def get_experiment_from_content(content, class_name):
     fake_filename = "expcontent"
-    spec = importlib.util.spec_from_loader(
-        "expmodule",
-        StringLoader(fake_filename, content)
-    )
-    module = importlib.util.module_from_spec(spec)
-    register_content_module(module)
-    spec.loader.exec_module(module)
+    module = tools.load_with_loader("expmodule", StringLoader(fake_filename, content))
     linecache.lazycache(fake_filename, module.__dict__)
     return tools.get_experiment(module, class_name)
 


### PR DESCRIPTION
# ARTIQ Pull Request

## Description of Changes

Import modules received through `--content` the same way as when given by a file, thus eliminating an edge case. (No changes to behaviour.)

### Related Issue

Together with [nac3#638](https://git.m-labs.hk/M-Labs/nac3/pulls/638), resolves [nac3#627](https://git.m-labs.hk/M-Labs/nac3/issues/627).

## Type of Changes

<!-- Leave ONLY the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |

## Steps (Choose relevant, delete irrelevant before submitting)

### All Pull Requests

- [x] Use correct spelling and grammar.
- [x] Close/update issues.

### Code Changes

- [x] Run `flake8` to check code style (follow PEP-8 style). `flake8` has issues with parsing Migen/gateware code, ignore as necessary.
- [x] Test your changes or have someone test them. Mention what was tested and how.

### Licensing

See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.