### PR TITLE
adf5356: Remove redundant cast in `calculate_pll`

### DIFF
--- a/artiq/coredevice/adf5356.py
+++ b/artiq/coredevice/adf5356.py
@@ -570,8 +570,6 @@ def calculate_pll(f_vco: TFloat, f_pfd: TInt64):
     :param f_pfd: PFD frequency
     :return: (``n``, ``frac1``, ``(frac2_msb, frac2_lsb)``, ``(mod2_msb, mod2_lsb)``)
     """
-    f_pfd = int64(f_pfd)
-
     # integral part
     n, r = int32(f_vco // f_pfd), f_vco % f_pfd
 


### PR DESCRIPTION
Casting a `TInt64` into an `int64` is unnecessary.

...unless we have to worry about something like a `str` being passed in? This _is_ a function decorated by `@portable` and there is no type checking when non-`@kernel` code calls this after all.