### PR TITLE
runtime: handle potential SchedError while resetting DRTIO

### DIFF
--- a/artiq/firmware/runtime/kern_hwreq.rs
+++ b/artiq/firmware/runtime/kern_hwreq.rs
@@ -285,7 +285,7 @@ pub fn process_kern_hwreq(io: &Io, aux_mutex: &Mutex, ddma_mutex: &Mutex, subker
     match request {
         &kern::RtioInitRequest => {
             info!("resetting RTIO");
-            rtio_mgt::reset(io, aux_mutex, ddma_mutex, subkernel_mutex, routing_table);
+            rtio_mgt::reset(io, aux_mutex, ddma_mutex, subkernel_mutex, routing_table)?;
             kern_acknowledge()
         }
 


### PR DESCRIPTION
In accordance to https://github.com/m-labs/artiq/issues/2123#issuecomment-3362671852 - ``io.sleep()`` is no longer unwrapping blindly; the reset function escalates ``SchedError``s (including the issue causing ``Interrupted``).

Compiled master and standalone kc705 successfully.

