### PR TITLE
mgmt: increase thread stack size

### DIFF
--- a/artiq/firmware/runtime/mgmt.rs
+++ b/artiq/firmware/runtime/mgmt.rs
@@ -663,7 +663,7 @@ pub fn thread(io: Io, restart_idle: &Urc<Cell<bool>>, aux_mutex: &Mutex, ddma_mu
         let subkernel_mutex = subkernel_mutex.clone();
         let routing_table = routing_table.clone();
         let stream = listener.accept().expect("mgmt: cannot accept").into_handle();
-        io.spawn(16384, move |io| {
+        io.spawn(32768, move |io| {
             let routing_table = routing_table.borrow();
             let mut stream = TcpStream::from_handle(&io, stream);
             match worker(&io, &mut stream, &restart_idle, &aux_mutex, &ddma_mutex, &subkernel_mutex, &routing_table) {


### PR DESCRIPTION
## Summary
- Using `artiq_coremgmt -s 4 log` on Phaser DRTIO will panic master Kasli. Double the stack size fixes the issue.

```bash
Trap frame: TrapFrame { ra: 4000aa0c, t0: 7fffffff, t1: ffba0000, t2: e0002000, t3: 4027e24c, t4: 20, t5: a8, t6: 36, a0: 402f1c50, a1: 402f1408, a2: 1, a3: 1e848, a4: 0, a5: 1, a6: 0, a7: 245c }
@ 0x400091fc
+0000: 01312623 01412423 01512223 01612023
+0010: 06060063 00060a93 00058a13 00050993
+0020: 00452903 00052b03 00852483 06996863
+0030: 40990433 01546463 000a8413 009b05b3
panic at runtime/main.rs:357:13: exception StoreFault at PC 0x400091fc, trap value 0x402f0ffc
backtrace for software version 9.0+unknown.beta;demo:
0x40066cb8
0x40013f34
0x40066220
halting.
use `artiq_coremgmt config write -s panic_reset 1` to restart instead
```
