### PR TITLE
doc: update NDSP list

### DIFF
--- a/doc/manual/list_of_ndsps.rst
+++ b/doc/manual/list_of_ndsps.rst
@@ -12,10 +12,8 @@ The following network device support packages are available for ARTIQ. If you wo
     Thorlabs T-Cubes,               ``thorlabs_tcube``, ``thorlabs_tcube``, Not available, `GitHub <https://github.com/m-labs/thorlabs_tcube>`__
     Korad KA3005P,                  ``korad_ka3005p``, ``korad_ka3005p``, Not available, `GitHub <https://github.com/m-labs/korad_ka3005p>`__
     Newfocus 8742,                  ``newfocus8742``, ``newfocus8742``, Not available, `GitHub <https://github.com/quartiq/newfocus8742>`__
-    Princeton Instruments PICam,    Not available, Not available, Not available, `GitHub <https://github.com/quartiq/picam>`__
-    Anel HUT2 power distribution,   ``hut2``, Not available, Not available, `GitHub <https://github.com/quartiq/hut2>`__
+    Anel HUT2 power distribution,   ``hut2``, ``hut2``, Not available, `Gitea <https://git.m-labs.hk/M-Labs/hut2>`__
     TOPTICA lasers,                 ``toptica-lasersdk-artiq``, Not available, Not available, `GitHub <https://github.com/quartiq/lasersdk-artiq>`__
-    HighFinesse wavemeters,         ``highfinesse-net``, Not available, Not available, `GitHub <https://github.com/quartiq/highfinesse-net>`__
-    InfluxDB database,              Not available, Not available, `HTML <https://gitlab.com/charlesbaynham/artiq_influx_generic>`__, `GitHub <https://gitlab.com/charlesbaynham/artiq_influx_generic>`__
+    InfluxDB database,              Not available, Not available, `HTML <https://gitlab.com/charlesbaynham/artiq_influx_generic>`__, `GitLab <https://gitlab.com/charlesbaynham/artiq_influx_generic>`__
 
 MSYS2 packages all start with the ``mingw-w64-clang-x86_64-`` prefix.


### PR DESCRIPTION
- Remove `Princeton Instruments PICam` and `HighFinesse wavemeters`
- Update `hut2` Git URL
- Update InfluxDB database: GitHub to GitLab