### PR TITLE
artiq_coremgmt: improve logging when flashing

### DIFF
--- a/artiq/coredevice/comm_mgmt.py
+++ b/artiq/coredevice/comm_mgmt.py
@@ -79,7 +79,11 @@ class CommMgmt:
     # Protocol elements
 
     def _write(self, data):
-        self.socket.sendall(data)
+        total_sent = 0
+        while total_sent < len(data):
+            sent = self.socket.send(data[total_sent:])
+            total_sent += sent
+            logger.debug("sent %d bytes", sent)
 
     def _write_header(self, ty):
         self.open()

--- a/artiq/coredevice/comm_mgmt.py
+++ b/artiq/coredevice/comm_mgmt.py
@@ -206,6 +206,7 @@ class CommMgmt:
 
         with io.BytesIO() as image_buf:
             for filename in bin_paths:
+                logger.debug("writing %s to byte buffer", filename)
                 with open(filename, "rb") as fi:
                     bin_ = fi.read()
                     if (len(bin_paths) > 1):
@@ -216,6 +217,7 @@ class CommMgmt:
             crc = binascii.crc32(image_buf.getvalue())
             image_buf.write(struct.pack(self.endian + "I", crc))
 
+            logger.debug("sending byte buffer to core device")
             self._write_bytes(image_buf.getvalue())
 
         self._read_expect(Reply.RebootImminent)

--- a/artiq/frontend/artiq_coremgmt.py
+++ b/artiq/frontend/artiq_coremgmt.py
@@ -5,6 +5,7 @@ import os
 import struct
 import tempfile
 import atexit
+import logging
 
 from sipyco import common_args
 
@@ -13,6 +14,8 @@ from artiq.master.databases import DeviceDB
 from artiq.coredevice.comm_kernel import CommKernel
 from artiq.coredevice.comm_mgmt import CommMgmt
 from artiq.frontend.flash_tools import bit2bin, fetch_bin
+
+logger = logging.getLogger(__name__)
 
 
 def get_argparser():
@@ -147,7 +150,7 @@ def main():
         if args.action == "read":
             value = mgmt.config_read(args.key)
             if not value:
-                print("Key {} does not exist".format(args.key))
+                logger.error("Key {} does not exist".format(args.key))
             else:
                 print(value)
         if args.action == "write":
@@ -175,6 +178,8 @@ def main():
             ],
         }
 
+        logger.info("Retrieving binaries...")
+
         for bin_list in bin_dict.values():
             try:
                 bins = []
@@ -192,8 +197,12 @@ def main():
             raise ValueError("both risc-v and zynq binaries were found, "
                              "please clean up your build directory. ")
 
+        logger.info("Flashing core device...")
+
         bins = retrieved_bins[0]
         mgmt.flash(bins)
+
+        logger.info("Rebooting core device.")
 
     if args.tool == "reboot":
         mgmt.reboot()

--- a/artiq/frontend/flash_tools.py
+++ b/artiq/frontend/flash_tools.py
@@ -1,7 +1,10 @@
 import atexit
+import logging
 import os
 import tempfile
 import struct
+
+logger = logging.getLogger(__name__)
 
 
 def artifact_path(this_binary_dir, *path_filename, srcbuild=False):
@@ -99,14 +102,14 @@ def bit2bin(bit, bin, flip=False):
                     "c": "Date",
                     "d": "Time"
                     }[key]
-            print("{}: {}".format(name, d))
+            logger.debug("{}: {}".format(name, d))
         elif key == "e":
             l, = struct.unpack(">I", bit.read(4))
-            print("Bitstream payload length: {:#x}".format(l))
+            logger.debug("Bitstream payload length: {:#x}".format(l))
             d = bit.read(l)
             if flip:
                 d = flip32(d)
             bin.write(d)
         else:
             d = bit.read(*struct.unpack(">H", bit.read(2)))
-            print("Unexpected key: {}: {}".format(key, d))
+            logger.error("Unexpected key: {}: {}".format(key, d))


### PR DESCRIPTION
Uses `logging` module in `artiq_coremgmt`, and adds additional logging when running `artiq_coremgmt flash`. 

Example output of `artiq_coremgmt -vv flash ...`:

```
INFO:__main__:Retrieving binaries...
DEBUG:artiq.frontend.flash_tools:converting gateware bit file to bin
DEBUG:artiq.frontend.flash_tools:Design: top;COMPRESS=TRUE;UserID=FFFFFFFF;Version=2024.2
DEBUG:artiq.frontend.flash_tools:Part name: 7a100tfgg484
DEBUG:artiq.frontend.flash_tools:Date: 2025/08/07
DEBUG:artiq.frontend.flash_tools:Time: 15:21:14
DEBUG:artiq.frontend.flash_tools:Bitstream payload length: 0x2bc888
INFO:__main__:Flashing core device...
DEBUG:artiq.coredevice.comm_mgmt:sent 1 bytes
DEBUG:artiq.coredevice.comm_mgmt:sending message: type=<Request.Flash: 9>
DEBUG:artiq.coredevice.comm_mgmt:sent 1 bytes
DEBUG:artiq.coredevice.comm_mgmt:writing /tmp/nix-shell.EvDsLr/artiq_pdcn6b2g_top.bit to byte buffer
DEBUG:artiq.coredevice.comm_mgmt:writing artiq_kasli/minimal/software/bootloader/bootloader.bin to byte buffer
DEBUG:artiq.coredevice.comm_mgmt:writing artiq_kasli/minimal/software/runtime/runtime.fbi to byte buffer
DEBUG:artiq.coredevice.comm_mgmt:sending byte buffer to core device
DEBUG:artiq.coredevice.comm_mgmt:sent 4 bytes
DEBUG:artiq.coredevice.comm_mgmt:sent 4886580 bytes
DEBUG:artiq.coredevice.comm_mgmt:receiving message: type=<Reply.RebootImminent: 3>
INFO:__main__:Rebooting core device.
```

