### PR TITLE
Fixed typo in windows install documentation regarding pacman config location

### DIFF
--- a/doc/manual/installing.rst
+++ b/doc/manual/installing.rst
@@ -176,7 +176,7 @@ Installing via MSYS2 (Windows)
 
 We recommend using our `offline installer <https://nixbld.m-labs.hk/job/artiq/extra-beta/msys2-offline-installer/latest>`_, which contains all the necessary packages and requires no additional configuration. After installation, simply launch ``MSYS2 with ARTIQ`` from the Windows Start menu.
 
-Alternatively, you may install `MSYS2 <https://msys2.org>`_, then edit ``C:\MINGW64\etc\pacman.conf`` and add at the end: ::
+Alternatively, you may install `MSYS2 <https://msys2.org>`_, then edit ``C:\msys64\etc\pacman.conf`` and add at the end: ::
 
     [artiq]
     SigLevel = Optional TrustAll


### PR DESCRIPTION
The default pacman conf location (type `pacman -v`  to show) location is `C:\msys64\etc\pacman.conf` or simply `etc\pacman.conf` if within the msys2 shell.