### PR TITLE
ad9910: Add set_profile convienience method

### DIFF
--- a/artiq/coredevice/ad9910.py
+++ b/artiq/coredevice/ad9910.py
@@ -1002,6 +1002,20 @@ class AD9910:
         self.cpld.cfg_att_en(self.chip_select - 4, state)
 
     @kernel
+    def set_profile(self, profile: TInt32):
+        """Set the PROFILE pins.
+
+        .. warning::
+            With CPLD proto_rev 8, this will silently set the profile pins of
+            all other AD9910 DDS channels on the same board!
+
+            Use proto_rev 9 for channel-specific profile setting.
+
+        :param profile: PROFILE pins in numeric representation (0-7).
+        """
+        self.cpld.set_profile(self.chip_select - 4, profile)
+
+    @kernel
     def set_sync(self, 
                  in_delay: TInt32, 
                  window: TInt32, 


### PR DESCRIPTION
Adds a convenience method for coredevice's `AD9910`, since in PROTO_REV 9 the profile pins of the individual channels are configurable now.

## Testing

Basic test code:
```python
        self.dds0.set(frequency=5*MHz, amplitude=1.0, profile=7)
        self.dds0.set(frequency=5*MHz, amplitude=0.5, profile=0)

        while True:
            delay(1.0)
            self.dds0.set_profile(0)
            delay(1.0)
            self.dds0.set_profile(7)
````
