### PR TITLE
Bring staticmethod support to ARTIQ

### DIFF
--- a/artiq/coredevice/core.py
+++ b/artiq/coredevice/core.py
@@ -40,6 +40,8 @@ nac3_builtins = {
     "tuple": tuple,
     "Exception": Exception,
 
+    "staticmethod": staticmethod,
+
     "types": {
         "GenericAlias": GenericAlias,
         "ModuleType": ModuleType,

--- a/artiq/language/core.py
+++ b/artiq/language/core.py
@@ -76,6 +76,8 @@ def extern(function):
 
 def kernel(function_or_method):
     """Decorates a function or method to be executed on the core device."""
+    if isinstance(function_or_method, staticmethod):
+        function_or_method = function_or_method.__func__
     _register_function(function_or_method)
     argspec = getfullargspec(function_or_method)
     if argspec.args and argspec.args[0] == "self":

--- a/artiq/test/coredevice/test_embedding.py
+++ b/artiq/test/coredevice/test_embedding.py
@@ -703,3 +703,55 @@ class BoolListTypeTest(ExperimentCase):
 
     def test_np_bool_list(self):
         self.create(_BoolListType).run_numpy_bool()
+
+
+@compile
+class _StaticMethods(EnvExperiment):
+    core: KernelInvariant[Core]
+
+    def build(self):
+        self.setattr_device("core")
+
+    @rpc
+    @staticmethod
+    def static_rpc_add(a: int32, b: int32) -> int32:
+        return a + b
+
+    @staticmethod
+    @kernel
+    def static_kernel_add(a: int32, b: int32) -> int32:
+        return a + b
+
+
+    @kernel
+    def static_rpc_fn(self) -> int32:
+        return _StaticMethods.static_rpc_add(1, 2)
+
+    @kernel
+    def static_kernel_fn(self) -> int32:
+        return _StaticMethods.static_kernel_add(1, 2)
+
+    @kernel
+    def static_call_on_instance(self) -> int32:
+        return self.static_kernel_add(1, 2)
+
+    @staticmethod
+    def static_host(a, b):
+        return a + b
+
+
+class StaticMethodsTest(ExperimentCase):
+    def test_rpc_staticmethod(self):
+        exp = self.create(_StaticMethods)
+        self.assertEqual(exp.static_rpc_fn(), 3)
+
+    def test_kernel_staticmethod(self):
+        exp = self.create(_StaticMethods)
+        self.assertEqual(exp.static_kernel_fn(), 3)
+
+    def test_host_staticmethod(self):
+        self.assertEqual(_StaticMethods.static_host(1, 2), 3)
+
+    def test_static_call_on_instance(self):
+        exp = self.create(_StaticMethods)
+        self.assertEqual(exp.static_call_on_instance(), 3)


### PR DESCRIPTION
## Changes
Pass through the python builtin `staticmethod` function to nac3. In conjunction with [nac3#639](https://git.m-labs.hk/M-Labs/nac3/pulls/639), this allows for RPC and kernel functions to be marked as static.

Commit 697942c298802f149e186f3b29070dadce758ae1 edits the `kernel` decorator so that even if applied to  a static method, i.e. `kernel(staticmethod(func)))` it will still apply to `func`. This commit could be removed, but then kernel must always be called before `staticmethod`.

### Type of Change
✓ | ✨ New feature

### Syntax
The syntax is identical to using the `@staticmethod` decorator in python.
```py
from numpy import int32

from artiq.experiment import rpc, kernel, compile, EnvExperiment, KernelInvariant, print_rpc
from artiq.coredevice.core import Core

@compile
class A(EnvExperiment):
    core: KernelInvariant[Core]

    def build(self):
        self.setattr_device("core")

    @rpc
    @staticmethod
    def add(a: int32, b: int32) -> int32:
        return a + b

    @kernel
    def run(self):
        print_rpc(A.add(1, 2))  # 3
        print_rpc(self.add(3, 4))  # 7
```
Note, the `staticmethod()` function without the decorator syntactic sugar is **not** supported.

## Testing
All of the existing `nix build` tests pass on both the artiq and the nac3 side. In addition, commit c47c7c76238caf39e63c83d6c3ad0818c795ffe3, added a new test case for static methods.

## Licensing
See [copyright & licensing for more info](https://github.com/m-labs/artiq/blob/master/CONTRIBUTING.rst#copyright-and-sign-off).
ARTIQ files that do not contain a license header are copyrighted by M-Labs Limited and are licensed under LGPLv3+.