### PR TITLE
Revert "adf5356: Remove redundant cast in calculate_pll"

### DIFF
--- a/artiq/coredevice/adf5356.py
+++ b/artiq/coredevice/adf5356.py
@@ -570,6 +570,8 @@ def calculate_pll(f_vco: TFloat, f_pfd: TInt64):
     :param f_pfd: PFD frequency
     :return: (``n``, ``frac1``, ``(frac2_msb, frac2_lsb)``, ``(mod2_msb, mod2_lsb)``)
     """
+    f_pfd = int64(f_pfd)
+
     # integral part
     n, r = int32(f_vco // f_pfd), f_vco % f_pfd
 


### PR DESCRIPTION
This reverts commit f2d0f422a30b4d1487787257f5e548188f0adb7b.

Caused tests to [fail](https://nixbld.m-labs.hk/build/187669). Apologies for having forgotten to run the unit test.