### PR TITLE
adf5356: Explain 6 GHz figure

### DIFF
--- a/artiq/coredevice/adf5356.py
+++ b/artiq/coredevice/adf5356.py
@@ -202,7 +202,7 @@ class ADF5356:
         f_pfd = self.f_pfd()
 
         # choose prescaler
-        if f > 6e9:
+        if f > 6 * GHz:  # see datasheet "Prescaler Value" section (Rev. A, p.21)
             self.regs[0] |= ADF5356_REG0_PRESCALER(1)  # 8/9
             n_min, n_max = 75, 65535
 


### PR DESCRIPTION
For prescaler selection.

As explained in the  *Prescaler Value* section of the ADF5356 [datasheet](https://www.analog.com/media/en/technical-documentation/data-sheets/adf5356.pdf):

<img width="427" height="103" alt="image" src="https://github.com/user-attachments/assets/9ec1df9d-dc79-4046-b80e-e254b829bd04" />

Suggested by @Spaqin in https://github.com/m-labs/artiq/pull/2848#discussion_r2306253233.

