### PR TITLE
add suservo CPLD

### DIFF
--- a/artiq/coredevice/suservo.py
+++ b/artiq/coredevice/suservo.py
@@ -564,3 +564,66 @@ class Channel:
             raise ValueError("Invalid SUServo y-value!")
         self.set_y_mu(profile, y_mu)
         return y_mu
+
+
+class ProtoRev8(urukul.ProtoRev8):
+    """
+    For use with suservo CPLD to get around polymorphic issues.
+    """
+
+
+class ProtoRev9(urukul.ProtoRev9):
+    """
+    For use with suservo CPLD to get around polymorphic issues.
+    """
+
+
+class CPLD(urukul.CPLD):
+    """
+    Needed to avoid polymorphic issues when using SUServo and regular Urukuls in the same experiment.
+    """
+    rb_len = 8
+
+    ProtoRev8 = ProtoRev8 # needed to avoid polymorphic issues 
+    ProtoRev9 = ProtoRev9 # needed to avoid polymorphic issues
+
+    def __init__(
+        self,
+        dmgr,
+        spi_device,
+        io_update_device=None,
+        dds_reset_device=None,
+        sync_device=None,
+        sync_sel=0,
+        clk_sel=0,
+        clk_div=0,
+        rf_sw=0,
+        refclk=125e6,
+        att=0x00000000,
+        sync_div=None,
+        proto_rev=0x08,
+        core_device="core",
+    ):
+        # Separate IO_UPDATE TTL output device used by SUServo core,
+        # if active, else by artiq.coredevice.suservo.AD9910
+        # :meth:`measure_io_update_alignment`.
+        # The urukul.CPLD driver utilises the CPLD CFG register
+        # option instead for pulsing IO_UPDATE of masked DDSs.
+        self.io_update_ttl = dmgr.get(io_update_device)
+        urukul.CPLD.__init__(
+            self,
+            dmgr,
+            spi_device,
+            io_update_device,
+            dds_reset_device,
+            sync_device,
+            sync_sel,
+            clk_sel,
+            clk_div,
+            rf_sw,
+            refclk,
+            att,
+            sync_div,
+            proto_rev,
+            core_device,
+        )

--- a/artiq/coredevice/urukul.py
+++ b/artiq/coredevice/urukul.py
@@ -724,6 +724,9 @@ class CPLD:
 
     kernel_invariants = {"refclk", "bus", "core", "io_update", "clk_div", "proto_rev"}
 
+    ProtoRev8 = ProtoRev8 # needed for compatibility with SUServo devices
+    ProtoRev9 = ProtoRev9 # needed for compatibility with SUServo devices
+
     def __init__(self, dmgr, spi_device, io_update_device=None,
                  dds_reset_device=None, sync_device=None,
                  sync_sel=0, clk_sel=0, clk_div=0, rf_sw=0,
@@ -753,14 +756,14 @@ class CPLD:
 
         self.proto_rev = proto_rev
         if proto_rev == STA_PROTO_REV_8:
-            self.version = ProtoRev8(self)
+            self.version = self.ProtoRev8(self)
         elif proto_rev == STA_PROTO_REV_9:
-            self.version = ProtoRev9(self)
+            self.version = self.ProtoRev9(self)
         else:
             raise ValueError(f"Urukul unsupported proto_rev: {proto_rev}")
 
         if self.proto_rev == STA_PROTO_REV_8:
-            self.cfg_reg = int64(ProtoRev8.urukul_cfg(
+            self.cfg_reg = int64(self.ProtoRev8.urukul_cfg(
                 rf_sw=rf_sw,
                 led=0,
                 profile=DEFAULT_PROFILE,
@@ -773,7 +776,7 @@ class CPLD:
                 clk_div=clk_div,
             ))
         else:
-            self.cfg_reg = int64(ProtoRev9.urukul_cfg(
+            self.cfg_reg = int64(self.ProtoRev9.urukul_cfg(
                 rf_sw=rf_sw,
                 led=0,
                 profile=(DEFAULT_PROFILE << 9)


### PR DESCRIPTION
With introduction of support for `ProtoRev9` in `coredevice.urukul`, workaround for using both SUServo and normal Urukul devices in the same experiment no longer working due to polymorphism issues. 
Introducing a suservo specific `CPLD` and providing class attributes for both `ProtoRev8` and `ProtoRev9`  in `coredevice.suservo` allows for using both SUServo and normal Urukul devices again.