### PR TITLE
NAC3: Test core exception traceback

### DIFF
--- a/artiq/test/coredevice/test_exceptions.py
+++ b/artiq/test/coredevice/test_exceptions.py
@@ -1,10 +1,12 @@
 import unittest
+import linecache
 import artiq.coredevice.exceptions as exceptions
 
 from artiq.experiment import *
 from artiq.test.hardware_testbench import ExperimentCase
 from artiq.language.embedding_map import EmbeddingMap
-from artiq.coredevice.core import test_exception_id_sync
+from artiq.coredevice.core import Core, test_exception_id_sync
+from artiq.coredevice.dma import CoreDMA
 from numpy import int32
 
 """
@@ -58,3 +60,50 @@ class ExceptionTest(ExperimentCase):
             name = name.split('.')[-1].split(':')[-1]
             with self.assertRaises(getattr(exceptions, name)) as ctx:
                 exp.raise_exception_host(id)
+
+
+@compile
+class CoreExceptionTraceback(EnvExperiment):
+    core: KernelInvariant[Core]
+    core_dma: KernelInvariant[CoreDMA]
+    trace_name: KernelInvariant[str]
+
+    def build(self):
+        self.setattr_device("core")
+        self.setattr_device("core_dma")
+        self.trace_name = "dummy_trace"
+    
+    @kernel
+    def run(self):
+        self.core_dma.prepare_record(self.trace_name)
+        with self.core_dma.recorder:
+            pass
+        self.core_dma.erase(self.trace_name)
+        self.core_dma.playback(self.trace_name)
+
+
+class TracebackTest(ExperimentCase):
+    def test_core_exception_traceback(self):
+        with self.assertRaises(exceptions.DMAError) as exn_context:
+            self.execute(CoreExceptionTraceback)
+
+        core_exn = exn_context.exception.artiq_core_exception
+        traceback = core_exn.traceback[core_exn.exception_info[0][1]:]
+        self.assertGreater(len(traceback), 0, "traceback is missing")
+
+        def get_backtrace_records():
+            for filename, line, *_, inlined in traceback:
+                for inlined_filename, inlined_line, *_ in reversed(inlined):
+                    yield inlined_filename, inlined_line
+                yield filename, line
+
+        for filename, line in get_backtrace_records():
+            source_line = linecache.getline(filename, line)
+            if source_line:
+                self.assertEqual(
+                    source_line.strip(),
+                    "self.core_dma.playback(self.trace_name)",
+                    "traceback found an incorrect source of exception")
+                return
+
+        self.fail("traceback failed to find the source of exception")


### PR DESCRIPTION
Regression test for [NAC3 666](https://git.m-labs.hk/M-Labs/nac3/issues/666).

2 things are tested:
- A traceback is generated
- the source of the exception is correctly reported

DMA error is chosen so this unit test would not be locked behind any specific peripheral entries.

### Test
On both Kasli and Kasli-SoC, this unit test passes after [adding the debug sections](https://git.m-labs.hk/M-Labs/nac3/pulls/671), fails otherwise.