### PR TITLE
dashboard: add interactive args to state manager

### DIFF
--- a/artiq/dashboard/interactive_args.py
+++ b/artiq/dashboard/interactive_args.py
@@ -156,3 +156,11 @@ class InteractiveArgsDock(QtWidgets.QDockWidget):
         except Exception:
             logger.error("failed to cancel interactive args request for experiment: %d",
                          rid, exc_info=True)
+
+    def save_state(self):
+        return {
+            "geometry": bytes(self.saveGeometry())
+        }
+
+    def restore_state(self, state):
+        self.restoreGeometry(QtCore.QByteArray(state["geometry"]))

--- a/artiq/frontend/artiq_dashboard.py
+++ b/artiq/frontend/artiq_dashboard.py
@@ -255,6 +255,7 @@ def main():
         sub_clients["interactive_args"],
         rpc_clients["interactive_arg_db"]
     )
+    smgr.register(d_interactive_args)
 
     d_schedule = schedule.ScheduleDock(
         rpc_clients["schedule"], sub_clients["schedule"])


### PR DESCRIPTION
Interactive arguments dock is hidden unless `restoreGeometry` is called on it directly. Register the dock with the state manager.