### PR TITLE
adf5356: Fix operation order in f_vco() for nac3

### DIFF
--- a/artiq/coredevice/adf5356.py
+++ b/artiq/coredevice/adf5356.py
@@ -324,10 +324,13 @@ class ADF5356:
         Return the VCO frequency for the cached set of registers.
         """
         return float(self.f_pfd()) * (
-                 float(self.pll_n())
-                 + (float(self.pll_frac1() + self.pll_frac2()) / float(self.pll_mod2()))
-                 / float(ADF5356_MODULUS1)
-             )
+            float(self.pll_n())
+            + (
+                float(self.pll_frac1())
+                + self.pll_frac2() / self.pll_mod2()
+            )
+            / float(ADF5356_MODULUS1)
+        )
 
     @portable
     def pll_n(self) -> int32:


### PR DESCRIPTION
Calculation should be frac1 + frac2 / mod2, not (frac1 + frac2) / mod2. Formatting adjusted to make it obvious.