### PR TITLE
dashboard: devarg_override clear button breaks on state restore

### DIFF
--- a/artiq/dashboard/experiments.py
+++ b/artiq/dashboard/experiments.py
@@ -204,7 +204,6 @@ class _ExperimentDock(QtWidgets.QMdiSubWindow):
         devarg_override = QtWidgets.QComboBox()
         devarg_override.setEditable(True)
         devarg_override.lineEdit().setPlaceholderText("Override device arguments")
-        devarg_override.lineEdit().setClearButtonEnabled(True)
         devarg_override.insertItem(0, "core:analyze_at_run_end=true")
         devarg_override.insertItem(1, "core:report_invariants=true")
         self.layout.addWidget(devarg_override, 2, 3)


### PR DESCRIPTION
Workaround for #2873 

With Qt 6.9.2, the `QLineEdit` built into the `QComboBox` for `devarg_override` breaks when restoring state for no obvious reason. The button does not appear, and all text input clears on removing focus. It also breaks all QDockWidgets in the main window, as the tabs in the tab bars no longer snap to the correct position. 

Ideally, we should find the root cause of this issue or some way to make the QComboBox work correctly. I have been unable to create a minimal reproducible example in either PyQt or Qt as of yet. It is also not obvious why this seems to have an influence on the `QTabBar`s in the main window.