### PR TITLE
GTP: Prohibit RX initialization before clock switch

### DIFF
--- a/artiq/gateware/drtio/transceiver/gtp_7series.py
+++ b/artiq/gateware/drtio/transceiver/gtp_7series.py
@@ -2,6 +2,7 @@ from functools import reduce
 from operator import or_
 
 from migen import *
+from migen.genlib.cdc import MultiReg
 from migen.genlib.resetsync import AsyncResetSynchronizer
 
 from misoc.cores.code_8b10b import Encoder, Decoder
@@ -44,6 +45,8 @@ class GTPSingle(Module):
             qpll_channel.reset.eq(tx_init.pllreset),
             tx_init.plllock.eq(qpll_channel.lock)
         ]
+
+        self.specials += MultiReg(tx_init.done, rx_init.tx_init_done)
 
         txdata = Signal(20)
         rxdata = Signal(20)

--- a/artiq/gateware/drtio/transceiver/gtp_7series_init.py
+++ b/artiq/gateware/drtio/transceiver/gtp_7series_init.py
@@ -180,6 +180,7 @@ class GTPRXInit(Module):
     def __init__(self, sys_clk_freq):
         self.done = Signal()
         self.restart = Signal()
+        self.tx_init_done = Signal()
 
         # GTP signals
         self.gtrxreset = Signal()
@@ -252,7 +253,11 @@ class GTPRXInit(Module):
         self.submodules += ready_timer
         self.comb += [
             ready_timer.wait.eq(~self.done & ~startup_fsm.reset),
-            startup_fsm.reset.eq(self.restart | ready_timer.done)
+            startup_fsm.reset.eq(
+                self.restart
+                | ready_timer.done
+                | ~self.tx_init_done    # No RX init before finalizing cd_sys
+            )
         ]
 
         cdr_stable_timer = WaitTimer(1024)


### PR DESCRIPTION
## Description
This PR disallows RX from initializing before switching sys clock. This is achieved by forcing the FSM to wait for TX to finish initialization.

## Motivating/Issue
Since the `GTPRXInit` is in `sys` clock domain, the clock switch interrupts the RX FSM through clock domain reset.
There is a chance that `rtio_rx` clock to be stuck at around 156.25 MHz after clock switch.

Normally, `rtio_rx` clock is expected to be switching in between one of the following:
- no signal, when under reset;
- 156.25 MHz, when DRP is being configured after RX reset (the divider in PMA is /4).
- 125 MHz, when initialized (such that the divider in PMA is /5);

When stuck at 156.25 MHz, RX link can never be acquired until reconfiguration.

This PR proposes putting RX after TX for these reasons:
1. TX init cannot start until the RX clock is established. Finishing TX init implies the clock is switched and `sys` clock is ready.
2. We can assume the PLL is locked (checked by TX) and not having to check it in RX as suggested by UG482.