### PR TITLE
urukul: add slack for SPI startup

### DIFF
--- a/artiq/coredevice/urukul.py
+++ b/artiq/coredevice/urukul.py
@@ -306,6 +306,11 @@ class ProtoRev8(CPLDVersion):
         cfg = cpld.cfg_reg
         # Don't pulse MASTER_RESET (m-labs/artiq#940)
         cpld.cfg_reg = cfg | (0 << ProtoRev8.CFG_RST) | (1 << ProtoRev8.CFG_IO_RST)
+        # Preemptively enable the SPI. Voltages of both common mode and
+        # differential are too small initially.
+        # This dummy config value is similar to the coming SPI config
+        cpld.bus.set_config_mu(SPI_CONFIG, 24, SPIT_CFG_WR, CS_CFG)
+        delay(1 * us)
         if blind:
             cpld.cfg_write(cpld.cfg_reg)
         elif urukul_sta_proto_rev(self.sta_read(cpld))!= STA_PROTO_REV_8:
@@ -484,6 +489,11 @@ class ProtoRev9(CPLDVersion):
         cfg = cpld.cfg_reg
         # Don't pulse MASTER_RESET (m-labs/artiq#940)
         cpld.cfg_reg = cfg | (int64(0) << ProtoRev9.CFG_RST) | (int64(1) << ProtoRev9.CFG_IO_RST)
+        # Preemptively enable the SPI. Voltages of both common mode and
+        # differential are too small initially.
+        # This dummy config value is the coming SPI config
+        cpld.bus.set_config_mu(SPI_CONFIG, 24, SPIT_CFG_WR, CS_CFG)
+        delay(1 * us)
         if blind:
             cpld.cfg_write(cpld.cfg_reg)
         elif urukul_sta_proto_rev(self.sta_read(cpld))!= STA_PROTO_REV_9:


### PR DESCRIPTION
## Background

Currently, there is only a 8 ns delay between enabling the SPI interface and transfer data via SPI.
The iCE40 FPGA may miss the first few clock edges.

This PR makes sure that the SPI transfer meet the differential and common mode voltage specifications on iCE40. ~~This change is added to PROTO_REV 9 specifically since iCE40 only supports this revision.~~ This patch is added to both rev 8 and 9 as both CPLD and iCE40 variants suffer from this phenomenon in various degree.
Experimentally, an additional delay as little as 80 ns is sufficient to read back the `proto_rev` field correctly.

See [urukul-pld PR](https://git.m-labs.hk/M-Labs/urukul-pld/pulls/1#issuecomment-15163).

Note: This issue was not observed on the Xilinx CPLD variant.

## Tests

iCE40 Urukul can read back `proto_rev` = 9 in the `sta_read()` call during `init()`.