### PR TITLE
JSON: add proto_rev to SU-Servo json schema

### DIFF
--- a/artiq/coredevice/coredevice_generic.schema.json
+++ b/artiq/coredevice/coredevice_generic.schema.json
@@ -443,6 +443,10 @@
                         },
                         "pll_vco": {
                             "type": "integer"
+                        },
+                        "proto_rev": {
+                            "type": "integer",
+                            "default": 9
                         }
                     },
                     "required": ["sampler_ports", "urukul0_ports"]


### PR DESCRIPTION
#2732 and #2736, but for SU-Servo.

Only SU-Servos with homogeneous Urukul proto_rev are supported.

Passed `artiq_sinara_tester` for a proto_rev=8 system and a proto_rev=9 system respectively.