### PR TITLE
Coremgmt: use config log_level

### DIFF
--- a/artiq/coredevice/comm_mgmt.py
+++ b/artiq/coredevice/comm_mgmt.py
@@ -13,8 +13,6 @@ class Request(Enum):
     GetLog = 1
     ClearLog = 2
     PullLog = 7
-    SetLogFilter = 3
-    SetUartLogFilter = 6
 
     ConfigRead = 12
     ConfigWrite = 13
@@ -38,15 +36,6 @@ class Reply(Enum):
     ConfigData = 7
 
     RebootImminent = 3
-
-
-class LogLevel(Enum):
-    OFF = 0
-    ERROR = 1
-    WARN = 2
-    INFO = 3
-    DEBUG = 4
-    TRACE = 5
 
 
 class CommMgmt:
@@ -146,22 +135,6 @@ class CommMgmt:
         self._write_header(Request.PullLog)
         self._read_expect(Reply.LogContent)
         return self._read_string()
-
-    def set_log_level(self, level):
-        if level not in LogLevel.__members__:
-            raise ValueError("invalid log level {}".format(level))
-
-        self._write_header(Request.SetLogFilter)
-        self._write_int8(getattr(LogLevel, level).value)
-        self._read_expect(Reply.Success)
-
-    def set_uart_log_level(self, level):
-        if level not in LogLevel.__members__:
-            raise ValueError("invalid log level {}".format(level))
-
-        self._write_header(Request.SetUartLogFilter)
-        self._write_int8(getattr(LogLevel, level).value)
-        self._read_expect(Reply.Success)
 
     def config_read(self, key):
         self._write_header(Request.ConfigRead)

--- a/artiq/examples/kasli_shuttler/kasli_shuttler.json
+++ b/artiq/examples/kasli_shuttler/kasli_shuttler.json
@@ -4,6 +4,16 @@
     "hw_rev": "v2.0",
     "drtio_role": "master",
     "peripherals": [
-
+        {
+            "type": "shuttler",
+            "hw_rev": "v1.1",
+            "ports": [0]
+        },
+        {
+            "type": "dio",
+            "ports": [1],
+            "bank_direction_low": "input",
+            "bank_direction_high": "output"
+        }
     ]
 }   

--- a/artiq/firmware/liblogger_artiq/lib.rs
+++ b/artiq/firmware/liblogger_artiq/lib.rs
@@ -11,18 +11,6 @@ use log::{Log, LevelFilter};
 use log_buffer::LogBuffer;
 use board_misoc::clock;
 
-pub enum LogError{
-    Utf8Error(core::str::Utf8Error),
-    ParseError,
-    KeyNotFound
-}
-
-impl From<core::str::Utf8Error> for LogError {
-    fn from(error: core::str::Utf8Error) -> Self {
-        LogError::Utf8Error(error)
-    }
-}
-
 pub struct LogBufferRef<'a> {
     buffer:        RefMut<'a, LogBuffer<&'static mut [u8]>>,
     old_log_level: LevelFilter
@@ -111,26 +99,6 @@ impl BufferLogger {
     pub fn set_buffer_log_level(&self, max_level: LevelFilter) {
         self.buffer_filter.set(max_level);
         self.update_global_log_level()
-    }
-
-    pub fn set_log_filter_level(&self, key: &str, value: &[u8]) -> Result<(), LogError> {
-        let value_str = core::str::from_utf8(value)?;
-        let max_level = value_str.parse::<LevelFilter>()
-            .map_err(|_| LogError::ParseError)?;
-
-        match key{
-            "log_level" => {
-                self.set_buffer_log_level(max_level);
-                log::info!("changing log level to {}", max_level);
-            }
-            "uart_log_level" => {
-                self.set_uart_log_level(max_level);
-                log::info!("changing UART log level to {}", max_level);
-            }
-            _ => return Err(LogError::KeyNotFound)
-        }
-
-        Ok(())
     }
 
     pub fn update_global_log_level(&self){

--- a/artiq/firmware/libproto_artiq/drtioaux_proto.rs
+++ b/artiq/firmware/libproto_artiq/drtioaux_proto.rs
@@ -136,8 +136,6 @@ pub enum Packet {
 
     CoreMgmtGetLogRequest { destination: u8, clear: bool },
     CoreMgmtClearLogRequest { destination: u8 },
-    CoreMgmtSetLogLevelRequest { destination: u8, log_level: u8 },
-    CoreMgmtSetUartLogLevelRequest { destination: u8, log_level: u8 },
     CoreMgmtConfigReadRequest { destination: u8, length: u16, key: [u8; MASTER_PAYLOAD_MAX_SIZE] },
     CoreMgmtConfigReadContinue { destination: u8 },
     CoreMgmtConfigWriteRequest { destination: u8, last: bool, length: u16, data: [u8; MASTER_PAYLOAD_MAX_SIZE] },
@@ -448,15 +446,7 @@ impl Packet {
             0xd1 => Packet::CoreMgmtClearLogRequest {
                 destination: reader.read_u8()?,
             },
-            0xd2 => Packet::CoreMgmtSetLogLevelRequest {
-                destination: reader.read_u8()?,
-                log_level: reader.read_u8()?,
-            },
-            0xd3 => Packet::CoreMgmtSetUartLogLevelRequest {
-                destination: reader.read_u8()?,
-                log_level: reader.read_u8()?,
-            },
-            0xd4 => {
+            0xd2 => {
                 let destination = reader.read_u8()?;
                 let length = reader.read_u16()?;
                 let mut key: [u8; MASTER_PAYLOAD_MAX_SIZE] = [0; MASTER_PAYLOAD_MAX_SIZE];
@@ -467,10 +457,10 @@ impl Packet {
                     key: key,
                 }
             },
-            0xd5 => Packet::CoreMgmtConfigReadContinue {
+            0xd3 => Packet::CoreMgmtConfigReadContinue {
                 destination: reader.read_u8()?,
             },
-            0xd6 => {
+            0xd4 => {
                 let destination = reader.read_u8()?;
                 let last = reader.read_bool()?;
                 let length = reader.read_u16()?;
@@ -483,7 +473,7 @@ impl Packet {
                     data: data,
                 }
             },
-            0xd7 => {
+            0xd5 => {
                 let destination = reader.read_u8()?;
                 let length = reader.read_u16()?;
                 let mut key: [u8; MASTER_PAYLOAD_MAX_SIZE] = [0; MASTER_PAYLOAD_MAX_SIZE];
@@ -494,20 +484,20 @@ impl Packet {
                     key: key,
                 }
             },
-            0xd8 => Packet::CoreMgmtConfigEraseRequest {
+            0xd6 => Packet::CoreMgmtConfigEraseRequest {
                 destination: reader.read_u8()?,
             },
-            0xd9 => Packet::CoreMgmtRebootRequest {
+            0xd7 => Packet::CoreMgmtRebootRequest {
                 destination: reader.read_u8()?,
             },
-            0xda => Packet::CoreMgmtAllocatorDebugRequest {
+            0xd8 => Packet::CoreMgmtAllocatorDebugRequest {
                 destination: reader.read_u8()?,
             },
-            0xdb => Packet::CoreMgmtFlashRequest {
+            0xd9 => Packet::CoreMgmtFlashRequest {
                 destination: reader.read_u8()?,
                 payload_length: reader.read_u32()?,
             },
-            0xdc => {
+            0xda => {
                 let destination = reader.read_u8()?;
                 let last = reader.read_bool()?;
                 let length = reader.read_u16()?;
@@ -520,11 +510,11 @@ impl Packet {
                     data: data,
                 }
             },
-            0xdd => Packet::CoreMgmtDropLinkAck {
+            0xdb => Packet::CoreMgmtDropLinkAck {
                 destination: reader.read_u8()?,
             },
-            0xde => Packet::CoreMgmtDropLink,
-            0xdf => {
+            0xdc => Packet::CoreMgmtDropLink,
+            0xdd => {
                 let last = reader.read_bool()?;
                 let length = reader.read_u16()?;
                 let mut data: [u8; SAT_PAYLOAD_MAX_SIZE] = [0; SAT_PAYLOAD_MAX_SIZE];
@@ -535,7 +525,7 @@ impl Packet {
                     data: data,
                 }
             },
-            0xe0 => {
+            0xde => {
                 let last = reader.read_bool()?;
                 let length = reader.read_u16()?;
                 let mut value: [u8; SAT_PAYLOAD_MAX_SIZE] = [0; SAT_PAYLOAD_MAX_SIZE];
@@ -546,45 +536,45 @@ impl Packet {
                     value: value,
                 }
             },
-            0xe1 => Packet::CoreMgmtReply {
+            0xdf => Packet::CoreMgmtReply {
                 succeeded: reader.read_bool()?,
             },
-            0xe2 => {
+            0xe0 => {
                 let length = reader.read_u16()?;
                 let mut message: [u8; CXP_PAYLOAD_MAX_SIZE] = [0; CXP_PAYLOAD_MAX_SIZE];
                 reader.read_exact(&mut message[0..length as usize])?;
                 Packet::CXPError { length, message }
             }
-            0xe3 => Self::CXPWaitReply,
-            0xe4 => Packet::CXPReadRequest {
+            0xe1 => Self::CXPWaitReply,
+            0xe2 => Packet::CXPReadRequest {
                 destination: reader.read_u8()?,
                 address: reader.read_u32()?,
                 length: reader.read_u16()?,
             },
-            0xe5 => {
+            0xe3 => {
                 let length = reader.read_u16()?;
                 let mut data: [u8; CXP_PAYLOAD_MAX_SIZE] = [0; CXP_PAYLOAD_MAX_SIZE];
                 reader.read_exact(&mut data[0..length as usize])?;
                 Packet::CXPReadReply { length, data }
             }
-            0xe6 => Packet::CXPWrite32Request {
+            0xe4 => Packet::CXPWrite32Request {
                 destination: reader.read_u8()?,
                 address: reader.read_u32()?,
                 value: reader.read_u32()?,
             },
-            0xe7 => Packet::CXPWrite32Reply,
-            0xe8 => Packet::CXPROIViewerSetupRequest {
+            0xe5 => Packet::CXPWrite32Reply,
+            0xe6 => Packet::CXPROIViewerSetupRequest {
                 destination: reader.read_u8()?,
                 x0: reader.read_u16()?,
                 y0: reader.read_u16()?,
                 x1: reader.read_u16()?,
                 y1: reader.read_u16()?,
             },
-            0xe9 => Packet::CXPROIViewerSetupReply,
-            0xea => Packet::CXPROIViewerDataRequest {
+            0xe7 => Packet::CXPROIViewerSetupReply,
+            0xe8 => Packet::CXPROIViewerDataRequest {
                 destination: reader.read_u8()?,
             },
-            0xeb => {
+            0xe9 => {
                 let length = reader.read_u16()?;
                 let mut data: [u64; CXP_PAYLOAD_MAX_SIZE / 8] = [0; CXP_PAYLOAD_MAX_SIZE / 8];
                 for i in 0..length as usize {
@@ -592,7 +582,7 @@ impl Packet {
                 }
                 Packet::CXPROIViewerPixelDataReply { length, data }
             }
-            0xec => Packet::CXPROIViewerFrameDataReply {
+            0xea => Packet::CXPROIViewerFrameDataReply {
                 width: reader.read_u16()?,
                 height: reader.read_u16()?,
                 pixel_code: reader.read_u16()?,
@@ -896,28 +886,18 @@ impl Packet {
                 writer.write_u8(0xd1)?;
                 writer.write_u8(destination)?;
             },
-            Packet::CoreMgmtSetLogLevelRequest { destination, log_level } => {
-                writer.write_u8(0xd2)?;
-                writer.write_u8(destination)?;
-                writer.write_u8(log_level)?;
-            },
-            Packet::CoreMgmtSetUartLogLevelRequest { destination, log_level } => {
-                writer.write_u8(0xd3)?;
-                writer.write_u8(destination)?;
-                writer.write_u8(log_level)?;
-            },
             Packet::CoreMgmtConfigReadRequest {
                 destination,
                 length,
                 key,
             } => {
-                writer.write_u8(0xd4)?;
+                writer.write_u8(0xd2)?;
                 writer.write_u8(destination)?;
                 writer.write_u16(length)?;
                 writer.write_all(&key[0..length as usize])?;
             },
             Packet::CoreMgmtConfigReadContinue { destination } => {
-                writer.write_u8(0xd5)?;
+                writer.write_u8(0xd3)?;
                 writer.write_u8(destination)?;
             },
             Packet::CoreMgmtConfigWriteRequest {
@@ -926,7 +906,7 @@ impl Packet {
                 length,
                 data,
             } => {
-                writer.write_u8(0xd6)?;
+                writer.write_u8(0xd4)?;
                 writer.write_u8(destination)?;
                 writer.write_bool(last)?;
                 writer.write_u16(length)?;
@@ -937,77 +917,77 @@ impl Packet {
                 length,
                 key,
             } => {
-                writer.write_u8(0xd7)?;
+                writer.write_u8(0xd5)?;
                 writer.write_u8(destination)?;
                 writer.write_u16(length)?;
                 writer.write_all(&key[0..length as usize])?;
             },
             Packet::CoreMgmtConfigEraseRequest { destination } => {
-                writer.write_u8(0xd8)?;
+                writer.write_u8(0xd6)?;
                 writer.write_u8(destination)?;
             },
             Packet::CoreMgmtRebootRequest { destination } => {
-                writer.write_u8(0xd9)?;
+                writer.write_u8(0xd7)?;
                 writer.write_u8(destination)?;
             },
             Packet::CoreMgmtAllocatorDebugRequest { destination } => {
-                writer.write_u8(0xda)?;
+                writer.write_u8(0xd8)?;
                 writer.write_u8(destination)?;
             },
             Packet::CoreMgmtFlashRequest { destination, payload_length } => {
-                writer.write_u8(0xdb)?;
+                writer.write_u8(0xd9)?;
                 writer.write_u8(destination)?;
                 writer.write_u32(payload_length)?;
             },
             Packet::CoreMgmtFlashAddDataRequest { destination, last, length, data } => {
-                writer.write_u8(0xdc)?;
+                writer.write_u8(0xda)?;
                 writer.write_u8(destination)?;
                 writer.write_bool(last)?;
                 writer.write_u16(length)?;
                 writer.write_all(&data[..length as usize])?;
             },
             Packet::CoreMgmtDropLinkAck { destination } => {
-                writer.write_u8(0xdd)?;
+                writer.write_u8(0xdb)?;
                 writer.write_u8(destination)?;
             },
             Packet::CoreMgmtDropLink => 
-                writer.write_u8(0xde)?,
+                writer.write_u8(0xdc)?,
             Packet::CoreMgmtGetLogReply { last, length, data } => {
-                writer.write_u8(0xdf)?;
+                writer.write_u8(0xdd)?;
                 writer.write_bool(last)?;
                 writer.write_u16(length)?;
                 writer.write_all(&data[0..length as usize])?;
             },
             Packet::CoreMgmtConfigReadReply { last, length, value } => {
-                writer.write_u8(0xe0)?;
+                writer.write_u8(0xde)?;
                 writer.write_bool(last)?;
                 writer.write_u16(length)?;
                 writer.write_all(&value[0..length as usize])?;
             },
             Packet::CoreMgmtReply { succeeded } => {
-                writer.write_u8(0xe1)?;
+                writer.write_u8(0xdf)?;
                 writer.write_bool(succeeded)?;
             },
             Packet::CXPError { length, message } => {
-                writer.write_u8(0xe2)?;
+                writer.write_u8(0xe0)?;
                 writer.write_u16(length)?;
                 writer.write_all(&message[0..length as usize])?;
             }
             Packet::CXPWaitReply => {
-                writer.write_u8(0xe3)?;
+                writer.write_u8(0xe1)?;
             }
             Packet::CXPReadRequest {
                 destination,
                 address,
                 length,
             } => {
-                writer.write_u8(0xe4)?;
+                writer.write_u8(0xe2)?;
                 writer.write_u8(destination)?;
                 writer.write_u32(address)?;
                 writer.write_u16(length)?;
             }
             Packet::CXPReadReply { length, data } => {
-                writer.write_u8(0xe5)?;
+                writer.write_u8(0xe3)?;
                 writer.write_u16(length)?;
                 writer.write_all(&data[0..length as usize])?;
             }
@@ -1016,13 +996,13 @@ impl Packet {
                 address,
                 value,
             } => {
-                writer.write_u8(0xe6)?;
+                writer.write_u8(0xe4)?;
                 writer.write_u8(destination)?;
                 writer.write_u32(address)?;
                 writer.write_u32(value)?;
             }
             Packet::CXPWrite32Reply => {
-                writer.write_u8(0xe7)?;
+                writer.write_u8(0xe5)?;
             }
             Packet::CXPROIViewerSetupRequest {
                 destination,
@@ -1031,7 +1011,7 @@ impl Packet {
                 x1,
                 y1,
             } => {
-                writer.write_u8(0xe8)?;
+                writer.write_u8(0xe6)?;
                 writer.write_u8(destination)?;
                 writer.write_u16(x0)?;
                 writer.write_u16(y0)?;
@@ -1039,14 +1019,14 @@ impl Packet {
                 writer.write_u16(y1)?;
             }
             Packet::CXPROIViewerSetupReply => {
-                writer.write_u8(0xe9)?;
+                writer.write_u8(0xe7)?;
             }
             Packet::CXPROIViewerDataRequest { destination } => {
-                writer.write_u8(0xea)?;
+                writer.write_u8(0xe8)?;
                 writer.write_u8(destination)?;
             }
             Packet::CXPROIViewerPixelDataReply { length, data } => {
-                writer.write_u8(0xeb)?;
+                writer.write_u8(0xe9)?;
                 writer.write_u16(length)?;
                 for i in 0..length as usize {
                     writer.write_u64(data[i])?;
@@ -1057,7 +1037,7 @@ impl Packet {
                 height,
                 pixel_code,
             } => {
-                writer.write_u8(0xec)?;
+                writer.write_u8(0xea)?;
                 writer.write_u16(width)?;
                 writer.write_u16(height)?;
                 writer.write_u16(pixel_code)?;

--- a/artiq/firmware/libproto_artiq/mgmt_proto.rs
+++ b/artiq/firmware/libproto_artiq/mgmt_proto.rs
@@ -1,7 +1,5 @@
 use core::str::Utf8Error;
 use alloc::{vec::Vec, string::String};
-#[cfg(feature = "log")]
-use log;
 
 use io::{Read, ProtoRead, Write, ProtoWrite, Error as IoError, ReadStringError};
 
@@ -11,8 +9,8 @@ pub enum Error<T> {
     WrongMagic,
     #[fail(display = "unknown packet {:#02x}", _0)]
     UnknownPacket(u8),
-    #[fail(display = "unknown log level {}", _0)]
-    UnknownLogLevel(u8),
+    #[fail(display = "unknown log level")]
+    UnknownLogLevel,
     #[fail(display = "invalid UTF-8: {}", _0)]
     Utf8(Utf8Error),
     #[fail(display = "{}", _0)]
@@ -61,10 +59,6 @@ pub enum Request {
     GetLog,
     ClearLog,
     PullLog,
-    #[cfg(feature = "log")]
-    SetLogFilter(log::LevelFilter),
-    #[cfg(feature = "log")]
-    SetUartLogFilter(log::LevelFilter),
 
     ConfigRead   { key: String },
     ConfigWrite  { key: String, value: Vec<u8> },
@@ -94,28 +88,10 @@ impl Request {
     pub fn read_from<R>(reader: &mut R) -> Result<Self, Error<R::ReadError>>
         where R: Read + ?Sized
     {
-        #[cfg(feature = "log")]
-        fn read_log_level_filter<T: Read + ?Sized>(reader: &mut T) ->
-                Result<log::LevelFilter, Error<T::ReadError>> {
-            Ok(match reader.read_u8()? {
-                0 => log::LevelFilter::Off,
-                1 => log::LevelFilter::Error,
-                2 => log::LevelFilter::Warn,
-                3 => log::LevelFilter::Info,
-                4 => log::LevelFilter::Debug,
-                5 => log::LevelFilter::Trace,
-                lv => return Err(Error::UnknownLogLevel(lv))
-            })
-        }
-
         Ok(match reader.read_u8()? {
             1  => Request::GetLog,
             2  => Request::ClearLog,
             7  => Request::PullLog,
-            #[cfg(feature = "log")]
-            3 => Request::SetLogFilter(read_log_level_filter(reader)?),
-            #[cfg(feature = "log")]
-            6 => Request::SetUartLogFilter(read_log_level_filter(reader)?),
 
             12 => Request::ConfigRead {
                 key: reader.read_string()?

--- a/artiq/firmware/runtime/mgmt.rs
+++ b/artiq/firmware/runtime/mgmt.rs
@@ -74,22 +74,6 @@ mod local_coremgmt {
         Ok(())
     }
 
-    pub fn set_log_filter(_io: &Io, stream: &mut TcpStream, level: LevelFilter) -> Result<(), Error<SchedError>> {
-        info!("changing log level to {}", level);
-        BufferLogger::with(|logger|
-            logger.set_buffer_log_level(level));
-        Reply::Success.write_to(stream)?;
-        Ok(())
-    }
-
-    pub fn set_uart_log_filter(_io: &Io, stream: &mut TcpStream, level: LevelFilter) -> Result<(), Error<SchedError>> {
-        info!("changing UART log level to {}", level);
-        BufferLogger::with(|logger|
-            logger.set_uart_log_level(level));
-        Reply::Success.write_to(stream)?;
-        Ok(())
-    }
-
     pub fn config_read(_io: &Io, stream: &mut TcpStream, key: &String) -> Result<(), Error<SchedError>>{
         config::read(key, |result| {
             match result {
@@ -101,28 +85,30 @@ mod local_coremgmt {
     }
 
     pub fn config_write(io: &Io, stream: &mut TcpStream, key: &String, value: &Vec<u8>, restart_idle: &Urc<Cell<bool>>) -> Result<(), Error<SchedError>> {
-        if key == "log_level" || key == "uart_log_level" {
-            let byte = value.first().copied().unwrap_or(255);
-            let value_str = core::str::from_utf8(value)
-                .map_err(Error::<SchedError>::from)?;
-            let max_level = value_str.parse::<LevelFilter>()
-                .map_err(|_| Error::<SchedError>::UnknownLogLevel(byte))?;
-
-            BufferLogger::with(|logger| {
-                if key == "log_level" {
-                    logger.set_buffer_log_level(max_level);
-                    log::info!("changing log level to {}", max_level);
-                } else {
-                    logger.set_uart_log_level(max_level);
-                    log::info!("changing UART log level to {}", max_level);
-                }
-            })
-        };
         match config::write(key, value) {
             Ok(_) => {
-                if key == "idle_kernel" {
-                    io.until(|| !restart_idle.get())?;
-                    restart_idle.set(true);
+                match key.as_str() {
+                    "idle_kernel" => {
+                        io.until(|| !restart_idle.get())?;
+                        restart_idle.set(true);
+                    }
+                    "log_level" | "uart_log_level" => {
+                        let value_str = core::str::from_utf8(value)
+                            .map_err(Error::<SchedError>::from)?;
+                        let max_level = value_str.parse::<LevelFilter>()
+                            .map_err(|_| Error::<SchedError>::UnknownLogLevel)?;
+
+                        BufferLogger::with(|logger| {
+                            if key == "log_level" {
+                                logger.set_buffer_log_level(max_level);
+                                log::info!("changing log level to {}", max_level);
+                            } else {
+                                logger.set_uart_log_level(max_level);
+                                log::info!("changing UART log level to {}", max_level);
+                            }
+                        })
+                    }
+                    _ => {}
                 }
                 Reply::Success.write_to(stream)?
             },
@@ -210,7 +196,6 @@ mod local_coremgmt {
 #[cfg(has_drtio)]
 mod remote_coremgmt {
     use alloc::{string::String, vec::Vec};
-    use log::LevelFilter;
 
     use board_artiq::{drtioaux, drtioaux::Packet};
     use io::ProtoWrite;
@@ -311,58 +296,6 @@ mod remote_coremgmt {
                     error!("aux packet error ({})", e);
                     return Err(e.into());
                 }
-            }
-        }
-    }
-
-    pub fn set_log_filter(io: &Io, aux_mutex: &Mutex,
-        ddma_mutex: &Mutex, subkernel_mutex: &Mutex, 
-        routing_table: &RoutingTable, linkno: u8,
-        destination: u8, stream: &mut TcpStream, level: LevelFilter) -> Result<(), Error<SchedError>> {
-        let reply = drtio::aux_transact(io, aux_mutex, ddma_mutex, subkernel_mutex, routing_table, linkno,
-            &Packet::CoreMgmtSetLogLevelRequest { destination, log_level: level as u8 }
-        );
-
-        match reply {
-            Ok(Packet::CoreMgmtReply { succeeded: true }) => {
-                Reply::Success.write_to(stream)?;
-                Ok(())
-            }
-            Ok(packet) => {
-                error!("received unexpected aux packet: {:?}", packet);
-                Reply::Error.write_to(stream)?;
-                Err(drtio::Error::UnexpectedReply.into())
-            }
-            Err(e) => {
-                error!("aux packet error ({})", e);
-                Reply::Error.write_to(stream)?;
-                Err(e.into())
-            }
-        }
-    }
-
-    pub fn set_uart_log_filter(io: &Io, aux_mutex: &Mutex,
-        ddma_mutex: &Mutex, subkernel_mutex: &Mutex, 
-        routing_table: &RoutingTable, linkno: u8,
-        destination: u8, stream: &mut TcpStream, level: LevelFilter) -> Result<(), Error<SchedError>> {
-        let reply = drtio::aux_transact(io, aux_mutex, ddma_mutex, subkernel_mutex, routing_table, linkno,
-            &Packet::CoreMgmtSetUartLogLevelRequest { destination, log_level: level as u8 }
-        );
-
-        match reply {
-            Ok(Packet::CoreMgmtReply { succeeded: true }) => {
-                Reply::Success.write_to(stream)?;
-                Ok(())
-            }
-            Ok(packet) => {
-                error!("received unexpected aux packet: {:?}", packet);
-                Reply::Error.write_to(stream)?;
-                Err(drtio::Error::UnexpectedReply.into())
-            }
-            Err(e) => {
-                error!("aux packet error ({})", e);
-                Reply::Error.write_to(stream)?;
-                Err(e.into())
             }
         }
     }
@@ -656,8 +589,6 @@ fn worker(io: &Io, stream: &mut TcpStream, restart_idle: &Urc<Cell<bool>>,
             Request::GetLog => process!(io, _aux_mutex, _ddma_mutex, _subkernel_mutex, _routing_table, stream, _destination, get_log),
             Request::ClearLog => process!(io, _aux_mutex, _ddma_mutex, _subkernel_mutex, _routing_table, stream, _destination, clear_log),
             Request::PullLog => process!(io, _aux_mutex, _ddma_mutex, _subkernel_mutex, _routing_table, stream, _destination, pull_log),
-            Request::SetLogFilter(level) => process!(io, _aux_mutex, _ddma_mutex, _subkernel_mutex, _routing_table, stream, _destination, set_log_filter, level),
-            Request::SetUartLogFilter(level) => process!(io, _aux_mutex, _ddma_mutex, _subkernel_mutex, _routing_table, stream, _destination, set_uart_log_filter, level),
             Request::ConfigRead { ref key } => process!(io, _aux_mutex, _ddma_mutex, _subkernel_mutex, _routing_table, stream, _destination, config_read, key),
             Request::ConfigWrite { ref key, ref value } => process!(io, _aux_mutex, _ddma_mutex, _subkernel_mutex, _routing_table, stream, _destination, config_write, key, value, restart_idle),
             Request::ConfigRemove { ref key } => process!(io, _aux_mutex, _ddma_mutex, _subkernel_mutex, _routing_table, stream, _destination, config_remove, key, restart_idle),

--- a/artiq/firmware/satman/main.rs
+++ b/artiq/firmware/satman/main.rs
@@ -525,30 +525,6 @@ fn process_aux_packet(dmamgr: &mut DmaManager, analyzer: &mut Analyzer, kernelmg
 
             drtioaux::send(0, &drtioaux::Packet::CoreMgmtReply { succeeded: mgmt::clear_log().is_ok() })
         }
-        drtioaux::Packet::CoreMgmtSetLogLevelRequest {destination: _destination, log_level } => {
-            forward!(router, _routing_table, _destination, *rank, *self_destination, _repeaters, &packet);
-
-            if let Ok(level_filter) = mgmt::byte_to_level_filter(log_level) {
-                info!("changing log level to {}", level_filter);
-                logger_artiq::BufferLogger::with(|logger|
-                    logger.set_buffer_log_level(level_filter));
-                drtioaux::send(0, &drtioaux::Packet::CoreMgmtReply { succeeded: true })
-            } else {
-                drtioaux::send(0, &drtioaux::Packet::CoreMgmtReply { succeeded: false })
-            }
-        }
-        drtioaux::Packet::CoreMgmtSetUartLogLevelRequest { destination: _destination, log_level } => {
-            forward!(router, _routing_table, _destination, *rank, *self_destination, _repeaters, &packet);
-
-            if let Ok(level_filter) = mgmt::byte_to_level_filter(log_level) {
-                info!("changing UART log level to {}", level_filter);
-                logger_artiq::BufferLogger::with(|logger|
-                    logger.set_uart_log_level(level_filter));
-                drtioaux::send(0, &drtioaux::Packet::CoreMgmtReply { succeeded: true })
-            } else {
-                drtioaux::send(0, &drtioaux::Packet::CoreMgmtReply { succeeded: false })
-            }
-        }
         drtioaux::Packet::CoreMgmtConfigReadRequest {
             destination: _destination,
             length,

--- a/artiq/firmware/satman/mgmt.rs
+++ b/artiq/firmware/satman/mgmt.rs
@@ -17,21 +17,6 @@ pub fn clear_log() -> Result<(), ()> {
     }).map_err(|()| error!("error on clearing log buffer"))
 }
 
-pub fn byte_to_level_filter(level_byte: u8) -> Result<LevelFilter, ()> {
-    Ok(match level_byte {
-        0 => LevelFilter::Off,
-        1 => LevelFilter::Error,
-        2 => LevelFilter::Warn,
-        3 => LevelFilter::Info,
-        4 => LevelFilter::Debug,
-        5 => LevelFilter::Trace,
-        lv => {
-            error!("unknown log level: {}", lv);
-            return Err(());
-        }
-    })
-}
-
 pub struct Manager {
     config_payload: Cursor<Vec<u8>>,
     image_payload: Cursor<Vec<u8>>,
@@ -114,17 +99,15 @@ impl Manager {
                 }
             };
 
-            if key == "log_level" {
-                info!("Changing log level to {}", max_level);
-                BufferLogger::with(|logger| {
-                    logger.set_buffer_log_level(max_level)
-                });
-            } else {
-                info!("Changing UART log level to {}", max_level);
-                BufferLogger::with(|logger| {
-                    logger.set_uart_log_level(max_level)
-                });
-            }
+            BufferLogger::with(|logger| {
+                if key == "log_level" {
+                    logger.set_buffer_log_level(max_level);
+                    log::info!("changing log level to {}", max_level);
+                } else {
+                    logger.set_uart_log_level(max_level);
+                    log::info!("changing UART log level to {}", max_level);
+                }
+            })
         };
         
         let succeeded = config::write(&key, &value).map_err(|err| {

--- a/artiq/frontend/artiq_coremgmt.py
+++ b/artiq/frontend/artiq_coremgmt.py
@@ -34,23 +34,12 @@ def get_argparser():
 
     # logging
     t_log = tools.add_parser("log",
-                             help="read logs and change log levels")
+                             help="read logs")
 
     subparsers = t_log.add_subparsers(dest="action")
 
     p_clear = subparsers.add_parser("clear",
                                     help="clear log buffer")
-
-    p_set_level = subparsers.add_parser("set_level",
-                                        help="set minimum level for messages to be logged")
-    p_set_level.add_argument("level", metavar="LEVEL", type=str,
-                             help="log level (one of: OFF ERROR WARN INFO DEBUG TRACE)")
-
-    p_set_uart_level = subparsers.add_parser("set_uart_level",
-                                             help="set minimum level for messages to be logged "
-                                                  "to UART")
-    p_set_uart_level.add_argument("level", metavar="LEVEL", type=str,
-                                  help="log level (one of: OFF ERROR WARN INFO DEBUG TRACE)")
 
     # configuration
     t_config = tools.add_parser("config",
@@ -138,10 +127,6 @@ def main():
     mgmt = CommMgmt(core_addr, drtio_dest=args.drtio_dest)
 
     if args.tool == "log":
-        if args.action == "set_level":
-            mgmt.set_log_level(args.level)
-        if args.action == "set_uart_level":
-            mgmt.set_uart_log_level(args.level)
         if args.action == "clear":
             mgmt.clear_log()
         if args.action == None:


### PR DESCRIPTION
(Based on PR #2841 log set_level: modify buffer log level only)
Try to use `artiq_coremgmt config` command and `log_level `/ `uart_log_level` keys to configure filter levels, both at runtime and store in flash.

Previous situation:
`artiq_coremgmt log set_level` / `artiq_coremgmt log set_uart_level` changes filter levels only at runtime, with error handling of invalid sub-command and invalid `LevelFilter`.
`artiq_coremgmt config write log_level` / `artiq_coremgmt config write uart_log_level` store keys in flash and only take effects on boot via `setup_log_levels`, with no error handling.

This commit:
`artiq_coremgmt config write log_level` / `artiq_coremgmt config write uart_log_level`  store keys in flash as well as change filter levels at run time, by adding `set_log_filter_level` and call it in `config_write`.

Concerns:
1. What to do with `artiq_coremgmt log set_level`, should do the same as `artiq_coremgmt config write log_level`, or to delete them?
2. Error handling: previously `artiq_coremgmt log` have error checking, while `artiq_coremgmt config write` do not have (like other normal config keys). Shall the merged `artiq_coremgmt config write log_level` have error check on sub-command, UTF8 and `LevelFilter`?