### PR TITLE
Add support for passing flags to extern decorators

### DIFF
--- a/artiq/coredevice/cache.py
+++ b/artiq/coredevice/cache.py
@@ -4,9 +4,10 @@ from artiq.language.core import compile, extern, kernel, KernelInvariant
 from artiq.coredevice.core import Core
 
 
-@extern
+@extern(flags={"allow-external-alloc"})
 def cache_get(key: str) -> list[int32]:
     raise NotImplementedError("syscall not simulated")
+
 
 @extern
 def cache_put(key: str, value: list[int32]):

--- a/artiq/language/core.py
+++ b/artiq/language/core.py
@@ -68,10 +68,14 @@ def _register_class(cls):
     _registered_classes[cls] = module
 
 
-def extern(function):
+def extern(arg=None, flags={}):
     """Decorates a function declaration defined by the core device runtime."""
-    _register_function(function)
-    return function
+    if arg is None:
+        def inner_decorator(function):
+            _register_function(function)
+            return extern(function, flags)
+        return inner_decorator
+    return arg 
 
 
 def kernel(function_or_method):


### PR DESCRIPTION
## Feature
Allow flags to be passed to an extern decorator. Additionally add the `allow-external-alloc` flag to `cache_get` function, to allow for it to return a list type with [change 636](https://git.m-labs.hk/M-Labs/nac3/pulls/636) to nac3.

✓ | ✨ New feature

## Testing
`nix build` unit tests here and in nac3 repo. Failing test in nac3, due to `cache_get` list return value, now passes.

## Licensing
See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.