### PR TITLE
nac3: Fix DDS compilation errors

### DIFF
--- a/artiq/coredevice/urukul.py
+++ b/artiq/coredevice/urukul.py
@@ -769,7 +769,7 @@ class CPLD:
         if io_update_device is not None:
             self.io_update = dmgr.get(io_update_device)
         else:
-            self.io_update = RegIOUpdate(self.core, self)
+            self.io_update = io_update_device
         if dds_reset_device is not None:
             self.dds_reset = Some(dmgr.get(dds_reset_device))
         else:

--- a/artiq/test/coredevice/test_ad9910.py
+++ b/artiq/test/coredevice/test_ad9910.py
@@ -150,7 +150,7 @@ class AD9910Exp(EnvExperiment):
         self.dev.set_frequency(f)
         self.dev.set_phase(p)
         self.dev.set_amplitude(a)
-        self.dev.io_update.pulse_mu(8)
+        self.dev.io_update.pulse_mu(int64(8))
 
         self.core.break_realtime()
         ftw = self.dev.get_ftw()
@@ -184,8 +184,8 @@ class AD9910Exp(EnvExperiment):
         self.dev.write64(_AD9910_REG_PROFILE0 + DEFAULT_PROFILE, hi, lo)
         self.dev.io_update.pulse_mu(int64(8))
         read = self.dev.read64(_AD9910_REG_PROFILE0 + DEFAULT_PROFILE)
-        self.set_dataset("write", (int64(hi) << 32) | int64(lo))
-        self.set_dataset("read", read)
+        self.report_int64("write", (int64(hi) << 32) | int64(lo))
+        self.report_int64("read", read)
         if not self.io_update_device:
             self.core.break_realtime()
             # Unset MASK_NU to un-trigger CFG.IO_UPDATE


### PR DESCRIPTION
## Bug Fix
Includes these items:
- Make DDS driver to hold I/O update reference, instead of the PLD. This is already introduced in the `master` branch.
- Fixes various AD9910 and AD9912 tests.

Passes `test_ad9910` and `test_ad9912` unit tests.