### PR TITLE
artiq_sinara_tester: Improve displayed output of Urukul sync calibration

### DIFF
--- a/artiq/frontend/artiq_sinara_tester.py
+++ b/artiq/frontend/artiq_sinara_tester.py
@@ -278,10 +278,10 @@ class SinaraTester(EnvExperiment):
         self.core.break_realtime()
         channel.init()
         self.core.break_realtime()
-        sync_delay_seed, _ = channel.tune_sync_delay()
+        sync_delay, _ = channel.tune_sync_delay()
         self.core.break_realtime()
         io_update_delay = channel.tune_io_update_delay()
-        return sync_delay_seed, io_update_delay
+        return sync_delay, io_update_delay
 
     @kernel
     def setup_urukul(self, channel, frequency):
@@ -327,9 +327,9 @@ class SinaraTester(EnvExperiment):
             else:
                 eeprom = channel_dev.sync_data.eeprom_device
                 offset = channel_dev.sync_data.eeprom_offset
-                sync_delay_seed, io_update_delay = self.calibrate_urukul(channel_dev)
-                print("{}\tSYNC_IN delay = {}, IO_UPDATE delay = {}".format(channel_name, sync_delay_seed, io_update_delay))
-                eeprom_word = (sync_delay_seed << 24) | (io_update_delay << 16)
+                sync_delay, io_update_delay = self.calibrate_urukul(channel_dev)
+                print("{}\tSYNC_IN delay = {}, IO_UPDATE delay = {}".format(channel_name, sync_delay, io_update_delay))
+                eeprom_word = (sync_delay << 24) | (io_update_delay << 16)
                 eeprom.write_i32(offset, eeprom_word)
         print("...done")
 


### PR DESCRIPTION
Label the delays displayed after calibrating synchronization. Also renamed the related variable `sync_delay_seed` as it isn't the seed value.

`artiq_sinara_tester` output now:

```
Calibrating inter-device synchronization...
urukul0_ch0     SYNC_IN delay = 18, IO_UPDATE delay = 0
urukul0_ch1     SYNC_IN delay = 20, IO_UPDATE delay = 0
urukul0_ch2     SYNC_IN delay = 19, IO_UPDATE delay = 0
urukul0_ch3     SYNC_IN delay = 19, IO_UPDATE delay = 3
...done
```

Instead of:
```
Calibrating inter-device synchronization...
urukul0_ch0     20 0
urukul0_ch1     18 0
urukul0_ch2     9 3
urukul0_ch3     21 3
...done
```