### PR TITLE
Extend SUServo to variable number of Urukul cards

### DIFF
--- a/artiq/coredevice/coredevice_generic.schema.json
+++ b/artiq/coredevice/coredevice_generic.schema.json
@@ -406,21 +406,12 @@
                             "pattern": "^v[0-9]+\\.[0-9]+",
                             "default": "v2.2"
                         },
-                        "urukul0_ports": {
+                        "urukul_ports": {
                             "type": "array",
                             "items": {
-                                "type": "integer"
+                                "$ref": "#/definitions/urukul_ports_pair"
                             },
-                            "minItems": 2,
-                            "maxItems": 2
-                        },
-                        "urukul1_ports": {
-                            "type": "array",
-                            "items": {
-                                "type": "integer"
-                            },
-                            "minItems": 2,
-                            "maxItems": 2
+                            "minItems": 1
                         },
                         "refclk": {
                             "type": "number",
@@ -449,7 +440,7 @@
                             "default": 9
                         }
                     },
-                    "required": ["sampler_ports", "urukul0_ports"]
+                    "required": ["sampler_ports", "urukul_ports"]
                 }
             }, {
                 "title": "Zotino",
@@ -678,6 +669,15 @@
                     }
                 }
             }]
+        },
+
+        "urukul_ports_pair": {
+            "type": "array",
+            "items": {
+                "type": "integer"
+            },
+            "minItems": 2,
+            "maxItems": 2
         }
     }
 }

--- a/artiq/coredevice/suservo.py
+++ b/artiq/coredevice/suservo.py
@@ -7,11 +7,6 @@ from artiq.coredevice import urukul, sampler
 
 COEFF_WIDTH = 18
 Y_FULL_SCALE_MU = (1 << (COEFF_WIDTH - 1)) - 1
-COEFF_DEPTH = 10 + 1
-WE = 1 << COEFF_DEPTH + 1
-STATE_SEL = 1 << COEFF_DEPTH
-CONFIG_SEL = 1 << COEFF_DEPTH - 1
-CONFIG_ADDR = CONFIG_SEL | STATE_SEL
 T_CYCLE = (2*(8 + 64) + 2)*8*ns  # Must match gateware Servo.t_cycle.
 COEFF_SHIFT = 11
 
@@ -66,7 +61,8 @@ class SUServo:
     :param core_device: Core device name
     """
     kernel_invariants = {"channel", "core", "pgia", "cplds", "ddses",
-                         "ref_period_mu", "corrected_fs"}
+                         "ref_period_mu", "corrected_fs", "we", "state_sel",
+                         "config_addr"}
 
     def __init__(self, dmgr, channel, pgia_device,
                  cpld_devices, dds_devices,
@@ -84,6 +80,12 @@ class SUServo:
             self.core.coarse_ref_period)
         self.corrected_fs = sampler.Sampler.use_corrected_fs(sampler_hw_rev)
         assert self.ref_period_mu == self.core.ref_multiplier
+
+        coeff_depth = 10 + (len(cpld_devices) - 1).bit_length()
+        self.we = 1 << coeff_depth + 1
+        self.state_sel = 1 << coeff_depth
+        config_sel = 1 << coeff_depth - 1
+        self.config_addr = self.state_sel | config_sel
 
     @staticmethod
     def get_rtio_channels(channel, **kwargs):
@@ -128,7 +130,7 @@ class SUServo:
         :param addr: Memory location address.
         :param value: Data to be written.
         """
-        addr |= WE
+        addr |= self.we
         value &= (1 << COEFF_WIDTH) - 1
         value |= (addr >> 8) << COEFF_WIDTH
         addr = addr & 0xff
@@ -164,7 +166,7 @@ class SUServo:
             Disabling takes up to two servo cycles (~2.3 µs) to clear the
             processing pipeline.
         """
-        self.write(CONFIG_ADDR, enable)
+        self.write(self.config_addr, enable)
 
     @kernel
     def get_status(self):
@@ -185,7 +187,7 @@ class SUServo:
         :return: Status. Bit 0: enabled, bit 1: done,
           bits 8-15: channel clip indicators.
         """
-        return self.read(CONFIG_ADDR)
+        return self.read(self.config_addr)
 
     @kernel
     def get_adc_mu(self, adc):
@@ -203,7 +205,7 @@ class SUServo:
         # State memory entries are 25 bits. Due to the pre-adder dynamic
         # range, X0/X1/OFFSET are only 24 bits. Finally, the RTIO interface
         # only returns the 18 MSBs (the width of the coefficient memory).
-        return self.read(STATE_SEL | (adc << 1) | (1 << 8))
+        return self.read(self.state_sel | (adc << 1) | (1 << 8))
 
     @kernel
     def set_pgia_mu(self, channel, gain):
@@ -501,7 +503,7 @@ class Channel:
         :param profile: Profile number (0-31)
         :return: 17-bit unsigned Y0
         """
-        return self.servo.read(STATE_SEL | (self.servo_channel << 5) | profile)
+        return self.servo.read(self.servo.state_sel | (self.servo_channel << 5) | profile)
 
     @kernel
     def get_y(self, profile):
@@ -539,7 +541,7 @@ class Channel:
         """
         # State memory is 25 bits wide and signed.
         # Reads interact with the 18 MSBs (coefficient memory width)
-        self.servo.write(STATE_SEL | (self.servo_channel << 5) | profile, y)
+        self.servo.write(self.servo.state_sel | (self.servo_channel << 5) | profile, y)
 
     @kernel
     def set_y(self, profile, y):

--- a/artiq/frontend/artiq_ddb_template.py
+++ b/artiq/frontend/artiq_ddb_template.py
@@ -496,9 +496,11 @@ class PeripheralManager:
     def process_suservo(self, rtio_offset, peripheral):
         suservo_name = self.get_name("suservo")
         sampler_name = self.get_name("sampler")
-        urukul_names = [self.get_name("urukul") for _ in range(2)]
+        num_of_urukuls = len(peripheral["urukul_ports"])
+        urukul_names = [self.get_name("urukul") for _ in range(num_of_urukuls)]
         channel = count(0)
-        for i in range(8):
+        num_of_channels = num_of_urukuls * 4
+        for i in range(num_of_channels):
             self.gen("""
                 device_db["{suservo_name}_ch{suservo_chn}"] = {{
                     "type": "local",

--- a/artiq/frontend/artiq_sinara_tester.py
+++ b/artiq/frontend/artiq_sinara_tester.py
@@ -794,9 +794,10 @@ class SinaraTester(EnvExperiment):
             self.setup_suservo(card_dev)
         print("...done")
         print("Setting up SUServo channels...")
+        print("ADC to DDS mapping:")
         for channels in chunker(self.suschannels, 8):
             for i, (channel_name, channel_dev) in enumerate(channels):
-                print(channel_name)
+                print("ADC{i} -> {name}".format(i=i, name=channel_name))
                 self.setup_suservo_loop(channel_dev, i)
         print("...done")
         print("Enabling...")
@@ -805,8 +806,7 @@ class SinaraTester(EnvExperiment):
             self.setup_start_suservo(card_dev)
         print("...done")
         print("Each Sampler channel applies proportional amplitude control")
-        print("on the respective Urukul0 (ADC 0-3) and Urukul1 (ADC 4-7, if")
-        print("present) channels.")
+        print("on the respective Urukul channels. See the mapping.")
         print("Frequency: 10 MHz, output power: about -9 dBm at 0 V and about -15 dBm at 1.5 V")
         print("Verify frequency and power behavior.")
         print("Press ENTER when done.")

--- a/artiq/gateware/eem.py
+++ b/artiq/gateware/eem.py
@@ -544,11 +544,10 @@ class Grabber(_EEM):
 class SUServo(_EEM):
     @staticmethod
     def io(*eems, iostandard):
-        assert len(eems) in (4, 6)
-        io = (Sampler.io(*eems[0:2], iostandard=iostandard)
-                + Urukul.io_qspi(*eems[2:4], iostandard=iostandard))
-        if len(eems) == 6:  # two Urukuls
-            io += Urukul.io_qspi(*eems[4:6], iostandard=iostandard)
+        assert len(eems) in range(4, 12 + 1, 2)
+        io = Sampler.io(*eems[0:2], iostandard=iostandard)
+        for eem0, eem1 in zip(eems[2::2], eems[3::2]):
+            io += Urukul.io_qspi(eem0, eem1, iostandard=iostandard)
         return io
 
     @classmethod
@@ -587,10 +586,12 @@ class SUServo(_EEM):
                                 # difference (4 cycles measured)
                                 t_conv=57 - 4, t_rtt=t_rtt + 4)
         iir_p = servo.IIRWidths(state=25, coeff=18, adc=16, asf=14, word=16,
-                                accu=48, shift=shift, channel=3,
+                                accu=48, shift=shift,
+                                adc_channels=adc_p.channels,
+                                dds_channels=4*len(eems_urukul),
                                 profile=profile, dly=8)
         dds_p = servo.DDSParams(width=8 + 32 + 16 + 16,
-                                channels=adc_p.channels, clk=clk)
+                                channels=iir_p.dds_channels, clk=clk)
         su = servo.Servo(sampler_pads, urukul_pads, adc_p, iir_p, dds_p)
         su = ClockDomainsRenamer("rio_phy")(su)
         # explicitly name the servo submodule to enable the migen namer to derive
@@ -611,20 +612,15 @@ class SUServo(_EEM):
         target.submodules += phy
         target.rtio_channels.append(rtio.Channel.from_phy(phy, ififo_depth=4))
 
-        for i in range(2):
-            if len(eem_urukul) > i:
-                spi_p, spi_n = (
-                    target.platform.request("{}_spi_p".format(eem_urukul[i])),
-                    target.platform.request("{}_spi_n".format(eem_urukul[i])))
-            else:  # create a dummy bus
-                spi_p = Record([("clk", 1), ("cs_n", 1)])  # mosi, cs_n
-                spi_n = None
+        for j, eem_urukuli in enumerate(eem_urukul):
+            spi_p, spi_n = (
+                target.platform.request("{}_spi_p".format(eem_urukuli)),
+                target.platform.request("{}_spi_n".format(eem_urukuli)))
 
             phy = spi2.SPIMaster(spi_p, spi_n)
             target.submodules += phy
             target.rtio_channels.append(rtio.Channel.from_phy(phy, ififo_depth=4))
 
-        for j, eem_urukuli in enumerate(eem_urukul):
             pads = target.platform.request("{}_dds_reset_sync_in".format(eem_urukuli))
             target.specials += DifferentialOutput(0, pads.p, pads.n)
 

--- a/artiq/gateware/eem_7series.py
+++ b/artiq/gateware/eem_7series.py
@@ -71,17 +71,9 @@ def peripheral_sampler(module, peripheral, **kwargs):
 def peripheral_suservo(module, peripheral, **kwargs):
     if len(peripheral["sampler_ports"]) != 2:
         raise ValueError("wrong number of Sampler ports")
-    urukul_ports = []
-    if len(peripheral["urukul0_ports"]) != 2:
-        raise ValueError("wrong number of Urukul #0 ports")
-    urukul_ports.append(peripheral["urukul0_ports"])
-    if "urukul1_ports" in peripheral:
-        if len(peripheral["urukul1_ports"]) != 2:
-            raise ValueError("wrong number of Urukul #1 ports")
-        urukul_ports.append(peripheral["urukul1_ports"])
     eem.SUServo.add_std(module,
         peripheral["sampler_ports"],
-        urukul_ports, **kwargs)
+        peripheral["urukul_ports"], **kwargs)
 
 
 def peripheral_zotino(module, peripheral, **kwargs):

--- a/artiq/gateware/rtio/phy/servo.py
+++ b/artiq/gateware/rtio/phy/servo.py
@@ -83,7 +83,7 @@ class RTServoMem(Module):
         assert 8 + w.dly < w.coeff
 
         # coeff, profile, channel, 2 mems, rw
-        internal_address_width = 3 + w.profile + w.channel + 1 + 1
+        internal_address_width = 3 + w.profile + bits_for(w.dds_channels - 1) + 1 + 1
         rtlink_address_width = min(8, internal_address_width)
         overflow_address_width = internal_address_width - rtlink_address_width
         self.rtlink = rtlink.Interface(

--- a/artiq/gateware/suservo/iir.py
+++ b/artiq/gateware/suservo/iir.py
@@ -7,18 +7,20 @@ logger = logging.getLogger(__name__)
 
 # all these are number of bits!
 IIRWidths = namedtuple("IIRWidths", [
-    "state",    # the signed x and y states of the IIR filter
-                # DSP A input, x state is one bit smaller
-                # due to AD pre-adder, y has full width (25)
-    "coeff",    # signed IIR filter coefficients a1, b0, b1 (18)
-    "accu",     # IIR accumulator width (48)
-    "adc",      # signed ADC data (16)
-    "word",     # "word" size to break up DDS profile data (16)
-    "asf",      # unsigned amplitude scale factor for DDS (14)
-    "shift",    # fixed point scaling coefficient for a1, b0, b1 (log2!) (11)
-    "channel",  # channels (log2!) (3)
-    "profile",  # profiles per channel (log2!) (5)
-    "dly",      # the activation delay
+    "state",        # the signed x and y states of the IIR filter
+                    # DSP A input, x state is one bit smaller
+                    # due to AD pre-adder, y has full width (25)
+    "coeff",        # signed IIR filter coefficients a1, b0, b1 (18)
+    "accu",         # IIR accumulator width (48)
+    "adc",          # signed ADC data (16)
+    "word",         # "word" size to break up DDS profile data (16)
+    "asf",          # unsigned amplitude scale factor for DDS (14)
+    "shift",        # fixed point scaling coefficient for a1, b0, b1 (log2!) (11)
+    "adc_channels", # number of input ADC channels (8)
+    "dds_channels", # number of output DDS channels (8)
+                    # the number of IIR channels is matched to this
+    "profile",      # profiles per channel (log2!) (5)
+    "dly",          # the activation delay
 ])
 
 
@@ -224,13 +226,13 @@ class IIR(Module):
         # ~processing
         self.specials.m_coeff = Memory(
                 width=2*w.coeff,  # Cat(pow/ftw/offset, cfg/a/b)
-                depth=4 << w.profile + w.channel)
+                depth=(4 << w.profile) * w.dds_channels)
         # m_state[x] should only be read externally during ~(shifting | loading)
         # m_state[y] of active profiles should only be read externally during
         # ~processing
         self.specials.m_state = Memory(
                 width=w.state,  # y1,x0,x1
-                depth=(1 << w.profile + w.channel) + (2 << w.channel))
+                depth=((1 << w.profile) * w.dds_channels) + (2 * w.adc_channels))
         # ctrl should only be updated synchronously
         self.ctrl = [Record([
                 ("profile", w.profile),
@@ -238,14 +240,14 @@ class IIR(Module):
                 ("en_iir", 1),
                 ("clip", 1),
                 ("stb", 1)])
-                for i in range(1 << w.channel)]
+                for i in range(w.dds_channels)]
         # only update during ~loading
         self.adc = [Signal((w.adc, True), reset_less=True)
-                for i in range(1 << w.channel)]
+                for i in range(w.adc_channels)]
         # Cat(ftw0, ftw1, pow, asf)
         # only read externally during ~processing
         self.dds = [Signal(4*w.word, reset_less=True)
-                for i in range(1 << w.channel)]
+                for i in range(w.dds_channels)]
         # perform one IIR iteration, start with loading,
         # then processing, then shifting, end with done
         self.start = Signal()
@@ -281,7 +283,7 @@ class IIR(Module):
         # using the (MSBs of) t_current_step, and, after all channels have been
         # covered, proceed once the pipeline has completely drained.
         self.submodules.fsm = fsm = FSM("IDLE")
-        t_current_step = Signal(w.channel + 2)
+        t_current_step = Signal(max=max(w.adc_channels * 2, w.dds_channels * 4, ))
         t_current_step_clr = Signal()
 
         # pipeline group activity flags (SR)
@@ -298,7 +300,7 @@ class IIR(Module):
         )
         fsm.act("LOAD",
                 self.loading.eq(1),
-                If(t_current_step == (1 << w.channel) - 1,
+                If(t_current_step == w.adc_channels - 1,
                     t_current_step_clr.eq(1),
                     NextValue(stages_active[0], 1),
                     NextState("PROCESS")
@@ -315,7 +317,7 @@ class IIR(Module):
         )
         fsm.act("SHIFT",
                 self.shifting.eq(1),
-                If(t_current_step == (2 << w.channel) - 1,
+                If(t_current_step == (w.adc_channels * 2) - 1,
                     NextState("IDLE")
                 )
         )
@@ -333,13 +335,13 @@ class IIR(Module):
         # pipeline group channel pointer (SR)
         # for each pipeline stage, this is the channel currently being
         # processed
-        channel = [Signal(w.channel, reset_less=True) for i in range(3)]
+        channel = [Signal(max=w.dds_channels, reset_less=True) for i in range(3)]
         self.comb += Cat(pipeline_phase, channel[0]).eq(t_current_step)
         self.sync += [
             If(pipeline_phase == 3,
                 Cat(channel[1:]).eq(Cat(channel[:-1])),
                 stages_active[1:].eq(stages_active[:-1]),
-                If(channel[0] == (1 << w.channel) - 1,
+                If(channel[0] == w.dds_channels - 1,
                     stages_active[0].eq(0)
                 )
             )
@@ -393,13 +395,13 @@ class IIR(Module):
 
         # selected adc and profile delay (combinatorial from dat_r)
         # both share the same coeff word (sel in the lower 8 bits)
-        sel_profile = Signal(w.channel)
+        sel_profile = Signal(max=w.adc_channels)
         dly_profile = Signal(w.dly)
-        assert w.channel <= 8
+        # assert w.channels <= 1 << 8
         assert 8 + w.dly <= w.coeff
 
         # latched adc selection
-        sel = Signal(w.channel, reset_less=True)
+        sel = Signal(max=w.adc_channels, reset_less=True)
         # iir enable SR
         en = Signal(2, reset_less=True)
 
@@ -407,12 +409,12 @@ class IIR(Module):
                 sel_profile.eq(m_coeff.dat_r[w.coeff:]),
                 dly_profile.eq(m_coeff.dat_r[w.coeff + 8:]),
                 If(self.shifting,
-                    m_state.adr.eq(t_current_step | (1 << w.profile + w.channel)),
+                    m_state.adr.eq(t_current_step + ((1 << w.profile) * w.dds_channels)),
                     m_state.dat_w.eq(m_state.dat_r),
                     m_state.we.eq(t_current_step[0])
                 ),
                 If(self.loading,
-                    m_state.adr.eq((t_current_step << 1) | (1 << w.profile + w.channel)),
+                    m_state.adr.eq((t_current_step << 1) + ((1 << w.profile) * w.dds_channels)),
                     m_state.dat_w[-w.adc - 1:-1].eq(Array(self.adc)[t_current_step]),
                     m_state.dat_w[-1].eq(m_state.dat_w[-2]),
                     m_state.we.eq(1)
@@ -424,9 +426,9 @@ class IIR(Module):
                         # read old y
                         Cat(profile[0], channel[0]),
                         # read x0 (recent)
-                        0 | (sel_profile << 1) | (1 << w.profile + w.channel),
+                        0 | (sel_profile << 1) + ((1 << w.profile) * w.dds_channels),
                         # read x1 (old)
-                        1 | (sel << 1) | (1 << w.profile + w.channel),
+                        1 | (sel << 1) + ((1 << w.profile) * w.dds_channels),
                     ])[pipeline_phase]),
                     m_state.dat_w.eq(dsp.output),
                     m_state.we.eq((pipeline_phase == 0) & stages_active[2] & en[1]),
@@ -439,10 +441,10 @@ class IIR(Module):
 
         # internal channel delay counters
         dlys = Array([Signal(w.dly)
-            for i in range(1 << w.channel)])
+            for i in range(w.dds_channels)])
         self._dlys = dlys  # expose for debugging only
 
-        for i in range(1 << w.channel):
+        for i in range(w.dds_channels):
             self.sync += [
                     # (profile != profile_old) | ~en_out
                     If(self.ctrl[i].stb,
@@ -559,6 +561,8 @@ class IIR(Module):
             val &= mask
         if coeff in "offset a1 b0 b1".split():
             val = signed(val, w.coeff)
+        elif coeff in "ftw0 ftw1 pow".split():
+            val = val & ((1 << w.word) - 1)
         return val
 
     def set_state(self, channel, val, profile=None, coeff="y1"):
@@ -570,11 +574,11 @@ class IIR(Module):
         elif coeff == "x0":
             assert profile is None
             yield self.m_state[(channel << 1) |
-                    (1 << w.profile + w.channel)].eq(val)
+                    ((1 << w.profile) * w.dds_channels)].eq(val)
         elif coeff == "x1":
             assert profile is None
             yield self.m_state[1 | (channel << 1) |
-                    (1 << w.profile + w.channel)].eq(val)
+                    ((1 << w.profile) * w.dds_channels)].eq(val)
         else:
             raise ValueError("no such state", coeff)
 
@@ -585,10 +589,10 @@ class IIR(Module):
             val = yield self.m_state[profile | (channel << w.profile)]
         elif coeff == "x0":
             val = yield self.m_state[(channel << 1) |
-                    (1 << w.profile + w.channel)]
+                    ((1 << w.profile) * w.dds_channels)]
         elif coeff == "x1":
             val = yield self.m_state[1 | (channel << 1) |
-                    (1 << w.profile + w.channel)]
+                    ((1 << w.profile) * w.dds_channels)]
         else:
             raise ValueError("no such state", coeff)
         return signed(val, w.state)
@@ -622,7 +626,7 @@ class IIR(Module):
 
         x0s = []
         # check adc loading
-        for i in range(1 << w.channel):
+        for i in range(w.adc_channels):
             v_adc = signed((yield self.adc[i]), w.adc)
             x0 = yield from self.get_state(i, coeff="x0")
             x0s.append(x0)
@@ -631,7 +635,7 @@ class IIR(Module):
 
         data = []
         # predict output
-        for i in range(1 << w.channel):
+        for i in range(w.dds_channels):
             j = yield self.ctrl[i].profile
             en_iir = yield self.ctrl[i].en_iir
             en_out = yield self.ctrl[i].en_out
@@ -640,7 +644,7 @@ class IIR(Module):
                     i, j, en_iir, en_out, dly_i)
 
             cfg = yield from self.get_coeff(i, j, "cfg")
-            k_j = cfg & ((1 << w.channel) - 1)
+            k_j = cfg & (w.adc_channels - 1)
             dly_j = (cfg >> 8) & 0xff
             logger.debug("cfg[%d,%d] sel=%d dly=%d", i, j, k_j, dly_j)
 
@@ -694,7 +698,7 @@ class IIR(Module):
             logger.debug("adc[%d] x0=%x x1=%x", i, x0, x1)
 
         # check new state
-        for i in range(1 << w.channel):
+        for i in range(w.dds_channels):
             j = yield self.ctrl[i].profile
             logger.debug("ch[%d] profile=%d", i, j)
             y1 = yield from self.get_state(i, j, "y1")
@@ -702,7 +706,7 @@ class IIR(Module):
             assert y1 == y0, (hex(y1), hex(y0))
 
         # check dds output
-        for i in range(1 << w.channel):
+        for i in range(w.dds_channels):
             ftw0, ftw1, pow, y0, x1, x0 = data[i]
             asf = y0 >> (w.state - w.asf - 1)
             dds = (ftw0 | (ftw1 << w.word) |

--- a/artiq/gateware/suservo/pads.py
+++ b/artiq/gateware/suservo/pads.py
@@ -72,10 +72,9 @@ class UrukulPads(Module):
                 DifferentialOutput(self.clk, spip[i].clk, spin[i].clk),
                 DifferentialOutput(self.io_update, ioup[i].p, ioup[i].n))
                 for i in range(len(eems))]
-        for i in range(8):
+        for i in range(4*len(eems)):
             mosi = Signal()
             setattr(self, "mosi{}".format(i), mosi)
-        for i in range(4*len(eems)):
             self.specials += [
                 DifferentialOutput(getattr(self, "mosi{}".format(i)),
                     getattr(spip[i // 4], "mosi{}".format(i % 4)),

--- a/artiq/gateware/test/suservo/test_iir.py
+++ b/artiq/gateware/test/suservo/test_iir.py
@@ -8,10 +8,12 @@ from artiq.gateware.suservo import iir
 def main():
     w_kasli = iir.IIRWidths(state=25, coeff=18, adc=16,
             asf=14, word=16, accu=48, shift=11,
-            channel=3, profile=5, dly=8)
+            adc_channels=8, dds_channels=4,
+            profile=5, dly=8)
     w = iir.IIRWidths(state=17, coeff=16, adc=16,
             asf=14, word=16, accu=48, shift=11,
-            channel=2, profile=1, dly=8)
+            adc_channels=4, dds_channels=4,
+            profile=1, dly=8)
 
     def run(dut):
         for i, ch in enumerate(dut.adc):
@@ -20,9 +22,10 @@ def main():
             yield ch.en_iir.eq(1)
             yield ch.en_out.eq(1)
             yield ch.profile.eq(i)
-        for i in range(1 << w.channel):
+        for i in range(w.adc_channels):
             yield from dut.set_state(i, i << 8, coeff="x1")
             yield from dut.set_state(i, i << 8, coeff="x0")
+        for i in range(w.dds_channels):
             for j in range(1 << w.profile):
                 yield from dut.set_state(i,
                         (j << 1) | (i << 8), profile=j, coeff="y1")
@@ -30,7 +33,7 @@ def main():
                     yield from dut.set_coeff(i, profile=j, coeff=l,
                             value=(i << 12) | (j << 8) | (k << 4))
         yield
-        for i in range(1 << w.channel):
+        for i in range(w.dds_channels):
             for j in range(1 << w.profile):
                 for k, l in enumerate("cfg a1 b0 b1".split()):
                     yield from dut.set_coeff(i, profile=j, coeff=l,

--- a/artiq/gateware/test/suservo/test_servo.py
+++ b/artiq/gateware/test/suservo/test_servo.py
@@ -13,7 +13,9 @@ class ServoSim(servo.Servo):
         adc_p = servo.ADCParams(width=16, channels=8, lanes=4,
                 t_cnvh=4, t_conv=57 - 4, t_rtt=4 + 4)
         iir_p = servo.IIRWidths(state=25, coeff=18, adc=16, asf=14, word=16,
-                accu=48, shift=11, channel=3, profile=5, dly=8)
+                accu=48, shift=11,
+                adc_channels=adc_p.channels, dds_channels=8,
+                profile=5, dly=8)
         dds_p = servo.DDSParams(width=8 + 32 + 16 + 16,
                 channels=adc_p.channels, clk=1)
 


### PR DESCRIPTION
Superseding #1782. Other than rebasing to master, it has the following key changes:

- RTIO config address spaces changes are removed/postponed to coherent SU-Servo PR (WIP).
- Unify `urukulx_ports` key in the JSON schema into a `urukul_ports` entry. It is currently represented as a nested list.

All existing JSONs with specific `urukulx_ports` should be replaced.

### Tests
On a standalone Kasli v2.0:
- Targets with an SU-Servo that contains 1-4 urukuls can be compiled.
- All IIR channels can select an ADC input, which scales the DDS amplitude.
Passed all SU-Servo gateware unit test, after making appropriate fixes.

Docstring needs an update to distinguish ADC channels from DDS channels (would be `i_channels` and `o_channels` in #1782).