### PR TITLE
Revert support for passing flags to extern decorators

### DIFF
--- a/artiq/coredevice/cache.py
+++ b/artiq/coredevice/cache.py
@@ -4,7 +4,7 @@ from artiq.language.core import compile, extern, kernel, KernelInvariant
 from artiq.coredevice.core import Core
 
 
-@extern(flags={"allow-external-alloc"})
+@extern
 def cache_get(key: str) -> list[int32]:
     raise NotImplementedError("syscall not simulated")
 

--- a/artiq/language/core.py
+++ b/artiq/language/core.py
@@ -68,14 +68,10 @@ def _register_class(cls):
     _registered_classes[cls] = module
 
 
-def extern(arg=None, flags={}):
+def extern(function):
     """Decorates a function declaration defined by the core device runtime."""
-    if arg is None:
-        def inner_decorator(function):
-            return extern(function, flags)
-        return inner_decorator
-    _register_function(arg)
-    return arg 
+    _register_function(function)
+    return function
 
 
 def kernel(function_or_method):


### PR DESCRIPTION
This reverts commit 41c3c32f16dce9a6335b708927df246081026e46; the feature in NAC3 requiring flags to be passed to `extern` decorators was also reverted, so this is no longer needed.