### PR TITLE
artiq_sinara_tester: Fix for Fastino with >1 width

### DIFF
--- a/artiq/frontend/artiq_sinara_tester.py
+++ b/artiq/frontend/artiq_sinara_tester.py
@@ -597,11 +597,12 @@ class SinaraTester(EnvExperiment):
         self.core.break_realtime()
         fastino.init()
         delay(200*us)
-        i = 0
-        for voltage in voltages:
-            fastino.set_dac(i, voltage)
+        for i in range(0, 32, fastino.width):
+            if fastino.width == 1:
+                fastino.set_dac(i, voltages[i])
+            else:
+                fastino.set_group(i, voltages[i:i+fastino.width])
             delay(100*us)
-            i += 1
 
     @kernel
     def fastinos_led_wave(self, fastinos):


### PR DESCRIPTION
The tester didn't consider using the set_group API instead of the set_dac API for Fastinos with non-zero `log2_width`s (i.e. width != 1). Add corresponding branch to set all voltages properly.

Closes #2811.