### PR TITLE
flash_tools: don't compare list with None

### DIFF
--- a/artiq/frontend/flash_tools.py
+++ b/artiq/frontend/flash_tools.py
@@ -31,7 +31,7 @@ def fetch_bin(binary_dir, components, srcbuild=False):
             except FileNotFoundError:
                 pass
 
-        if bins is None:
+        if not bins:
             raise FileNotFoundError("multiple components not found: {}".format(
                                         " ".join(components)))
         


### PR DESCRIPTION
Fixes a check that tried to test whether a list is empty with `is None`, which is always false and causes a confusing error message later.

(Should we perhaps run some sort of Python type checking on our code? Might help catch trivial mistakes even without type annotations.)