### PR TITLE
Exception: Fix traceback ordering when not inlined

### DIFF
--- a/artiq/coredevice/comm_kernel.py
+++ b/artiq/coredevice/comm_kernel.py
@@ -239,10 +239,11 @@ class CoreException:
     def single_traceback(self, exception_index):
         # note that we insert in reversed order
         lines = []
-        last_sp = 0
         start_backtrace_index = self.exception_info[exception_index][1]
-        zipped = list(zip(self.traceback[start_backtrace_index:],
-                          self.stack_pointers[start_backtrace_index:]))
+        end_backtrace_index = self.exception_info[exception_index][2]
+        zipped = list(zip(
+            self.traceback[start_backtrace_index:end_backtrace_index],
+            self.stack_pointers[start_backtrace_index:end_backtrace_index]))
         exception = self.exceptions[exception_index]
         name = exception[0]
         message = exception[1]


### PR DESCRIPTION
Fixes traceback ordering, which causes failing test in NAC3 when optimization level is 0.

### Background
When compiling without optimization, function calls are not inlined. Inlined entries generate a traceback with the most recent invocation appearing first.
However, there are no mechanism to also reverse the non-inlined backtrace. The original implementation will keep non-inlined backtrace with the least recent invocation appearing first.
This causes the test to fail when the compiler do not perform inlining, as internal DMA driver code (the callee) appears after the DMA API code (the caller).

Same issue can be reproduced in the legacy compiler when LLVM optimizations are disabled.

### Changes
https://github.com/m-labs/artiq/commit/9638c1ed88e5a7b4ef909f3592c9a4c76cd2e3d8 implements the missing reversal.
https://github.com/m-labs/artiq/commit/4b02b6502afb373a7dfe9ae663bce0f5c3047da3 constraints each individual traceback to its own supplied traceback addresses.

Specifically, the second commit is meant to address this issue with nested exceptions. Consider this kernel:
```python
    @kernel
    def run(self):
        self.core_dma.prepare_record(self.trace_name)
        with self.core_dma.recorder:
            pass
        self.core_dma.erase(self.trace_name)
        try:
            self.core_dma.playback(self.trace_name)
        except DMAError:
            raise ValueError(self.trace_name)
```

Will result in this traceback:
```
Core Device Traceback:
Traceback (most recent call first):
  File "ksupport/lib.rs", line 394, column 10, in (Rust function)
    <unknown>
             ^
  File "dma.py", line 67, in .Lpcrel_hi7 (RA=+0x360)
    raise ValueError(self.trace_name)
  File "<artiq>/coredevice/dma.py", line 116, in artiq.coredevice.dma.CoreDMA.playback.0 (RA=+0x250)
    (advance_mu, ptr, uses_ddma) = dma_retrieve(name)
  File "dma.py", line 65, in .Lpcrel_hi7 (inlined)
    self.core_dma.playback(self.trace_name)
artiq.coredevice.exceptions.DMAError(0): DMA trace not found

During handling of the above exception, another exception occurred:

Traceback (most recent call first):
  File "dma.py", line 67, column 14, in artiq_run_dma.DMATest.run.0
    raise ValueError(self.trace_name)
     ^
  File "dma.py", line 67, in .Lpcrel_hi7 (RA=+0x360)
    raise ValueError(self.trace_name)
  File "<nac3_internal>", line 2, in __modinit__ (RA=+0xe4)
    <unknown>
ValueError(0): dummy_trace

End of Core Device Traceback
```

Note that `raise ValueError(self.trace_name)` is included twice. The first inclusion seems to suggest that raising the `ValueError` causes the `DMAError`.

This PR is WIP because
- [x] Yet to be ported to legacy compiler/master;
- [x] ~~Given that we constrain the traceback to itself, we should not need to care about the stack pointers.~~ Will be better to incorporate into a separate PR.

### Related PR
#1831 