### PR TITLE
urukul: Remove CPLD usage in IO_UPDATE CFG control

### DIFF
--- a/artiq/coredevice/urukul.py
+++ b/artiq/coredevice/urukul.py
@@ -410,7 +410,7 @@ class ProtoRev8(CPLDVersion):
         :param state: IO_UPDATE state as a 4-bit integer.
             IO_UPDATE is asserted if any bit(s) is/are asserted, deasserted otherwise.
         """
-        self.cfg_io_update(self.cpld, 0, (state & 0xF) != 0)
+        self.cfg_io_update(0, (state & 0xF) != 0)
 
 
 class ProtoRev9(CPLDVersion):


### PR DESCRIPTION
Removes the `cpld` argument in the function call. This change is missing in #2830.

Closes #2861.

On proto rev 8, `cpld.cfg_io_update_all(..)` compiled without error.
