### PR TITLE
feat: add `nac3_{free, malloc}`

### DIFF
--- a/artiq/firmware/ksupport/api.rs
+++ b/artiq/firmware/ksupport/api.rs
@@ -180,6 +180,9 @@ static mut API: &'static [(&'static str, *const ())] = &[
     api!(cxp_start_roi_viewer = ::cxp::start_roi_viewer),
     api!(cxp_download_roi_viewer_frame = ::cxp::download_roi_viewer_frame),
 
+    api!(nac3_free = ::mem::nac3_free),
+    api!(nac3_malloc = ::mem::nac3_malloc),
+
     /*
      * syscall for unit tests
      * Used in `artiq.tests.coredevice.test_exceptions.ExceptionTest.test_raise_exceptions_kernel`

--- a/artiq/firmware/ksupport/lib.rs
+++ b/artiq/firmware/ksupport/lib.rs
@@ -113,6 +113,7 @@ mod api;
 mod rtio;
 mod nrt_bus;
 mod cxp;
+mod mem;
 
 static mut LIBRARY: Option<Library<'static>> = None;
 

--- a/artiq/firmware/ksupport/mem.rs
+++ b/artiq/firmware/ksupport/mem.rs
@@ -1,0 +1,19 @@
+use alloc::alloc::{Layout, alloc, dealloc};
+use core::mem;
+
+pub unsafe extern "C" fn nac3_malloc(size: usize) -> *mut u8 {
+    let ptr = alloc(Layout::from_size_align_unchecked(size + mem::size_of::<usize>(), 8));
+    let size_ptr = ptr.cast::<usize>();
+    *size_ptr = size;
+
+    ptr.add(mem::size_of::<usize>())
+}
+
+pub unsafe extern "C" fn nac3_free(ptr: *mut u8) {
+    let size_ptr = ptr.sub(mem::size_of::<usize>()).cast::<usize>();
+
+    dealloc(
+        size_ptr.cast::<u8>(),
+        Layout::from_size_align_unchecked(*size_ptr + mem::size_of::<usize>(), 8),
+    );
+}


### PR DESCRIPTION
Same as adding dynamic memory allocation support to ARTIQ/Zynq.