### PR TITLE
unify coremgmt flash binary discovery

### DIFF
--- a/artiq/frontend/flash_tools.py
+++ b/artiq/frontend/flash_tools.py
@@ -4,6 +4,31 @@ import tempfile
 import struct
 
 
+def discover_bins(path, srcbuild=False):
+    if not os.path.exists(path):
+        raise FileNotFoundError("path does not exist")
+
+    if os.path.isfile(path):
+        if os.path.basename(path) == "boot.bin":
+            return {"boot": path}
+        raise ValueError("file is not a valid binary")
+
+    retrieved_bins = {}
+    bin_dict = {
+        "boot": ["boot"],
+        "gateware": ["gateware"],
+        "bootloader": ["bootloader"],
+        "firmware": ["runtime", "satman"],
+    }
+
+    for name, components in bin_dict.items():
+        try:
+            retrieved_bins[name] = fetch_bin(path, components, srcbuild)
+        except FileNotFoundError:
+            pass
+    return retrieved_bins
+
+
 def artifact_path(this_binary_dir, *path_filename, srcbuild=False):
     if srcbuild:
         # source tree - use path elements to locate file


### PR DESCRIPTION
Adds `discover_bins` helper in `flash_tools.py` returning a dictionary of `region` : `path` that can be used by both `artiq_flash` and `artiq_coremgmt`.

+ Fetches binaries with `srcbuild` or without
+ Supports supplying just a single file for `boot.bin` (Zynq)

### Testing

Not tested with coredevice. Printed all paths that would be sent to `mgmt.flash` or `programmer.write_binary` (using dry run option on  `artiq_flash`). Works correctly with `srcbuild` for both Kasli v2 and Kasli-SoC. Correctly errors on broken directory and missing file.