### PR TITLE
sipyco with PYON v2

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -44,15 +44,15 @@ ARTIQ-9 (Unreleased)
 
 Breaking changes:
 
-* Migration of existing data to the new PYON v2 format:
-   - Data is always stored as PYON v2. Ensure backups of existing PYON v1 data are
-     successful before starting ARTIQ-9. Keep a backup of the PYON v1 dataset DB.
-   - Remote controllers and custom applets: ensure sipyco v2 is used by all controllers,
-     controller managers, applets.
-   - The support for encoding/saving data as PYON v1 has been removed. The support
-     for PYON v1 decoding will be removed in a future ARTIQ release.
-   - When PYON v2 decoding fails in the following contexts, an attempt is made to decode
-     data as PYON v1:
+* Migration to PYON v2:
+   - Serialized data is always stored as PYON v2. Ensure backups of existing PYON v1 data
+     exist before starting ARTIQ-9. Keep a backup of the PYON v1 dataset DB.
+   - Both PYON v1 and PYON v2 sipyco pc_rpc controllers are supported simultaneously.
+     PYON v2 support will be required in a future sipyco/ARTIQ release.
+   - Custom applets, sync_struct/broadcast consumers (dataset db, scheduler, log, experiment db)
+     require PYON v2: ensure sipyco v2 is used.
+   - When PYON v2 decoding fails in the following contexts, decoding as PYON v1 is attempted.
+     The support for PYON v1 decoding will be removed in a future ARTIQ release.
       + Dataset DB file
       + HDF5 results ``expid``. Note that existing files are never altered.
       + artiq_client set-dataset

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -46,16 +46,16 @@ Breaking changes:
 
 * Migration of existing data to the new PYON v2 format:
    - Data is always stored as PYON v2. Ensure backups of existing PYON v1 data are
-     successful before starting ARTIQ-9. Keep a backup of the PYON v1 dataset DB
-     and of the GUI state files.
-   - Remote controllers and custom applets: ensure sipyco v2 is used everywhere.
-   - The support for encoding/saving data as PYON v1 has been removed.
-   - Decoding of data in the following contexts falls back to PYON v1 if the PYON v2
-     decoding fails. The support for PYON v1 decoding will be removed in a future ARTIQ
-     release.
+     successful before starting ARTIQ-9. Keep a backup of the PYON v1 dataset DB.
+   - Remote controllers and custom applets: ensure sipyco v2 is used by all controllers,
+     controller managers, applets.
+   - The support for encoding/saving data as PYON v1 has been removed. The support
+     for PYON v1 decoding will be removed in a future ARTIQ release.
+   - When PYON v2 decoding fails in the following contexts, an attempt is made to decode
+     data as PYON v1:
       + Dataset DB file
-      + artiq_client: set-dataset, get-dataset, show datasets
       + HDF5 results ``expid``. Note that existing files are never altered.
+      + artiq_client set-dataset
       + command line experiment arguments (artiq_run/artiq_client submit/artiq_compile)
       + PYONArgument data
       + Interactive arguments (artiq_run, artiq_client)

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -42,6 +42,26 @@ ARTIQ-9 (Unreleased)
 * The Zadig driver installer was added to the MSYS2 offline installer.
 * ``artiq.coredevice.fmcdio_vhdci_eem`` has been removed.
 
+Breaking changes:
+
+* Migration of existing data to the new PYON v2 format:
+   - Data is always stored as PYON v2. Ensure backups of existing PYON v1 data are
+     successful before starting ARTIQ-9. Keep a backup of the PYON v1 dataset DB
+     and of the GUI state files.
+   - Remote controllers and custom applets: ensure sipyco v2 is used everywhere.
+   - The support for encoding/saving data as PYON v1 has been removed.
+   - Decoding of data in the following contexts falls back to PYON v1 if the PYON v2
+     decoding fails. The support for PYON v1 decoding will be removed in a future ARTIQ
+     release.
+      + Dataset DB file
+      + artiq_client: set-dataset, get-dataset, show datasets
+      + HDF5 results ``expid``. Note that existing files are never altered.
+      + command line experiment arguments (artiq_run/artiq_client submit/artiq_compile)
+      + PYONArgument data
+      + Interactive arguments (artiq_run, artiq_client)
+      + Waveform channel list file
+      + devarg overrides
+
 ARTIQ-8
 -------
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -57,7 +57,7 @@ Breaking changes:
       + HDF5 results ``expid``. Note that existing files are never altered.
       + artiq_client set-dataset
       + command line experiment arguments (artiq_run/artiq_client submit/artiq_compile)
-      + PYONArgument data
+      + PYONValue data
       + Interactive arguments (artiq_run, artiq_client)
       + Waveform channel list file
       + devarg overrides

--- a/artiq/browser/experiments.py
+++ b/artiq/browser/experiments.py
@@ -13,7 +13,7 @@ from artiq import __artiq_dir__ as artiq_dir
 from artiq.gui.tools import (LayoutWidget, log_level_to_name, get_open_file_name)
 from artiq.gui.entries import procdesc_to_entry, EntryTreeWidget
 from artiq.master.worker import Worker, log_worker_exception
-from artiq.tools import pyon_decode_robust
+from artiq.compat import pyon_decode_compat
 
 logger = logging.getLogger(__name__)
 
@@ -193,7 +193,7 @@ class _ExperimentDock(QtWidgets.QMdiSubWindow):
         try:
             with h5py.File(filename, "r") as f:
                 expid = f["expid"][()]
-            expid = pyon_decode_robust(expid)
+            expid = pyon_decode_compat(expid)
             arguments = expid["arguments"]
         except:
             logger.error("Could not retrieve expid from HDF5 file",

--- a/artiq/browser/experiments.py
+++ b/artiq/browser/experiments.py
@@ -7,13 +7,11 @@ from collections import OrderedDict
 from PyQt6 import QtCore, QtGui, QtWidgets
 import h5py
 
-from sipyco import pyon
-
 from artiq import __artiq_dir__ as artiq_dir
 from artiq.gui.tools import (LayoutWidget, log_level_to_name, get_open_file_name)
 from artiq.gui.entries import procdesc_to_entry, EntryTreeWidget
 from artiq.master.worker import Worker, log_worker_exception
-from artiq.compat import pyon_decode_compat
+from artiq import compat
 
 logger = logging.getLogger(__name__)
 
@@ -193,7 +191,7 @@ class _ExperimentDock(QtWidgets.QMdiSubWindow):
         try:
             with h5py.File(filename, "r") as f:
                 expid = f["expid"][()]
-            expid = pyon_decode_compat(expid)
+            expid = compat.pyon_decode(expid)
             arguments = expid["arguments"]
         except:
             logger.error("Could not retrieve expid from HDF5 file",

--- a/artiq/browser/experiments.py
+++ b/artiq/browser/experiments.py
@@ -13,6 +13,7 @@ from artiq import __artiq_dir__ as artiq_dir
 from artiq.gui.tools import (LayoutWidget, log_level_to_name, get_open_file_name)
 from artiq.gui.entries import procdesc_to_entry, EntryTreeWidget
 from artiq.master.worker import Worker, log_worker_exception
+from artiq.tools import pyon_decode_robust
 
 logger = logging.getLogger(__name__)
 
@@ -192,7 +193,7 @@ class _ExperimentDock(QtWidgets.QMdiSubWindow):
         try:
             with h5py.File(filename, "r") as f:
                 expid = f["expid"][()]
-            expid = pyon.decode(expid)
+            expid = pyon_decode_robust(expid)
             arguments = expid["arguments"]
         except:
             logger.error("Could not retrieve expid from HDF5 file",

--- a/artiq/browser/files.py
+++ b/artiq/browser/files.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import h5py
 from PyQt6 import QtCore, QtWidgets, QtGui
 
-from sipyco import pyon
+from artiq.tools import pyon_decode_robust
 
 
 logger = logging.getLogger(__name__)
@@ -102,7 +102,7 @@ class Hdf5FileSystemModel(QtGui.QFileSystemModel):
             h5 = open_h5(info)
             if h5 is not None:
                 try:
-                    expid = pyon.decode(h5["expid"][()]) if "expid" in h5 else dict()
+                    expid = pyon_decode_robust(h5["expid"][()]) if "expid" in h5 else dict()
                     start_time = datetime.fromtimestamp(h5["start_time"][()]) if "start_time" in h5 else "<none>"
                     v = ("artiq_version: {}\nrepo_rev: {}\nfile: {}\n"
                          "class_name: {}\nrid: {}\nstart_time: {}").format(
@@ -175,7 +175,7 @@ class FilesDock(QtWidgets.QDockWidget):
         logger.debug("loading datasets from %s", info.filePath())
         with f:
             try:
-                expid = pyon.decode(f["expid"][()]) if "expid" in f else dict()
+                expid = pyon_decode_robust(f["expid"][()]) if "expid" in f else dict()
                 start_time = datetime.fromtimestamp(f["start_time"][()]) if "start_time" in f else "<none>"
                 v = {
                     "artiq_version": f["artiq_version"].asstr()[()] if "artiq_version" in f else "<none>",

--- a/artiq/browser/files.py
+++ b/artiq/browser/files.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import h5py
 from PyQt6 import QtCore, QtWidgets, QtGui
 
-from artiq.tools import pyon_decode_compat
+from artiq.compat import pyon_decode_compat
 
 
 logger = logging.getLogger(__name__)

--- a/artiq/browser/files.py
+++ b/artiq/browser/files.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import h5py
 from PyQt6 import QtCore, QtWidgets, QtGui
 
-from artiq.tools import pyon_decode_robust
+from artiq.tools import pyon_decode_compat
 
 
 logger = logging.getLogger(__name__)
@@ -102,7 +102,7 @@ class Hdf5FileSystemModel(QtGui.QFileSystemModel):
             h5 = open_h5(info)
             if h5 is not None:
                 try:
-                    expid = pyon_decode_robust(h5["expid"][()]) if "expid" in h5 else dict()
+                    expid = pyon_decode_compat(h5["expid"][()]) if "expid" in h5 else dict()
                     start_time = datetime.fromtimestamp(h5["start_time"][()]) if "start_time" in h5 else "<none>"
                     v = ("artiq_version: {}\nrepo_rev: {}\nfile: {}\n"
                          "class_name: {}\nrid: {}\nstart_time: {}").format(
@@ -175,7 +175,7 @@ class FilesDock(QtWidgets.QDockWidget):
         logger.debug("loading datasets from %s", info.filePath())
         with f:
             try:
-                expid = pyon_decode_robust(f["expid"][()]) if "expid" in f else dict()
+                expid = pyon_decode_compat(f["expid"][()]) if "expid" in f else dict()
                 start_time = datetime.fromtimestamp(f["start_time"][()]) if "start_time" in f else "<none>"
                 v = {
                     "artiq_version": f["artiq_version"].asstr()[()] if "artiq_version" in f else "<none>",

--- a/artiq/browser/files.py
+++ b/artiq/browser/files.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import h5py
 from PyQt6 import QtCore, QtWidgets, QtGui
 
-from artiq.compat import pyon_decode_compat
+from artiq import compat
 
 
 logger = logging.getLogger(__name__)
@@ -102,7 +102,7 @@ class Hdf5FileSystemModel(QtGui.QFileSystemModel):
             h5 = open_h5(info)
             if h5 is not None:
                 try:
-                    expid = pyon_decode_compat(h5["expid"][()]) if "expid" in h5 else dict()
+                    expid = compat.pyon_decode(h5["expid"][()]) if "expid" in h5 else dict()
                     start_time = datetime.fromtimestamp(h5["start_time"][()]) if "start_time" in h5 else "<none>"
                     v = ("artiq_version: {}\nrepo_rev: {}\nfile: {}\n"
                          "class_name: {}\nrid: {}\nstart_time: {}").format(
@@ -175,7 +175,7 @@ class FilesDock(QtWidgets.QDockWidget):
         logger.debug("loading datasets from %s", info.filePath())
         with f:
             try:
-                expid = pyon_decode_compat(f["expid"][()]) if "expid" in f else dict()
+                expid = compat.pyon_decode(f["expid"][()]) if "expid" in f else dict()
                 start_time = datetime.fromtimestamp(f["start_time"][()]) if "start_time" in f else "<none>"
                 v = {
                     "artiq_version": f["artiq_version"].asstr()[()] if "artiq_version" in f else "<none>",

--- a/artiq/compat.py
+++ b/artiq/compat.py
@@ -1,0 +1,29 @@
+import json
+import warnings
+
+from sipyco import pyon
+
+
+def pyon_decode_compat(s):
+    try:
+        return pyon.decode(s)
+    except json.JSONDecodeError as e:
+        try:
+            o = pyon.decode_v1(s)
+            warnings.warn("Decoded as PYON v1")
+            return o
+        except:
+            raise e
+
+
+def pyon_load_file_compat(filename):
+    try:
+        return pyon.load_file(filename)
+    except json.JSONDecodeError as e:
+        try:
+            with open(filename, "r", encoding="utf-8") as f:
+                o = pyon.decode_v1(f.read())
+                warnings.warn(f"Loaded `{filename}` as PYON v1")
+                return o
+        except:
+            raise e

--- a/artiq/compat.py
+++ b/artiq/compat.py
@@ -1,29 +1,24 @@
 import json
 import warnings
 
-from sipyco import pyon
+from sipyco import pyon, pyon_v1
 
 
-def pyon_decode_compat(s):
+def pyon_decode(s):
     try:
         return pyon.decode(s)
-    except json.JSONDecodeError as e:
+    except json.JSONDecodeError:
         try:
-            o = pyon.decode_v1(s)
-            warnings.warn("Decoded as PYON v1")
-            return o
+            return pyon_v1.decode(s)
         except:
-            raise e
+            raise
 
 
-def pyon_load_file_compat(filename):
+def pyon_load_file(filename):
     try:
         return pyon.load_file(filename)
-    except json.JSONDecodeError as e:
+    except json.JSONDecodeError:
         try:
-            with open(filename, "r", encoding="utf-8") as f:
-                o = pyon.decode_v1(f.read())
-                warnings.warn(f"Loaded `{filename}` as PYON v1")
-                return o
+            return pyon_v1.load_file(filename)
         except:
-            raise e
+            raise

--- a/artiq/dashboard/experiments.py
+++ b/artiq/dashboard/experiments.py
@@ -10,7 +10,8 @@ import h5py
 from artiq.gui.entries import procdesc_to_entry, EntryTreeWidget
 from artiq.gui.fuzzy_select import FuzzySelectWidget
 from artiq.gui.tools import (LayoutWidget, log_level_to_name, get_open_file_name)
-from artiq.tools import parse_devarg_override, unparse_devarg_override, pyon_decode_robust
+from artiq.tools import parse_devarg_override, unparse_devarg_override
+from artiq.compat import pyon_decode_compat
 
 
 logger = logging.getLogger(__name__)
@@ -415,7 +416,7 @@ class _ExperimentDock(QtWidgets.QMdiSubWindow):
         try:
             with h5py.File(filename, "r") as f:
                 expid = f["expid"][()]
-            expid = pyon_decode_robust(expid)
+            expid = pyon_decode_compat(expid)
             arguments = expid["arguments"]
         except:
             logger.error("Could not retrieve expid from HDF5 file",

--- a/artiq/dashboard/experiments.py
+++ b/artiq/dashboard/experiments.py
@@ -206,8 +206,8 @@ class _ExperimentDock(QtWidgets.QMdiSubWindow):
         devarg_override.setEditable(True)
         devarg_override.lineEdit().setPlaceholderText("Override device arguments")
         devarg_override.lineEdit().setClearButtonEnabled(True)
-        devarg_override.insertItem(0, "core:analyze_at_run_end=True")
-        devarg_override.insertItem(1, "core:report_invariants=True")
+        devarg_override.insertItem(0, "core:analyze_at_run_end=true")
+        devarg_override.insertItem(1, "core:report_invariants=true")
         self.layout.addWidget(devarg_override, 2, 3)
 
         devarg_override.setCurrentText(options["devarg_override"])

--- a/artiq/dashboard/experiments.py
+++ b/artiq/dashboard/experiments.py
@@ -7,12 +7,10 @@ from collections import OrderedDict
 from PyQt6 import QtCore, QtGui, QtWidgets
 import h5py
 
-from sipyco import pyon
-
 from artiq.gui.entries import procdesc_to_entry, EntryTreeWidget
 from artiq.gui.fuzzy_select import FuzzySelectWidget
 from artiq.gui.tools import (LayoutWidget, log_level_to_name, get_open_file_name)
-from artiq.tools import parse_devarg_override, unparse_devarg_override
+from artiq.tools import parse_devarg_override, unparse_devarg_override, pyon_decode_robust
 
 
 logger = logging.getLogger(__name__)
@@ -417,7 +415,7 @@ class _ExperimentDock(QtWidgets.QMdiSubWindow):
         try:
             with h5py.File(filename, "r") as f:
                 expid = f["expid"][()]
-            expid = pyon.decode(expid)
+            expid = pyon_decode_robust(expid)
             arguments = expid["arguments"]
         except:
             logger.error("Could not retrieve expid from HDF5 file",

--- a/artiq/dashboard/experiments.py
+++ b/artiq/dashboard/experiments.py
@@ -11,7 +11,7 @@ from artiq.gui.entries import procdesc_to_entry, EntryTreeWidget
 from artiq.gui.fuzzy_select import FuzzySelectWidget
 from artiq.gui.tools import (LayoutWidget, log_level_to_name, get_open_file_name)
 from artiq.tools import parse_devarg_override, unparse_devarg_override
-from artiq.compat import pyon_decode_compat
+from artiq import compat
 
 
 logger = logging.getLogger(__name__)
@@ -416,7 +416,7 @@ class _ExperimentDock(QtWidgets.QMdiSubWindow):
         try:
             with h5py.File(filename, "r") as f:
                 expid = f["expid"][()]
-            expid = pyon_decode_compat(expid)
+            expid = compat.pyon_decode(expid)
             arguments = expid["arguments"]
         except:
             logger.error("Could not retrieve expid from HDF5 file",

--- a/artiq/dashboard/waveform.py
+++ b/artiq/dashboard/waveform.py
@@ -13,7 +13,8 @@ import numpy as np
 from sipyco.pc_rpc import AsyncioClient
 from sipyco import pyon
 
-from artiq.tools import exc_to_warning, short_format, pyon_load_file_robust
+from artiq.compat import pyon_load_file_compat
+from artiq.tools import exc_to_warning, short_format
 from artiq.coredevice import comm_analyzer
 from artiq.coredevice.comm_analyzer import WaveformType
 from artiq.gui.tools import LayoutWidget, get_open_file_name, get_save_file_name
@@ -878,7 +879,7 @@ class WaveformDock(QtWidgets.QDockWidget):
             return
         self._current_dir = os.path.dirname(filename)
         try:
-            channel_list = pyon_load_file_robust(filename)
+            channel_list = pyon_load_file_compat(filename)
             self._waveform_model.import_list(channel_list)
             self._waveform_model.update_all(self._waveform_data['data'])
         except:

--- a/artiq/dashboard/waveform.py
+++ b/artiq/dashboard/waveform.py
@@ -13,7 +13,7 @@ import numpy as np
 from sipyco.pc_rpc import AsyncioClient
 from sipyco import pyon
 
-from artiq.tools import exc_to_warning, short_format
+from artiq.tools import exc_to_warning, short_format, pyon_load_file_robust
 from artiq.coredevice import comm_analyzer
 from artiq.coredevice.comm_analyzer import WaveformType
 from artiq.gui.tools import LayoutWidget, get_open_file_name, get_save_file_name
@@ -878,7 +878,7 @@ class WaveformDock(QtWidgets.QDockWidget):
             return
         self._current_dir = os.path.dirname(filename)
         try:
-            channel_list = pyon.load_file(filename)
+            channel_list = pyon_load_file_robust(filename)
             self._waveform_model.import_list(channel_list)
             self._waveform_model.update_all(self._waveform_data['data'])
         except:

--- a/artiq/dashboard/waveform.py
+++ b/artiq/dashboard/waveform.py
@@ -13,7 +13,7 @@ import numpy as np
 from sipyco.pc_rpc import AsyncioClient
 from sipyco import pyon
 
-from artiq.compat import pyon_load_file_compat
+from artiq import compat
 from artiq.tools import exc_to_warning, short_format
 from artiq.coredevice import comm_analyzer
 from artiq.coredevice.comm_analyzer import WaveformType
@@ -879,7 +879,7 @@ class WaveformDock(QtWidgets.QDockWidget):
             return
         self._current_dir = os.path.dirname(filename)
         try:
-            channel_list = pyon_load_file_compat(filename)
+            channel_list = compat.pyon_load_file(filename)
             self._waveform_model.import_list(channel_list)
             self._waveform_model.update_all(self._waveform_data['data'])
         except:

--- a/artiq/frontend/artiq_client.py
+++ b/artiq/frontend/artiq_client.py
@@ -20,7 +20,7 @@ from sipyco.tools import SignalHandler
 
 from artiq.tools import (scale_from_metadata, short_format, parse_arguments,
                          parse_devarg_override)
-from artiq.compat import pyon_decode_compat
+from artiq import compat
 from artiq import __version__ as artiq_version
 
 
@@ -203,7 +203,7 @@ def _action_set_dataset(remote, args):
     if args.precision is not None:
         metadata["precision"] = args.precision
     scale = scale_from_metadata(metadata)
-    value = pyon_decode_compat(args.value)
+    value = compat.pyon_decode(args.value)
     t = type(value)
     if np.issubdtype(t, np.number) or t is np.ndarray:
         value = value * scale

--- a/artiq/frontend/artiq_client.py
+++ b/artiq/frontend/artiq_client.py
@@ -19,7 +19,7 @@ from sipyco import common_args, pyon
 from sipyco.tools import SignalHandler
 
 from artiq.tools import (scale_from_metadata, short_format, parse_arguments,
-                         parse_devarg_override)
+                         parse_devarg_override, pyon_decode_robust)
 from artiq import __version__ as artiq_version
 
 
@@ -202,7 +202,7 @@ def _action_set_dataset(remote, args):
     if args.precision is not None:
         metadata["precision"] = args.precision
     scale = scale_from_metadata(metadata)
-    value = pyon.decode(args.value)
+    value = pyon_decode_robust(args.value)
     t = type(value)
     if np.issubdtype(t, np.number) or t is np.ndarray:
         value = value * scale

--- a/artiq/frontend/artiq_client.py
+++ b/artiq/frontend/artiq_client.py
@@ -19,7 +19,8 @@ from sipyco import common_args, pyon
 from sipyco.tools import SignalHandler
 
 from artiq.tools import (scale_from_metadata, short_format, parse_arguments,
-                         parse_devarg_override, pyon_decode_robust)
+                         parse_devarg_override)
+from artiq.compat import pyon_decode_compat
 from artiq import __version__ as artiq_version
 
 
@@ -202,7 +203,7 @@ def _action_set_dataset(remote, args):
     if args.precision is not None:
         metadata["precision"] = args.precision
     scale = scale_from_metadata(metadata)
-    value = pyon_decode_robust(args.value)
+    value = pyon_decode_compat(args.value)
     t = type(value)
     if np.issubdtype(t, np.number) or t is np.ndarray:
         value = value * scale

--- a/artiq/frontend/artiq_run.py
+++ b/artiq/frontend/artiq_run.py
@@ -23,7 +23,7 @@ from artiq.master.worker_db import DeviceManager, DatasetManager
 from artiq.coredevice.core import CompileError, host_only
 from artiq.compiler.embedding import EmbeddingMap
 from artiq.compiler import import_cache
-from artiq.compat import pyon_decode_compat
+from artiq import compat
 from artiq.tools import *
 
 
@@ -177,7 +177,7 @@ class ArgumentManager(ProcessArgumentManager):
                 user_input = input("{}:{} (group={}, tooltip={}): ".format(
                     key, type(processor).__name__, group, tooltip))
                 try:
-                    user_input_deser = pyon_decode_compat(user_input)
+                    user_input_deser = compat.pyon_decode(user_input)
                     value = processor.process(user_input_deser)
                 except:
                     logger.error("failed to process user input, retrying",

--- a/artiq/frontend/artiq_run.py
+++ b/artiq/frontend/artiq_run.py
@@ -13,7 +13,7 @@ import h5py
 
 from llvmlite import binding as llvm
 
-from sipyco import common_args, pyon
+from sipyco import common_args
 
 from artiq import __version__ as artiq_version
 from artiq.language.environment import EnvExperiment, ProcessArgumentManager
@@ -176,7 +176,7 @@ class ArgumentManager(ProcessArgumentManager):
                 user_input = input("{}:{} (group={}, tooltip={}): ".format(
                     key, type(processor).__name__, group, tooltip))
                 try:
-                    user_input_deser = pyon.decode(user_input)
+                    user_input_deser = pyon_decode_robust(user_input)
                     value = processor.process(user_input_deser)
                 except:
                     logger.error("failed to process user input, retrying",

--- a/artiq/frontend/artiq_run.py
+++ b/artiq/frontend/artiq_run.py
@@ -23,6 +23,7 @@ from artiq.master.worker_db import DeviceManager, DatasetManager
 from artiq.coredevice.core import CompileError, host_only
 from artiq.compiler.embedding import EmbeddingMap
 from artiq.compiler import import_cache
+from artiq.compat import pyon_decode_compat
 from artiq.tools import *
 
 
@@ -176,7 +177,7 @@ class ArgumentManager(ProcessArgumentManager):
                 user_input = input("{}:{} (group={}, tooltip={}): ".format(
                     key, type(processor).__name__, group, tooltip))
                 try:
-                    user_input_deser = pyon_decode_robust(user_input)
+                    user_input_deser = pyon_decode_compat(user_input)
                     value = processor.process(user_input_deser)
                 except:
                     logger.error("failed to process user input, retrying",

--- a/artiq/gui/state.py
+++ b/artiq/gui/state.py
@@ -5,7 +5,8 @@ import shutil
 
 from sipyco.tools import TaskObject
 from sipyco import pyon
-from artiq.tools import pyon_load_file_robust
+
+from artiq.compat import pyon_load_file_compat
 
 
 logger = logging.getLogger(__name__)
@@ -42,7 +43,7 @@ class StateManager(TaskObject):
 
     def load(self):
         try:
-            data = pyon_load_file_robust(self.filename)
+            data = pyon_load_file_compat(self.filename)
         except FileNotFoundError:
             logger.info("State database '%s' not found, using defaults",
                         self.filename)

--- a/artiq/gui/state.py
+++ b/artiq/gui/state.py
@@ -6,7 +6,7 @@ import shutil
 from sipyco.tools import TaskObject
 from sipyco import pyon
 
-from artiq.compat import pyon_load_file_compat
+from artiq import compat
 
 
 logger = logging.getLogger(__name__)
@@ -43,7 +43,7 @@ class StateManager(TaskObject):
 
     def load(self):
         try:
-            data = pyon_load_file_compat(self.filename)
+            data = compat.pyon_load_file(self.filename)
         except FileNotFoundError:
             logger.info("State database '%s' not found, using defaults",
                         self.filename)

--- a/artiq/gui/state.py
+++ b/artiq/gui/state.py
@@ -5,6 +5,7 @@ import shutil
 
 from sipyco.tools import TaskObject
 from sipyco import pyon
+from artiq.tools import pyon_load_file_robust
 
 
 logger = logging.getLogger(__name__)
@@ -41,7 +42,7 @@ class StateManager(TaskObject):
 
     def load(self):
         try:
-            data = pyon.load_file(self.filename)
+            data = pyon_load_file_robust(self.filename)
         except FileNotFoundError:
             logger.info("State database '%s' not found, using defaults",
                         self.filename)

--- a/artiq/language/environment.py
+++ b/artiq/language/environment.py
@@ -4,10 +4,10 @@ from contextlib import contextmanager
 from types import SimpleNamespace
 
 from sipyco import pyon
-from artiq.tools import pyon_decode_compat
 
 from artiq.language import units
 from artiq.language.core import rpc
+from artiq.tools import pyon_decode_compat
 
 
 __all__ = ["NoDefault", "DefaultMissing",

--- a/artiq/language/environment.py
+++ b/artiq/language/environment.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from types import SimpleNamespace
 
 from sipyco import pyon
+from artiq.tools import pyon_decode_compat
 
 from artiq.language import units
 from artiq.language.core import rpc
@@ -66,8 +67,7 @@ class PYONValue(_SimpleArgProcessor):
             self.default_value = default
 
     def process(self, x):
-        from artiq.tools import pyon_decode_robust
-        return pyon_decode_robust(x)
+        return pyon_decode_compat(x)
 
     def describe(self):
         d = {"ty": self.__class__.__name__}

--- a/artiq/language/environment.py
+++ b/artiq/language/environment.py
@@ -7,7 +7,7 @@ from sipyco import pyon
 
 from artiq.language import units
 from artiq.language.core import rpc
-from artiq.tools import pyon_decode_compat
+from artiq.compat import pyon_decode_compat
 
 
 __all__ = ["NoDefault", "DefaultMissing",

--- a/artiq/language/environment.py
+++ b/artiq/language/environment.py
@@ -66,7 +66,8 @@ class PYONValue(_SimpleArgProcessor):
             self.default_value = default
 
     def process(self, x):
-        return pyon.decode(x)
+        from artiq.tools import pyon_decode_robust
+        return pyon_decode_robust(x)
 
     def describe(self):
         d = {"ty": self.__class__.__name__}

--- a/artiq/language/environment.py
+++ b/artiq/language/environment.py
@@ -7,7 +7,7 @@ from sipyco import pyon
 
 from artiq.language import units
 from artiq.language.core import rpc
-from artiq.compat import pyon_decode_compat
+from artiq import compat
 
 
 __all__ = ["NoDefault", "DefaultMissing",
@@ -67,7 +67,7 @@ class PYONValue(_SimpleArgProcessor):
             self.default_value = default
 
     def process(self, x):
-        return pyon_decode_compat(x)
+        return compat.pyon_decode(x)
 
     def describe(self):
         d = {"ty": self.__class__.__name__}

--- a/artiq/master/databases.py
+++ b/artiq/master/databases.py
@@ -7,7 +7,7 @@ from sipyco.sync_struct import (Notifier, process_mod, ModAction,
 from sipyco import pyon
 from sipyco.tools import TaskObject
 
-from artiq.tools import file_import
+from artiq.tools import file_import, pyon_decode_robust
 
 
 def device_db_from_file(filename):
@@ -50,7 +50,7 @@ class DatasetDB(TaskObject):
         data = dict()
         with self.lmdb.begin() as txn:
             for key, value_and_metadata in txn.cursor():
-                value, metadata = pyon.decode(value_and_metadata.decode())
+                value, metadata = pyon_decode_robust(value_and_metadata.decode())
                 data[key.decode()] = (True, value, metadata)
         self.data = Notifier(data)
         self.pending_keys = set()

--- a/artiq/master/databases.py
+++ b/artiq/master/databases.py
@@ -7,7 +7,8 @@ from sipyco.sync_struct import (Notifier, process_mod, ModAction,
 from sipyco import pyon
 from sipyco.tools import TaskObject
 
-from artiq.tools import file_import, pyon_decode_compat
+from artiq.compat import pyon_decode_compat
+from artiq.tools import file_import
 
 
 def device_db_from_file(filename):

--- a/artiq/master/databases.py
+++ b/artiq/master/databases.py
@@ -7,7 +7,7 @@ from sipyco.sync_struct import (Notifier, process_mod, ModAction,
 from sipyco import pyon
 from sipyco.tools import TaskObject
 
-from artiq.compat import pyon_decode_compat
+from artiq import compat
 from artiq.tools import file_import
 
 
@@ -51,7 +51,7 @@ class DatasetDB(TaskObject):
         data = dict()
         with self.lmdb.begin() as txn:
             for key, value_and_metadata in txn.cursor():
-                value, metadata = pyon_decode_compat(value_and_metadata.decode())
+                value, metadata = compat.pyon_decode(value_and_metadata.decode())
                 data[key.decode()] = (True, value, metadata)
         self.data = Notifier(data)
         self.pending_keys = set()

--- a/artiq/master/databases.py
+++ b/artiq/master/databases.py
@@ -7,7 +7,7 @@ from sipyco.sync_struct import (Notifier, process_mod, ModAction,
 from sipyco import pyon
 from sipyco.tools import TaskObject
 
-from artiq.tools import file_import, pyon_decode_robust
+from artiq.tools import file_import, pyon_decode_compat
 
 
 def device_db_from_file(filename):
@@ -50,7 +50,7 @@ class DatasetDB(TaskObject):
         data = dict()
         with self.lmdb.begin() as txn:
             for key, value_and_metadata in txn.cursor():
-                value, metadata = pyon_decode_robust(value_and_metadata.decode())
+                value, metadata = pyon_decode_compat(value_and_metadata.decode())
                 data[key.decode()] = (True, value, metadata)
         self.data = Notifier(data)
         self.pending_keys = set()

--- a/artiq/tools.py
+++ b/artiq/tools.py
@@ -2,10 +2,12 @@ import asyncio
 import importlib.util
 import importlib.machinery
 import inspect
+import json
 import logging
 import pathlib
 import string
 import sys
+import warnings
 
 import numpy as np
 
@@ -29,11 +31,36 @@ __all__ = ["parse_arguments",
 logger = logging.getLogger(__name__)
 
 
+def pyon_decode_robust(s):
+    try:
+        return pyon.decode(s)
+    except json.JSONDecodeError as e:
+        try:
+            o = pyon.decode_v1(s)
+            warnings.warn("Decoded as PYON v1", DeprecationWarning)
+            return o
+        except:
+            raise e
+
+
+def pyon_load_file_robust(filename):
+    try:
+        return pyon.load_file(filename)
+    except json.JSONDecodeError as e:
+        try:
+            with open(filename, "r", encoding="utf-8") as f:
+                o = pyon.decode_v1(f.read())
+                warnings.warn("Decoded as PYON v1", DeprecationWarning)
+                return o
+        except:
+            raise e
+
+
 def parse_arguments(arguments):
     d = {}
     for argument in arguments:
         name, eq, value = argument.partition("=")
-        d[name] = pyon.decode(value)
+        d[name] = pyon_decode_robust(value)
     return d
 
 

--- a/artiq/tools.py
+++ b/artiq/tools.py
@@ -49,7 +49,7 @@ def parse_devarg_override(devarg_override):
         argument, _, value = override.partition("=")
         if not value:
             raise ValueError
-        devarg_override_dict[device][argument] = pyon.decode(value)
+        devarg_override_dict[device][argument] = pyon_decode_compat(value)
     return devarg_override_dict
 
 

--- a/artiq/tools.py
+++ b/artiq/tools.py
@@ -2,12 +2,10 @@ import asyncio
 import importlib.util
 import importlib.machinery
 import inspect
-import json
 import logging
 import pathlib
 import string
 import sys
-import warnings
 
 import numpy as np
 
@@ -17,6 +15,7 @@ from platformdirs import user_config_dir
 from artiq import __version__ as artiq_version
 from artiq.language.environment import is_public_experiment
 from artiq.language import units
+from artiq.compat import pyon_decode_compat
 
 
 __all__ = ["parse_arguments",
@@ -31,36 +30,11 @@ __all__ = ["parse_arguments",
 logger = logging.getLogger(__name__)
 
 
-def pyon_decode_robust(s):
-    try:
-        return pyon.decode(s)
-    except json.JSONDecodeError as e:
-        try:
-            o = pyon.decode_v1(s)
-            warnings.warn("Decoded as PYON v1", DeprecationWarning)
-            return o
-        except:
-            raise e
-
-
-def pyon_load_file_robust(filename):
-    try:
-        return pyon.load_file(filename)
-    except json.JSONDecodeError as e:
-        try:
-            with open(filename, "r", encoding="utf-8") as f:
-                o = pyon.decode_v1(f.read())
-                warnings.warn("Decoded as PYON v1", DeprecationWarning)
-                return o
-        except:
-            raise e
-
-
 def parse_arguments(arguments):
     d = {}
     for argument in arguments:
         name, eq, value = argument.partition("=")
-        d[name] = pyon_decode_robust(value)
+        d[name] = pyon_decode_compat(value)
     return d
 
 

--- a/artiq/tools.py
+++ b/artiq/tools.py
@@ -15,7 +15,7 @@ from platformdirs import user_config_dir
 from artiq import __version__ as artiq_version
 from artiq.language.environment import is_public_experiment
 from artiq.language import units
-from artiq.compat import pyon_decode_compat
+from artiq import compat
 
 
 __all__ = ["parse_arguments",
@@ -34,7 +34,7 @@ def parse_arguments(arguments):
     d = {}
     for argument in arguments:
         name, eq, value = argument.partition("=")
-        d[name] = pyon_decode_compat(value)
+        d[name] = compat.pyon_decode(value)
     return d
 
 
@@ -49,7 +49,7 @@ def parse_devarg_override(devarg_override):
         argument, _, value = override.partition("=")
         if not value:
             raise ValueError
-        devarg_override_dict[device][argument] = pyon_decode_compat(value)
+        devarg_override_dict[device][argument] = compat.pyon_decode(value)
     return devarg_override_dict
 
 

--- a/flake.lock
+++ b/flake.lock
@@ -118,15 +118,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1750854871,
-        "narHash": "sha256-0zYtgqDJpGw0IdrobCmSO5+KsIRmdwIHIbsPrzuPLAQ=",
+        "lastModified": 1751275429,
+        "narHash": "sha256-05zPb670uHduOuSk92HYYaipdy+i3OVchXcHv8B5/u4=",
         "owner": "m-labs",
         "repo": "sipyco",
-        "rev": "72dd23a358b72b2a73dc02780137750630071d98",
+        "rev": "202dabcdaea34c8fa89d85a63db39aae49ee2418",
         "type": "github"
       },
       "original": {
         "owner": "m-labs",
+        "ref": "json",
         "repo": "sipyco",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751275429,
-        "narHash": "sha256-05zPb670uHduOuSk92HYYaipdy+i3OVchXcHv8B5/u4=",
+        "lastModified": 1751878169,
+        "narHash": "sha256-7bVWY410d723gIASn7d9VZ/X+itsEzLLd04Rj6MBKlw=",
         "owner": "m-labs",
         "repo": "sipyco",
-        "rev": "202dabcdaea34c8fa89d85a63db39aae49ee2418",
+        "rev": "87f2dd895534bb889d3cfaed2e9003159dfa31ae",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751892754,
-        "narHash": "sha256-7bVWY410d723gIASn7d9VZ/X+itsEzLLd04Rj6MBKlw=",
+        "lastModified": 1752137244,
+        "narHash": "sha256-g3AM4sLksC1vjj+MyLj9LS5yX3Pt/OY7bftE13y24zE=",
         "owner": "m-labs",
         "repo": "sipyco",
-        "rev": "db78b05ad979ded4e8b85f45cbd2bb6b51b6f968",
+        "rev": "877af6841359620f22d3d68f2fe32c01f9dfd8a3",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -118,16 +118,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1751878169,
+        "lastModified": 1751892754,
         "narHash": "sha256-7bVWY410d723gIASn7d9VZ/X+itsEzLLd04Rj6MBKlw=",
         "owner": "m-labs",
         "repo": "sipyco",
-        "rev": "87f2dd895534bb889d3cfaed2e9003159dfa31ae",
+        "rev": "db78b05ad979ded4e8b85f45cbd2bb6b51b6f968",
         "type": "github"
       },
       "original": {
         "owner": "m-labs",
-        "ref": "json",
         "repo": "sipyco",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
     };
 
     sipyco = {
-      url = "github:m-labs/sipyco?ref=json";
+      url = "github:m-labs/sipyco";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
     };
 
     sipyco = {
-      url = "github:m-labs/sipyco";
+      url = "github:m-labs/sipyco?ref=json";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 


### PR DESCRIPTION
This switches ARTIQ over from PYON v1 to PYON v2 (https://github.com/m-labs/sipyco/pull/64).

Migration to PYON v2:

   - Serialized data is always stored as PYON v2. Ensure backups of existing PYON v1 data
     exist before starting ARTIQ-9. Keep a backup of the PYON v1 dataset DB.
   - Both PYON v1 and PYON v2 sipyco pc_rpc controllers are supported simultaneously.
     PYON v2 support will be required in a future sipyco/ARTIQ release.
   - Custom applets, sync_struct/broadcast consumers (dataset db, scheduler, log, experiment db)
     require PYON v2: ensure sipyco v2 is used.
   - When PYON v2 decoding fails in the following contexts, decoding as PYON v1 is attempted.
     The support for PYON v1 decoding will be removed in a future ARTIQ release.
      + Dataset DB file
      + HDF5 results ``expid``. Note that existing files are never altered.
      + artiq_client set-dataset
      + command line experiment arguments (artiq_run/artiq_client submit/artiq_compile)
      + PYONValue data
      + Interactive arguments (artiq_run, artiq_client)
      + Waveform channel list file
      + devarg overrides