### PR TITLE
Fix missing NAC3 error messages in management system

### DIFF
--- a/artiq/master/worker_impl.py
+++ b/artiq/master/worker_impl.py
@@ -253,21 +253,18 @@ def put_completed():
 
 def put_exception_report():
     _, exc, _ = sys.exc_info()
-    # When we get CompileError, a more suitable diagnostic has already
-    # been printed.
-    if not isinstance(exc, CompileError):
-        short_exc_info = type(exc).__name__
-        exc_str = str(exc)
-        if exc_str:
-            short_exc_info += ": " + exc_str.splitlines()[0]
-        lines = ["Terminating with exception ("+short_exc_info+")\n"]
-        if hasattr(exc, "artiq_core_exception"):
-            lines.append(str(exc.artiq_core_exception))
-        if hasattr(exc, "parent_traceback"):
-            lines += exc.parent_traceback
-            lines += traceback.format_exception_only(type(exc), exc)
-        logging.error("".join(lines).rstrip(),
-                      exc_info=not hasattr(exc, "parent_traceback"))
+    short_exc_info = type(exc).__name__
+    exc_str = str(exc)
+    if exc_str:
+        short_exc_info += ": " + exc_str.splitlines()[0]
+    lines = ["Terminating with exception ("+short_exc_info+")\n"]
+    if hasattr(exc, "artiq_core_exception"):
+        lines.append(str(exc.artiq_core_exception))
+    if hasattr(exc, "parent_traceback"):
+        lines += exc.parent_traceback
+        lines += traceback.format_exception_only(type(exc), exc)
+    logging.error("".join(lines).rstrip(),
+                    exc_info=not hasattr(exc, "parent_traceback"))
     put_object({"action": "exception"})
 
 


### PR DESCRIPTION
### Changes

Special handling of `nac3artiq.CompileError` removed from the management system to resolve missing error messages.

### Related Issue

#2771 