### PR TITLE
test_embedding: Remove skip from now passing `ListTupleTest`

### DIFF
--- a/artiq/test/coredevice/test_embedding.py
+++ b/artiq/test/coredevice/test_embedding.py
@@ -464,7 +464,6 @@ class _EmptyList(EnvExperiment):
 
 
 class ListTupleTest(ExperimentCase):
-    @unittest.skip("NAC3TODO https://git.m-labs.hk/M-Labs/nac3/issues/529")
     def test_list_tuple(self):
         self.create(_ListTuple).run()
 


### PR DESCRIPTION
With [PR nac3#653](git.m-labs.hk/M-Labs/nac3/pulls/653), the failing `ListTupleTest` now passes and does not need to be skipped.

🔧 | Test

## Testing
All previously passing tests still pass, additionally the `ListTupleTest` also passes now.