### PR TITLE
firmware: flush uart before reboot

### DIFF
--- a/artiq/firmware/libboard_misoc/uart.rs
+++ b/artiq/firmware/libboard_misoc/uart.rs
@@ -6,3 +6,7 @@ pub fn set_speed(rate: u32) {
         csr::uart_phy::tuning_word_write(tuning_word as u32);
     }
 }
+
+pub fn flush() {
+    unsafe { while csr::uart::txempty_read() == 0 {} }
+}

--- a/artiq/firmware/runtime/main.rs
+++ b/artiq/firmware/runtime/main.rs
@@ -402,6 +402,7 @@ pub fn panic_impl(info: &core::panic::PanicInfo) -> ! {
         println!("restarting...");
         unsafe {
             kernel::stop();
+            board_misoc::uart::flush();
             spiflash::reload();
         }
     } else {

--- a/artiq/firmware/runtime/mgmt.rs
+++ b/artiq/firmware/runtime/mgmt.rs
@@ -145,6 +145,7 @@ mod local_coremgmt {
         stream.flush()?;
 
         warn!("restarting");
+        board_misoc::uart::flush();
         unsafe { spiflash::reload(); }
     }
 

--- a/artiq/firmware/satman/main.rs
+++ b/artiq/firmware/satman/main.rs
@@ -628,6 +628,7 @@ fn process_aux_packet(dmamgr: &mut DmaManager, analyzer: &mut Analyzer, kernelmg
 
             drtioaux::send(0, &drtioaux::Packet::CoreMgmtReply { succeeded: true })?;
             warn!("restarting");
+            board_misoc::uart::flush();
             unsafe { spiflash::reload(); }
         }
         drtioaux::Packet::CoreMgmtFlashRequest { destination: _destination, payload_length } => {
@@ -661,6 +662,7 @@ fn process_aux_packet(dmamgr: &mut DmaManager, analyzer: &mut Analyzer, kernelmg
 
             coremgr.flash_image();
             warn!("restarting");
+            board_misoc::uart::flush();
             unsafe { spiflash::reload(); }
         }
         drtioaux::Packet::CXPReadRequest { destination: _destination, .. }


### PR DESCRIPTION
### Flush UART before rebooting with `artiq_coremgmt`

Needs https://github.com/m-labs/misoc/pull/173.

Delays until the UART tx fifo is empty. 

#### Testing
Runtime firmware builds, UART log flushes correctly on reboot. Passes HITL tests.
Satman firmware builds. DRTIO setups not tested.