### PR TITLE
artiq_sinara_tester: Add Urukul ATT ValueError msg

### DIFF
--- a/artiq/frontend/artiq_sinara_tester.py
+++ b/artiq/frontend/artiq_sinara_tester.py
@@ -271,7 +271,7 @@ class SinaraTester(EnvExperiment):
             readback_word = cpld.get_att_mu()
             if readback_word != test_word:
                 print(readback_word, test_word)
-                raise ValueError
+                raise ValueError("Test and readback attenuator word mismatch")
 
     @kernel
     def calibrate_urukul(self, channel):


### PR DESCRIPTION
Provide a message string to the cause of the error, lest it will display "ValueError: ValueError", which isn't helpful.