### PR TITLE
flake: add local LLVM 15 build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,8 @@
       QML2_IMPORT_PATH = "${qtbase}/${qtQmlPrefix}";
     };
 
+    inherit (pkgs.callPackage ./llvm {}) llvm_15 lld_15 llvmPackages_15;
+
     rust = pkgs.rust-bin.nightly."2021-09-01".default.override {
       extensions = ["rust-src"];
       targets = [];
@@ -167,7 +169,7 @@
       };
       pyproject = true;
       build-system = [pkgs.python3Packages.setuptools];
-      nativeBuildInputs = [pkgs.llvm_15];
+      nativeBuildInputs = [llvm_15];
       # Disable static linking
       # https://github.com/numba/llvmlite/issues/93
       postPatch = ''
@@ -176,7 +178,7 @@
       '';
       # Set directory containing llvm-config binary
       preConfigure = ''
-        export LLVM_CONFIG=${pkgs.llvm_15.dev}/bin/llvm-config
+        export LLVM_CONFIG=${llvm_15.dev}/bin/llvm-config
       '';
     };
 
@@ -195,7 +197,7 @@
       nativeBuildInputs = [pkgs.qt6.wrapQtAppsHook];
       # keep llvm_x and lld_x in sync with llvmlite
       propagatedBuildInputs =
-        [pkgs.llvm_15 pkgs.lld_15 sipyco.packages.x86_64-linux.sipyco pythonparser llvmlite-new pkgs.qt6.qtsvg artiq-comtools.packages.x86_64-linux.artiq-comtools]
+        [llvm_15 lld_15 sipyco.packages.x86_64-linux.sipyco pythonparser llvmlite-new pkgs.qt6.qtsvg artiq-comtools.packages.x86_64-linux.artiq-comtools]
         ++ (with pkgs.python3Packages; [pyqtgraph pygit2 numpy dateutil scipy prettytable pyserial levenshtein h5py pyqt6 qasync tqdm lmdb jsonschema platformdirs]);
 
       dontWrapQtApps = true;
@@ -220,7 +222,7 @@
       # FIXME: automatically propagate lld_15 llvm_15 dependencies
       # cacert is required in the check stage only, as certificates are to be
       # obtained from system elsewhere
-      nativeCheckInputs = with pkgs; [lld_15 llvm_15 lit outputcheck cacert] ++ [libartiq-support];
+      nativeCheckInputs = [lld_15 llvm_15 libartiq-support pkgs.lit pkgs.outputcheck pkgs.cacert];
       checkPhase = ''
         python -m unittest discover -v artiq.test
 
@@ -306,9 +308,9 @@
         nativeBuildInputs = [
           (pkgs.python3.withPackages (ps: [migen misoc (artiq.withExperimentalFeatures experimentalFeatures) ps.packaging]))
           rust
-          pkgs.llvmPackages_15.clang-unwrapped
-          pkgs.llvm_15
-          pkgs.lld_15
+          llvm_15
+          lld_15
+          llvmPackages_15.clang-unwrapped
           vivado
         ];
         overrideMain = _: {
@@ -496,9 +498,6 @@
           [
             git
             lit
-            lld_15
-            llvm_15
-            llvmPackages_15.clang-unwrapped
             outputcheck
             pdf2svg
 
@@ -511,8 +510,11 @@
             (python3.withPackages (ps: [migen misoc microscope ps.packaging ps.paramiko] ++ artiq.propagatedBuildInputs))
           ]
           ++ [
-            latex-artiq-manual
+            llvm_15
+            lld_15
+            llvmPackages_15.clang-unwrapped
             rust
+            latex-artiq-manual
             artiq-frontend-dev-wrappers
 
             # To manually run compiler tests:
@@ -536,9 +538,9 @@
         packages = [
           rust
 
-          pkgs.llvmPackages_15.clang-unwrapped
-          pkgs.llvm_15
-          pkgs.lld_15
+          llvm_15
+          lld_15
+          llvmPackages_15.clang-unwrapped
 
           packages.x86_64-linux.vivado
           packages.x86_64-linux.openocd-bscanspi
@@ -582,8 +584,8 @@
                 ]
                 ++ ps.paramiko.optional-dependencies.ed25519
           ))
-          pkgs.llvm_15
-          pkgs.lld_15
+          llvm_15
+          lld_15
           pkgs.openssh
           packages.x86_64-linux.openocd-bscanspi # for the bscanspi bitstreams
         ];

--- a/llvm/15/clang/default.nix
+++ b/llvm/15/clang/default.nix
@@ -1,0 +1,97 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  ninja,
+  python3,
+  libxml2,
+  runCommand,
+  libllvm,
+  src,
+  version,
+  llvm_meta,
+  getVersionFile,
+}:
+stdenv.mkDerivation {
+  pname = "clang";
+  inherit version;
+
+  # Extract clang from monorepo
+  src = runCommand "clang-src-${version}" {} ''
+    mkdir -p "$out"
+    cp -r ${src}/cmake "$out"
+    cp -r ${src}/clang "$out"
+    cp -r ${src}/clang-tools-extra "$out"
+  '';
+
+  sourceRoot = "clang-src-${version}/clang";
+
+  outputs = [
+    "out"
+    "lib"
+    "dev"
+    "python"
+  ];
+
+  patches = [
+    (getVersionFile "clang/purity.patch")
+    (getVersionFile "clang/gnu-install-dirs.patch")
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    python3
+  ];
+  buildInputs = [
+    libxml2
+    libllvm
+  ];
+
+  cmakeFlags = [
+    "-DLLVM_ENABLE_RTTI=ON"
+    "-DCLANG_INSTALL_PACKAGE_DIR=${placeholder "dev"}/lib/cmake/clang"
+    "-DLLVM_TABLEGEN_EXE=${libllvm.dev}/bin/llvm-tblgen"
+  ];
+
+  postPatch = ''
+    # Link clang-tools-extra
+    (cd tools && ln -s ../../clang-tools-extra extra)
+  '';
+
+  postInstall = ''
+    # Create cpp symlink
+    ln -sv $out/bin/clang $out/bin/cpp
+
+    # Move libclang to lib output
+    moveToOutput "lib/libclang.*" "$lib"
+    moveToOutput "lib/libclang-cpp.*" "$lib"
+
+    # Setup python output
+    mkdir -p $python/bin $python/share/clang/
+    mv $out/bin/{git-clang-format,scan-view} $python/bin
+    if [ -e $out/bin/set-xcode-analyzer ]; then
+      mv $out/bin/set-xcode-analyzer $python/bin
+    fi
+    mv $out/share/clang/*.py $python/share/clang
+
+    # Remove test binary
+    rm $out/bin/c-index-test
+
+    # Move tblgen to dev
+    mkdir -p $dev/bin
+    cp bin/clang-tblgen $dev/bin
+  '';
+
+  passthru = {
+    inherit libllvm;
+    isClang = true;
+  };
+
+  meta =
+    llvm_meta
+    // {
+      description = "C language family frontend for LLVM";
+      homepage = "https://clang.llvm.org/";
+    };
+}

--- a/llvm/15/clang/gnu-install-dirs.patch
+++ b/llvm/15/clang/gnu-install-dirs.patch
@@ -1,0 +1,105 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c27beec313d7..480f13e73c9f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -78,15 +78,17 @@ if(CLANG_BUILT_STANDALONE)
+   if (NOT LLVM_CONFIG_FOUND)
+     # Pull values from LLVMConfig.cmake.  We can drop this once the llvm-config
+     # path is removed.
+-    set(MAIN_INCLUDE_DIR "${LLVM_INCLUDE_DIR}")
++    set(INCLUDE_DIRS ${LLVM_INCLUDE_DIRS})
+     set(LLVM_OBJ_DIR "${LLVM_BINARY_DIR}")
+     # N.B. this is just a default value, the CACHE PATHs below can be overriden.
+     set(MAIN_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../llvm")
+     set(TOOLS_BINARY_DIR "${LLVM_TOOLS_BINARY_DIR}")
+     set(LIBRARY_DIR "${LLVM_LIBRARY_DIR}")
++  else()
++    set(INCLUDE_DIRS "${LLVM_BINARY_DIR}/include" "${MAIN_INCLUDE_DIR}")
+   endif()
+ 
+-  set(LLVM_MAIN_INCLUDE_DIR "${MAIN_INCLUDE_DIR}" CACHE PATH "Path to llvm/include")
++  set(LLVM_INCLUDE_DIRS ${INCLUDE_DIRS} CACHE PATH "Path to llvm/include and any other header dirs needed")
+   set(LLVM_BINARY_DIR "${LLVM_OBJ_ROOT}" CACHE PATH "Path to LLVM build tree")
+   set(LLVM_MAIN_SRC_DIR "${MAIN_SRC_DIR}" CACHE PATH "Path to LLVM source tree")
+   set(LLVM_TOOLS_BINARY_DIR "${TOOLS_BINARY_DIR}" CACHE PATH "Path to llvm/bin")
+@@ -128,7 +130,7 @@ if(CLANG_BUILT_STANDALONE)
+     set(LLVM_INCLUDE_TESTS ON)
+   endif()
+ 
+-  include_directories("${LLVM_BINARY_DIR}/include" "${LLVM_MAIN_INCLUDE_DIR}")
++  include_directories(${LLVM_INCLUDE_DIRS})
+   link_directories("${LLVM_LIBRARY_DIR}")
+ 
+   set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin )
+diff --git a/cmake/modules/AddClang.cmake b/cmake/modules/AddClang.cmake
+index 21ac332e4f5f..b16c314bd1e2 100644
+--- a/cmake/modules/AddClang.cmake
++++ b/cmake/modules/AddClang.cmake
+@@ -119,8 +119,8 @@ macro(add_clang_library name)
+         install(TARGETS ${lib}
+           COMPONENT ${lib}
+           ${export_to_clangtargets}
+-          LIBRARY DESTINATION lib${LLVM_LIBDIR_SUFFIX}
+-          ARCHIVE DESTINATION lib${LLVM_LIBDIR_SUFFIX}
++          LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}"
++          ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}"
+           RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+ 
+         if (NOT LLVM_ENABLE_IDE)
+diff --git a/lib/Headers/CMakeLists.txt b/lib/Headers/CMakeLists.txt
+index 6e2060991b92..b9bc930d26b8 100644
+--- a/lib/Headers/CMakeLists.txt
++++ b/lib/Headers/CMakeLists.txt
+@@ -420,7 +420,7 @@ add_header_target("openmp-resource-headers" ${openmp_wrapper_files})
+ add_header_target("windows-resource-headers" ${windows_only_files})
+ add_header_target("utility-resource-headers" ${utility_files})
+ 
+-set(header_install_dir lib${LLVM_LIBDIR_SUFFIX}/clang/${CLANG_VERSION}/include)
++set(header_install_dir ${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}/clang/${CLANG_VERSION}/include)
+ 
+ #############################################################
+ # Install rules for the catch-all clang-resource-headers target
+diff --git a/tools/libclang/CMakeLists.txt b/tools/libclang/CMakeLists.txt
+index 8d95d0900e8c..ebc70ff7526d 100644
+--- a/tools/libclang/CMakeLists.txt
++++ b/tools/libclang/CMakeLists.txt
+@@ -180,7 +180,7 @@ foreach(PythonVersion ${CLANG_PYTHON_BINDINGS_VERSIONS})
+           COMPONENT
+             libclang-python-bindings
+           DESTINATION
+-            "lib${LLVM_LIBDIR_SUFFIX}/python${PythonVersion}/site-packages")
++            "${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}/python${PythonVersion}/site-packages")
+ endforeach()
+ if(NOT LLVM_ENABLE_IDE)
+   add_custom_target(libclang-python-bindings)
+diff --git a/tools/scan-build-py/CMakeLists.txt b/tools/scan-build-py/CMakeLists.txt
+index 061dc7ef4dd9..adc54b2edc32 100644
+--- a/tools/scan-build-py/CMakeLists.txt
++++ b/tools/scan-build-py/CMakeLists.txt
+@@ -88,7 +88,7 @@ foreach(lib ${LibScanbuild})
+                      DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/lib/libscanbuild/${lib})
+   list(APPEND Depends ${CMAKE_BINARY_DIR}/lib/libscanbuild/${lib})
+   install(PROGRAMS lib/libscanbuild/${lib}
+-          DESTINATION lib/libscanbuild
++          DESTINATION "${CMAKE_INSTALL_LIBDIR}/libscanbuild"
+           COMPONENT scan-build-py)
+ endforeach()
+ 
+@@ -106,7 +106,7 @@ foreach(resource ${LibScanbuildResources})
+                      DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/lib/libscanbuild/resources/${resource})
+   list(APPEND Depends ${CMAKE_BINARY_DIR}/lib/libscanbuild/resources/${resource})
+   install(PROGRAMS lib/libscanbuild/resources/${resource}
+-          DESTINATION lib/libscanbuild/resources
++          DESTINATION "${CMAKE_INSTALL_LIBDIR}/libscanbuild/resources"
+           COMPONENT scan-build-py)
+ endforeach()
+ 
+@@ -122,7 +122,7 @@ foreach(lib ${LibEar})
+                      DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/lib/libear/${lib})
+   list(APPEND Depends ${CMAKE_BINARY_DIR}/lib/libear/${lib})
+   install(PROGRAMS lib/libear/${lib}
+-          DESTINATION lib/libear
++          DESTINATION "${CMAKE_INSTALL_LIBDIR}/libear"
+           COMPONENT scan-build-py)
+ endforeach()
+ 

--- a/llvm/15/clang/purity.patch
+++ b/llvm/15/clang/purity.patch
@@ -1,0 +1,29 @@
+From 4add81bba40dcec62c4ea4481be8e35ac53e89d8 Mon Sep 17 00:00:00 2001
+From: Will Dietz <w@wdtz.org>
+Date: Thu, 18 May 2017 11:56:12 -0500
+Subject: [PATCH] "purity" patch for 5.0
+
+---
+ lib/Driver/ToolChains/Gnu.cpp | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/lib/Driver/ToolChains/Gnu.cpp b/lib/Driver/ToolChains/Gnu.cpp
+index fe3c0191bb..c6a482bece 100644
+--- a/lib/Driver/ToolChains/Gnu.cpp
++++ b/lib/Driver/ToolChains/Gnu.cpp
+@@ -487,13 +487,7 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
+   } else {
+     if (Args.hasArg(options::OPT_rdynamic))
+       CmdArgs.push_back("-export-dynamic");
+
+-    if (!Args.hasArg(options::OPT_shared) && !IsStaticPIE &&
+-        !Args.hasArg(options::OPT_r)) {
+-      CmdArgs.push_back("-dynamic-linker");
+-      CmdArgs.push_back(Args.MakeArgString(Twine(D.DyldPrefix) +
+-                                           ToolChain.getDynamicLinker(Args)));
+-    }
+   }
+ 
+   CmdArgs.push_back("-o");
+-- 
+2.11.0

--- a/llvm/15/lld/default.nix
+++ b/llvm/15/lld/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  ninja,
+  libxml2,
+  libllvm,
+  runCommand,
+  src,
+  version,
+  llvm_meta,
+  getVersionFile,
+}:
+stdenv.mkDerivation {
+  pname = "lld";
+  inherit version;
+
+  src = runCommand "lld-src-${version}" {} ''
+    mkdir -p "$out"
+    cp -r ${src}/cmake "$out"
+    cp -r ${src}/lld "$out"
+    mkdir -p "$out/libunwind"
+    cp -r ${src}/libunwind/include "$out/libunwind"
+    mkdir -p "$out/llvm"
+  '';
+
+  sourceRoot = "lld-src-${version}/lld";
+
+  outputs = ["out" "lib" "dev"];
+
+  patches = [
+    (getVersionFile "lld/gnu-install-dirs.patch")
+  ];
+
+  nativeBuildInputs = [cmake ninja];
+  buildInputs = [libllvm libxml2];
+
+  cmakeFlags = [
+    "-DLLD_INSTALL_PACKAGE_DIR=${placeholder "dev"}/lib/cmake/lld"
+    "-DLLVM_TABLEGEN_EXE=${libllvm.dev}/bin/llvm-tblgen"
+  ];
+
+  meta =
+    llvm_meta
+    // {
+      description = "LLVM linker";
+      homepage = "https://lld.llvm.org/";
+    };
+}

--- a/llvm/15/lld/gnu-install-dirs.patch
+++ b/llvm/15/lld/gnu-install-dirs.patch
@@ -1,0 +1,46 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index dcc649629a4b..58dca54642e4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -70,13 +70,15 @@ if(LLD_BUILT_STANDALONE)
+   if (NOT LLVM_CONFIG_FOUND)
+     # Pull values from LLVMConfig.cmake.  We can drop this once the llvm-config
+     # path is removed.
+-    set(MAIN_INCLUDE_DIR "${LLVM_INCLUDE_DIR}")
++    set(INCLUDE_DIRS ${LLVM_INCLUDE_DIRS})
+     set(LLVM_OBJ_DIR "${LLVM_BINARY_DIR}")
+     # N.B. this is just a default value, the CACHE PATHs below can be overridden.
+     set(MAIN_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../llvm")
++  else()
++    set(INCLUDE_DIRS "${LLVM_BINARY_DIR}/include" "${MAIN_INCLUDE_DIR}")
+   endif()
+ 
+-  set(LLVM_MAIN_INCLUDE_DIR "${MAIN_INCLUDE_DIR}" CACHE PATH "Path to llvm/include")
++  set(LLVM_INCLUDE_DIRS ${INCLUDE_DIRS} CACHE PATH "Path to llvm/include and any other header dirs needed")
+   set(LLVM_BINARY_DIR "${LLVM_OBJ_ROOT}" CACHE PATH "Path to LLVM build tree")
+   set(LLVM_MAIN_SRC_DIR "${MAIN_SRC_DIR}" CACHE PATH "Path to LLVM source tree")
+ 
+@@ -95,7 +97,7 @@ if(LLD_BUILT_STANDALONE)
+ 
+   set(PACKAGE_VERSION "${LLVM_PACKAGE_VERSION}")
+ 
+-  include_directories("${LLVM_BINARY_DIR}/include" ${LLVM_INCLUDE_DIRS})
++  include_directories(${LLVM_INCLUDE_DIRS})
+   link_directories(${LLVM_LIBRARY_DIRS})
+ 
+   if(LLVM_INCLUDE_TESTS)
+diff --git a/cmake/modules/AddLLD.cmake b/cmake/modules/AddLLD.cmake
+index d3924f7243d4..42a7cd62281c 100644
+--- a/cmake/modules/AddLLD.cmake
++++ b/cmake/modules/AddLLD.cmake
+@@ -18,8 +18,8 @@ macro(add_lld_library name)
+     install(TARGETS ${name}
+       COMPONENT ${name}
+       ${export_to_lldtargets}
+-      LIBRARY DESTINATION lib${LLVM_LIBDIR_SUFFIX}
+-      ARCHIVE DESTINATION lib${LLVM_LIBDIR_SUFFIX}
++      LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}"
++      ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}"
+       RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+ 
+     if (${ARG_SHARED} AND NOT CMAKE_CONFIGURATION_TYPES)

--- a/llvm/15/llvm/default.nix
+++ b/llvm/15/llvm/default.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  ninja,
+  python3,
+  libffi,
+  libxml2,
+  ncurses,
+  zlib,
+  runCommand,
+  src,
+  version,
+  llvm_meta,
+  getVersionFile,
+}:
+stdenv.mkDerivation {
+  pname = "llvm";
+  inherit version;
+
+  src = runCommand "llvm-src-${version}" {} ''
+    mkdir -p "$out"
+    cp -r ${src}/llvm "$out"
+    cp -r ${src}/cmake "$out"
+    cp -r ${src}/third-party "$out"
+  '';
+
+  sourceRoot = "llvm-src-${version}/llvm";
+
+  outputs = ["out" "lib" "dev" "python"];
+
+  patches = [
+    (getVersionFile "llvm/gnu-install-dirs.patch")
+    (getVersionFile "llvm/llvm-lit-cfg-add-libs-to-dylib-path.patch")
+    (getVersionFile "llvm/lit-shell-script-runner-set-dyld-library-path.patch")
+  ];
+
+  nativeBuildInputs = [cmake ninja python3];
+  buildInputs = [libxml2 libffi];
+  propagatedBuildInputs = [ncurses zlib];
+
+  cmakeBuildType = "Release";
+
+  cmakeFlags = [
+    "-DLLVM_INSTALL_PACKAGE_DIR=${placeholder "dev"}/lib/cmake/llvm"
+    "-DLLVM_ENABLE_RTTI=ON"
+    "-DLLVM_LINK_LLVM_DYLIB=ON"
+    "-DLLVM_INSTALL_UTILS=ON"
+    "-DLLVM_BUILD_TESTS=OFF"
+    "-DLLVM_ENABLE_FFI=ON"
+    "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
+    "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.hostPlatform.config}"
+    "-DLLVM_ENABLE_DUMP=ON"
+    "-DLLVM_ENABLE_TERMINFO=ON"
+    "-DLLVM_INCLUDE_TESTS=OFF"
+  ];
+
+  LDFLAGS = "-Wl,--build-id=sha1";
+
+  postInstall = ''
+    # Move opt-viewer to python output
+    mkdir -p $python/share
+    mv $out/share/opt-viewer $python/share/opt-viewer
+
+    # Move llvm-config to dev output
+    moveToOutput "bin/llvm-config*" "$dev"
+
+    # Move llvm-tblgen to dev output (needed by clang and lld)
+    moveToOutput "bin/llvm-tblgen" "$dev"
+
+    # Fix cmake config to point to dev output
+    substituteInPlace "$dev/lib/cmake/llvm/LLVMExports-release.cmake" \
+      --replace-fail "$out/bin/llvm-config" "$dev/bin/llvm-config" \
+      --replace-fail "$out/bin/llvm-tblgen" "$dev/bin/llvm-tblgen"
+
+    substituteInPlace "$dev/lib/cmake/llvm/LLVMConfig.cmake" \
+      --replace-fail 'set(LLVM_BINARY_DIR "''${LLVM_INSTALL_PREFIX}")' 'set(LLVM_BINARY_DIR "'"$lib"'")'
+  '';
+
+  meta =
+    llvm_meta
+    // {
+      description = "LLVM compiler infrastructure";
+      homepage = "https://llvm.org/";
+    };
+}

--- a/llvm/15/llvm/gnu-install-dirs.patch
+++ b/llvm/15/llvm/gnu-install-dirs.patch
@@ -1,0 +1,138 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 45399dc0537e..5d946e9e6583 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -942,7 +942,7 @@ if (NOT TENSORFLOW_AOT_PATH STREQUAL "")
+   add_subdirectory(${TENSORFLOW_AOT_PATH}/xla_aot_runtime_src
+     ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/tf_runtime)
+   install(TARGETS tf_xla_runtime EXPORT LLVMExports
+-    ARCHIVE DESTINATION lib${LLVM_LIBDIR_SUFFIX} COMPONENT tf_xla_runtime)
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX} COMPONENT tf_xla_runtime)
+   set_property(GLOBAL APPEND PROPERTY LLVM_EXPORTS tf_xla_runtime)
+   # Once we add more modules, we should handle this more automatically.
+   if (DEFINED LLVM_OVERRIDE_MODEL_HEADER_INLINERSIZEMODEL)
+diff --git a/cmake/modules/AddLLVM.cmake b/cmake/modules/AddLLVM.cmake
+index 057431208322..56f0dcb258da 100644
+--- a/cmake/modules/AddLLVM.cmake
++++ b/cmake/modules/AddLLVM.cmake
+@@ -844,8 +844,8 @@ macro(add_llvm_library name)
+       get_target_export_arg(${name} LLVM export_to_llvmexports ${umbrella})
+       install(TARGETS ${name}
+               ${export_to_llvmexports}
+-              LIBRARY DESTINATION lib${LLVM_LIBDIR_SUFFIX} COMPONENT ${name}
+-              ARCHIVE DESTINATION lib${LLVM_LIBDIR_SUFFIX} COMPONENT ${name}
++              LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}" COMPONENT ${name}
++              ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}" COMPONENT ${name}
+               RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT ${name})
+ 
+       if (NOT LLVM_ENABLE_IDE)
+@@ -2007,7 +2007,7 @@ function(llvm_install_library_symlink name dest type)
+   set(full_name ${CMAKE_${type}_LIBRARY_PREFIX}${name}${CMAKE_${type}_LIBRARY_SUFFIX})
+   set(full_dest ${CMAKE_${type}_LIBRARY_PREFIX}${dest}${CMAKE_${type}_LIBRARY_SUFFIX})
+ 
+-  set(output_dir lib${LLVM_LIBDIR_SUFFIX})
++  set(output_dir ${CMAKE_INSTALL_FULL_LIBDIR}${LLVM_LIBDIR_SUFFIX})
+   if(WIN32 AND "${type}" STREQUAL "SHARED")
+     set(output_dir "${CMAKE_INSTALL_BINDIR}")
+   endif()
+@@ -2271,15 +2271,15 @@ function(llvm_setup_rpath name)
+ 
+   if (APPLE)
+     set(_install_name_dir INSTALL_NAME_DIR "@rpath")
+-    set(_install_rpath "@loader_path/../lib${LLVM_LIBDIR_SUFFIX}" ${extra_libdir})
++    set(_install_rpath "@loader_path/../${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}" ${extra_libdir})
+   elseif(${CMAKE_SYSTEM_NAME} MATCHES "AIX" AND BUILD_SHARED_LIBS)
+     # $ORIGIN is not interpreted at link time by aix ld.
+     # Since BUILD_SHARED_LIBS is only recommended for use by developers,
+     # hardcode the rpath to build/install lib dir first in this mode.
+     # FIXME: update this when there is better solution.
+-    set(_install_rpath "${LLVM_LIBRARY_OUTPUT_INTDIR}" "${CMAKE_INSTALL_PREFIX}/lib${LLVM_LIBDIR_SUFFIX}" ${extra_libdir})
++    set(_install_rpath "${LLVM_LIBRARY_OUTPUT_INTDIR}" "${CMAKE_INSTALL_FULL_LIBDIR}${LLVM_LIBDIR_SUFFIX}" ${extra_libdir})
+   elseif(UNIX)
+-    set(_install_rpath "\$ORIGIN/../lib${LLVM_LIBDIR_SUFFIX}" ${extra_libdir})
++    set(_install_rpath "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}" ${extra_libdir})
+     if(${CMAKE_SYSTEM_NAME} MATCHES "(FreeBSD|DragonFly)")
+       set_property(TARGET ${name} APPEND_STRING PROPERTY
+                    LINK_FLAGS " -Wl,-z,origin ")
+diff --git a/cmake/modules/AddOCaml.cmake b/cmake/modules/AddOCaml.cmake
+index 891c9e6d618c..8d963f3b0069 100644
+--- a/cmake/modules/AddOCaml.cmake
++++ b/cmake/modules/AddOCaml.cmake
+@@ -147,9 +147,9 @@ function(add_ocaml_library name)
+   endforeach()
+ 
+   if( APPLE )
+-    set(ocaml_rpath "@executable_path/../../../lib${LLVM_LIBDIR_SUFFIX}")
++    set(ocaml_rpath "@executable_path/../../../${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}")
+   elseif( UNIX )
+-    set(ocaml_rpath "\\$ORIGIN/../../../lib${LLVM_LIBDIR_SUFFIX}")
++    set(ocaml_rpath "\\$ORIGIN/../../../${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}")
+   endif()
+   list(APPEND ocaml_flags "-ldopt" "-Wl,-rpath,${ocaml_rpath}")
+ 
+diff --git a/cmake/modules/CMakeLists.txt b/cmake/modules/CMakeLists.txt
+index d4b0ab959148..26ed981fd09f 100644
+--- a/cmake/modules/CMakeLists.txt
++++ b/cmake/modules/CMakeLists.txt
+@@ -128,7 +128,7 @@ set(LLVM_CONFIG_INCLUDE_DIRS
+   )
+ list(REMOVE_DUPLICATES LLVM_CONFIG_INCLUDE_DIRS)
+ 
+-extend_path(LLVM_CONFIG_LIBRARY_DIR "\${LLVM_INSTALL_PREFIX}" "lib\${LLVM_LIBDIR_SUFFIX}")
++extend_path(LLVM_CONFIG_LIBRARY_DIR "\${LLVM_INSTALL_PREFIX}" "${CMAKE_INSTALL_LIBDIR}\${LLVM_LIBDIR_SUFFIX}")
+ set(LLVM_CONFIG_LIBRARY_DIRS
+   "${LLVM_CONFIG_LIBRARY_DIR}"
+   # FIXME: Should there be other entries here?
+diff --git a/docs/CMake.rst b/docs/CMake.rst
+index 879b7b231d4c..9c31d14e8950 100644
+--- a/docs/CMake.rst
++++ b/docs/CMake.rst
+@@ -250,7 +250,7 @@ description is in `LLVM-related variables`_ below.
+ **LLVM_LIBDIR_SUFFIX**:STRING
+   Extra suffix to append to the directory where libraries are to be
+   installed. On a 64-bit architecture, one could use ``-DLLVM_LIBDIR_SUFFIX=64``
+-  to install libraries to ``/usr/lib64``.
++  to install libraries to ``/usr/lib64``. See also ``CMAKE_INSTALL_LIBDIR``.
+ 
+ **LLVM_PARALLEL_{COMPILE,LINK}_JOBS**:STRING
+   Building the llvm toolchain can use a lot of resources, particularly
+@@ -284,6 +284,10 @@ manual, or execute ``cmake --help-variable VARIABLE_NAME``.
+   The path to install executables, relative to the *CMAKE_INSTALL_PREFIX*.
+   Defaults to "bin".
+ 
++**CMAKE_INSTALL_LIBDIR**:PATH
++  The path to install libraries, relative to the *CMAKE_INSTALL_PREFIX*.
++  Defaults to "lib".
++
+ **CMAKE_INSTALL_INCLUDEDIR**:PATH
+   The path to install header files, relative to the *CMAKE_INSTALL_PREFIX*.
+   Defaults to "include".
+diff --git a/tools/llvm-config/BuildVariables.inc.in b/tools/llvm-config/BuildVariables.inc.in
+index 370005cd8d7d..7e790bc52111 100644
+--- a/tools/llvm-config/BuildVariables.inc.in
++++ b/tools/llvm-config/BuildVariables.inc.in
+@@ -23,6 +23,7 @@
+ #define LLVM_CXXFLAGS "@LLVM_CXXFLAGS@"
+ #define LLVM_BUILDMODE "@LLVM_BUILDMODE@"
+ #define LLVM_LIBDIR_SUFFIX "@LLVM_LIBDIR_SUFFIX@"
++#define LLVM_INSTALL_LIBDIR "@CMAKE_INSTALL_LIBDIR@"
+ #define LLVM_INSTALL_INCLUDEDIR "@CMAKE_INSTALL_INCLUDEDIR@"
+ #define LLVM_INSTALL_PACKAGE_DIR "@LLVM_INSTALL_PACKAGE_DIR@"
+ #define LLVM_TARGETS_BUILT "@LLVM_TARGETS_BUILT@"
+diff --git a/tools/llvm-config/llvm-config.cpp b/tools/llvm-config/llvm-config.cpp
+index 2c6c55f89d38..f6d2068a0827 100644
+--- a/tools/llvm-config/llvm-config.cpp
++++ b/tools/llvm-config/llvm-config.cpp
+@@ -369,7 +369,11 @@ int main(int argc, char **argv) {
+       sys::fs::make_absolute(ActivePrefix, Path);
+       ActiveBinDir = std::string(Path.str());
+     }
+-    ActiveLibDir = ActivePrefix + "/lib" + LLVM_LIBDIR_SUFFIX;
++    {
++      SmallString<256> Path(LLVM_INSTALL_LIBDIR LLVM_LIBDIR_SUFFIX);
++      sys::fs::make_absolute(ActivePrefix, Path);
++      ActiveLibDir = std::string(Path.str());
++    }
+     {
+       SmallString<256> Path(LLVM_INSTALL_PACKAGE_DIR);
+       sys::fs::make_absolute(ActivePrefix, Path);

--- a/llvm/15/llvm/lit-shell-script-runner-set-dyld-library-path.patch
+++ b/llvm/15/llvm/lit-shell-script-runner-set-dyld-library-path.patch
@@ -1,0 +1,26 @@
+diff --git a/utils/lit/lit/TestRunner.py b/utils/lit/lit/TestRunner.py
+index 0242e0b75af3..d732011306f7 100644
+--- a/utils/lit/lit/TestRunner.py
++++ b/utils/lit/lit/TestRunner.py
+@@ -1029,6 +1029,12 @@ def executeScript(test, litConfig, tmpBase, commands, cwd):
+             f.write('@echo off\n')
+         f.write('\n@if %ERRORLEVEL% NEQ 0 EXIT\n'.join(commands))
+     else:
++        # This env var is *purged* when invoking subprocesses so we have to
++        # manually set it from within the bash script in order for the commands
++        # in run lines to see this var:
++        if "DYLD_LIBRARY_PATH" in test.config.environment:
++            f.write(f'export DYLD_LIBRARY_PATH="{test.config.environment["DYLD_LIBRARY_PATH"]}"\n')
++
+         for i, ln in enumerate(commands):
+             match = re.match(kPdbgRegex, ln)
+             if match:
+@@ -1363,7 +1369,7 @@ def applySubstitutions(script, substitutions, conditions={},
+         return processed
+ 
+     process = processLine if recursion_limit is None else processLineToFixedPoint
+-    
++
+     return [unescapePercents(process(ln)) for ln in script]
+ 
+ 

--- a/llvm/15/llvm/llvm-lit-cfg-add-libs-to-dylib-path.patch
+++ b/llvm/15/llvm/llvm-lit-cfg-add-libs-to-dylib-path.patch
@@ -1,0 +1,79 @@
+diff --git a/test/Unit/lit.cfg.py b/test/Unit/lit.cfg.py
+index 81e8dc04acea..479ff95681e2 100644
+--- a/test/Unit/lit.cfg.py
++++ b/test/Unit/lit.cfg.py
+@@ -3,6 +3,7 @@
+ # Configuration file for the 'lit' test runner.
+ 
+ import os
++import platform
+ import subprocess
+ 
+ import lit.formats
+@@ -55,3 +56,26 @@ if sys.platform in ['win32', 'cygwin'] and os.path.isdir(config.shlibdir):
+ # Win32 may use %SYSTEMDRIVE% during file system shell operations, so propogate.
+ if sys.platform == 'win32' and 'SYSTEMDRIVE' in os.environ:
+     config.environment['SYSTEMDRIVE'] = os.environ['SYSTEMDRIVE']
++
++# Add the LLVM dynamic libs to the platform-specific loader search path env var:
++#
++# TODO: this is copied from `clang`'s `lit.cfg.py`; should unify..
++def find_shlibpath_var():
++    if platform.system() in ['Linux', 'FreeBSD', 'NetBSD', 'OpenBSD', 'SunOS']:
++        yield 'LD_LIBRARY_PATH'
++    elif platform.system() == 'Darwin':
++        yield 'DYLD_LIBRARY_PATH'
++    elif platform.system() == 'Windows':
++        yield 'PATH'
++    elif platform.system() == 'AIX':
++        yield 'LIBPATH'
++
++for shlibpath_var in find_shlibpath_var():
++    shlibpath = os.path.pathsep.join(
++        (config.shlibdir,
++         config.environment.get(shlibpath_var, '')))
++    config.environment[shlibpath_var] = shlibpath
++    break
++else:
++    lit_config.warning("unable to inject shared library path on '{}'"
++                       .format(platform.system()))
+diff --git a/test/lit.cfg.py b/test/lit.cfg.py
+index 75a38b4c5dad..856fc75c9d74 100644
+--- a/test/lit.cfg.py
++++ b/test/lit.cfg.py
+@@ -42,6 +42,26 @@ llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)
+ llvm_config.with_system_environment(
+     ['HOME', 'INCLUDE', 'LIB', 'TMP', 'TEMP'])
+ 
++# Add the LLVM dynamic libs to the platform-specific loader search path env var:
++#
++# TODO: this is copied from `clang`'s `lit.cfg.py`; should unify..
++def find_shlibpath_var():
++    if platform.system() in ['Linux', 'FreeBSD', 'NetBSD', 'OpenBSD', 'SunOS']:
++        yield 'LD_LIBRARY_PATH'
++    elif platform.system() == 'Darwin':
++        yield 'DYLD_LIBRARY_PATH'
++    elif platform.system() == 'Windows':
++        yield 'PATH'
++    elif platform.system() == 'AIX':
++        yield 'LIBPATH'
++
++for shlibpath_var in find_shlibpath_var():
++    shlibpath = config.llvm_shlib_dir
++    llvm_config.with_environment(shlibpath_var, shlibpath, append_path = True)
++    break
++else:
++    lit_config.warning("unable to inject shared library path on '{}'"
++                       .format(platform.system()))
+ 
+ # Set up OCAMLPATH to include newly built OCaml libraries.
+ top_ocaml_lib = os.path.join(config.llvm_lib_dir, 'ocaml')
+@@ -318,7 +338,7 @@ def have_cxx_shared_library():
+ 
+     try:
+         readobj_cmd = subprocess.Popen(
+-            [readobj_exe, '--needed-libs', readobj_exe], stdout=subprocess.PIPE)
++            [readobj_exe, '--needed-libs', readobj_exe], stdout=subprocess.PIPE, env=config.environment)
+     except OSError:
+         print('could not exec llvm-readobj')
+         return False

--- a/llvm/default.nix
+++ b/llvm/default.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  stdenv,
+  callPackage,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  python3,
+  libffi,
+  libxml2,
+  ncurses,
+  zlib,
+  runCommand,
+}: let
+  version = "15.0.7";
+
+  src = fetchFromGitHub {
+    owner = "llvm";
+    repo = "llvm-project";
+    rev = "llvmorg-${version}";
+    sha256 = "sha256-wjuZQyXQ/jsmvy6y1aksCcEDXGBjuhpgngF3XQJ/T4s=";
+  };
+
+  llvm_meta = {
+    license = lib.licenses.ncsa;
+    platforms = lib.platforms.unix;
+  };
+
+  getVersionFile = p: ./15 + "/${p}";
+
+  # Build LLVM first (provides libllvm and llvm-tblgen)
+  libllvm = callPackage ./15/llvm {
+    inherit
+      lib
+      stdenv
+      cmake
+      ninja
+      python3
+      libffi
+      libxml2
+      ncurses
+      zlib
+      runCommand
+      src
+      version
+      llvm_meta
+      getVersionFile
+      ;
+  };
+
+  clang-unwrapped = callPackage ./15/clang {
+    inherit
+      lib
+      stdenv
+      cmake
+      ninja
+      python3
+      libxml2
+      runCommand
+      libllvm
+      src
+      version
+      llvm_meta
+      getVersionFile
+      ;
+  };
+
+  lld = callPackage ./15/lld {
+    inherit
+      lib
+      stdenv
+      cmake
+      ninja
+      libxml2
+      libllvm
+      runCommand
+      src
+      version
+      llvm_meta
+      getVersionFile
+      ;
+  };
+in {
+  llvm_15 = libllvm;
+  lld_15 = lld;
+  llvmPackages_15 = {clang-unwrapped = clang-unwrapped;};
+}


### PR DESCRIPTION
Add LLVM 15 support (removed from nixpkgs) locally while #2859 (LLVM 20 migration) remains in progress.

Tested: builds successfully on `kc705-hitl`.