### PR TITLE
[NAC3] adf5356: Recast `f_pfd` to `int64` in `calculate_pll`

### DIFF
--- a/artiq/coredevice/adf5356.py
+++ b/artiq/coredevice/adf5356.py
@@ -583,6 +583,8 @@ def calculate_pll(f_vco: float, f_pfd: int64) -> tuple[int32, int32, tuple[int32
     :param f_pfd: PFD frequency
     :return: (``n``, ``frac1``, ``(frac2_msb, frac2_lsb)``, ``(mod2_msb, mod2_lsb)``)
     """
+    f_pfd = int64(f_pfd)
+
     # integral part
     n, r = int32(f_vco // float(f_pfd)), f_vco % float(f_pfd)
 


### PR DESCRIPTION
Under the `@portable` context, a `float` could be passed in to the `f_pfd` parameter even when type-annotated as an `int64`. We want to be able to specify `f_pfd` as a literal like `125*MHz`, which is a `float` (due to the `Hz` unit) even if it is an integral value, hence the casting.

Related to https://github.com/m-labs/artiq/pull/2892.