### PR TITLE
sinara tester: separate handling of LVDS TTLs 

### DIFF
--- a/artiq/frontend/artiq_ddb_template.py
+++ b/artiq/frontend/artiq_ddb_template.py
@@ -140,6 +140,7 @@ class PeripheralManager:
             class_names[peripheral["bank_direction_high"]]
         ]
         channel = count(0)
+        board = peripheral["board"] if "board" in peripheral else ""
         name = [self.get_name("ttl") for _ in range(num_channels)]
         for i in range(num_channels):
             self.gen("""
@@ -147,11 +148,13 @@ class PeripheralManager:
                     "type": "local",
                     "module": "artiq.coredevice.ttl",
                     "class": "{class_name}",
+                    "board": "{board}",
                     "arguments": {{"channel": 0x{channel:06x}}},
                 }}""",
                      name=name[i],
                      class_name=classes[i // 4],
-                     channel=rtio_offset + next(channel))
+                     channel=rtio_offset + next(channel),
+                     board = board)
         if peripheral["edge_counter"]:
             for i in range(num_channels):
                 class_name = classes[i // 4]

--- a/artiq/frontend/artiq_sinara_tester.py
+++ b/artiq/frontend/artiq_sinara_tester.py
@@ -272,9 +272,11 @@ class SinaraTester(EnvExperiment):
             print("Not enough LVDS TTL output channels available to use as stimulus.")
             print("TTL input device group to switch to output mode (default: 0):")
             ttl_in_chunk_list = []
-            for x, ttl_chunk in enumerate(chunker(self.lvds_ttl_ins, 4 - len(self.lvds_ttl_outs))):
-                ttl_in_chunk_list.append(ttl_chunk)
-                print("\t{}: ({})".format(x, ", ".join(name for name, _ in ttl_chunk)))
+            ttl_num = 4 - len(self.lvds_ttl_outs)
+            for x, ttl_chunk in enumerate(chunker(self.lvds_ttl_ins, ttl_num)):
+                if len(ttl_chunk) == ttl_num:
+                    ttl_in_chunk_list.append(ttl_chunk)
+                    print("\t{}: ({})".format(x, ", ".join(name for name, _ in ttl_chunk)))
             new_ttl_out = ttl_in_chunk_list[int(input("") or "0")]
             self.cfg_lvds_io_out(new_ttl_out)
             lvds_ttl_out_chunk = self.lvds_ttl_outs + new_ttl_out


### PR DESCRIPTION
## Feature

Separate tests for LVDS TTLs in `artiq_sinara_tester`

 **Drafted as not Tested in HW and requires further consideration for code conventions**

### Changes
- Added ability to test LVDS TTLs in groups of 4.
- Added `"board": "dio_lvds"` to the corresponding TTLs in `device_db.py`. Changes to `device_db.py` are reflected in `artiq_ddb_template`. ( https://github.com/m-labs/artiq/pull/2532 )
- Avoids using oscilloscope for testing `TTLOut`s unless not enough `TTLInOut` channels are available 

In cases where there are't enough `TTLOut` to be used for stimulus, a group of additional `TTLInOut` channels can be chosen to be changed to output mode to use as stimulus.

LVDS `TTLInOut` and `TTLOut` channels are tested simultaneously


#### Possible changes/additions
- Test all LVDS `TTLInOut` channels in both input and output mode within a single run of `artiq_sinara_tester`
- Verify output (via oscilloscope) for stimulus before testing the inputs

### Related issue
#2287 
