### PR TITLE
suservo/test: fix coefficient signs

### DIFF
--- a/artiq/gateware/suservo/iir.py
+++ b/artiq/gateware/suservo/iir.py
@@ -554,10 +554,10 @@ class IIR(Module):
         word, addr, mask = self._coeff(channel, profile, coeff)
         val = yield self.m_coeff[addr]
         if word:
-            return val >> w.coeff
+            val >>= w.coeff
         else:
-            return val & mask
-        if val in "offset a1 b0 b1".split():
+            val &= mask
+        if coeff in "offset a1 b0 b1".split():
             val = signed(val, w.coeff)
         return val
 


### PR DESCRIPTION
## Bug Fix
Correct the `get_coeff` method in `IIR`. It is a convenience method for acquiring the IIR coefficients in gateware testbench.

This bug is discovered when running IIR test with parameter `channel > 3`. Note that the `channel` parameter is base 2 logarithmic (so `channel=3` means 8 IIR channels).

This PR serve as a stepping stone for #1782.

The current implementation erroneously perform early return for all coefficients. This and the subsequent coefficient checking mechanism are fixed.

This fix should be backported to `release-8`.

## Related PR
#1782

## Test
Passed `IIRTest` with `channel=4`.