### PR TITLE
Register `@rpc` decorated functions

### DIFF
--- a/artiq/language/core.py
+++ b/artiq/language/core.py
@@ -114,6 +114,7 @@ def rpc(arg=None, flags={}):
         def inner_decorator(function):
             return rpc(function, flags)
         return inner_decorator
+    _register_function(arg)
     return arg
 
 


### PR DESCRIPTION
## Bug Fix
Add a call to register the module containing a function when decorated with the `@rpc` decorator. This is to ensure that in the case where the function with the `@rpc` decorator is the only import from that module, the module is still registered.

Issue brought up in a [previous pull request](https://github.com/m-labs/artiq/pull/2789#discussion_r2174506080)

✓ | 🐛 Bug fix

## Testing
```py
# lone_rpc.py
from artiq.experiment import rpc


@rpc
def print_world():
    print("World!")
```
```py
# test.py
from artiq.experiment import *
from artiq.coredevice.core import Core

from lone_rpc import print_world


@compile
class Test(EnvExperiment):
    core: KernelInvariant[Core]


    def build(self):
        self.setattr_device("core")


    @rpc
    def print_hello(self):
        print("Hello")


    @kernel
    def run(self):
        self.print_hello()
        print_world()
```
Now prints:
```
Hello
World!
```
rather than emitting the error:
```
type error at identifier `print_world` (<class 'function'> is not registered with the compiler (@compile decorator missing?)) (at repository/test.py:25:9)
```

## Licensing
See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.