### PR TITLE
doc: corrections on board and development shells

### DIFF
--- a/doc/manual/building_developing.rst
+++ b/doc/manual/building_developing.rst
@@ -125,22 +125,20 @@ Once you have run ``nix develop`` you are in the ARTIQ development environment. 
 Building only standard binaries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you are working with original ARTIQ, and you only want to build a set of standard binaries (i.e. without changing the source code), you can also enter the development shell without cloning the repository, using ``nix develop`` as follows: ::
+If you are working with original ARTIQ, and you only want to build a set of standard binaries (i.e. without changing the source code), you can also enter the *boards* shell without cloning the repository, using ``nix develop`` as follows: ::
 
     $ nix develop git+https://github.com/m-labs/artiq.git\?ref=release-[number]#boards
 
 Leave off ``\?ref=release-[number]`` to prefer the current beta version instead of a numbered release.
 
 .. note::
-    Adding ``#boards`` makes use of the ARTIQ flake's provided ``artiq-boards-shell``, a lighter environment optimized for building firmware and flashing boards, which can also be accessed by running ``nix develop .#boards`` if you have already cloned the repository. Developers should be aware that in this shell the current copy of the ARTIQ sources is not added to your ``PYTHONPATH``. Run ``nix flake show`` and read ``flake.nix`` carefully to understand the different available shells.
+    With this command you are making use of the ARTIQ flake's provided ``artiq-boards-shell``, a lighter environment optimized for building firmware and flashing boards, which can also be accessed by running ``nix develop .#boards`` if you have already cloned the repository. Developers should be aware that in this shell the current copy of the ARTIQ sources is not added to your ``PYTHONPATH``, which is why the shell can be entered without a local repository. Run ``nix flake show`` and read ``flake.nix`` carefully to understand the different available shells.
 
 The parallel command does exist for ARTIQ-Zynq: ::
 
     $ nix develop git+https://git.m-labs.hk/m-labs/artiq-zynq\?ref=release-[number]
 
-but if you are building ARTIQ-Zynq without intention to change the source, it is not actually necessary to enter the development environment at all; Nix is capable of accessing the official flake directly to set up the build, eliminating the requirement for any particular environment.
-
-This is equally possible for original ARTIQ, but not as useful, as the development environment (specifically the ``#boards`` shell) is still the easiest way to access the necessary tools for flashing the board. On the other hand, Zynq boards can also be flashed by writing to the SD card directly, which requires no further special tools. As long as you have a functioning Nix/Vivado installation with flakes enabled, you can progress directly to the building instructions below.
+but if you are building ARTIQ-Zynq without intention to change the source, it is not actually necessary to enter the development environment at all; Nix is capable of accessing the official flake directly to set up a build, eliminating the requirement for any particular environment. For original ARTIQ, the development environment (specifically the ``#boards`` shell) is still the easiest way to access the necessary tools for flashing a board.
 
 .. _building:
 

--- a/doc/manual/flashing.rst
+++ b/doc/manual/flashing.rst
@@ -27,17 +27,17 @@ Installing and configuring OpenOCD
 .. warning::
   These instructions are not applicable to :ref:`Zynq devices <devices-table>`, which do not use the utility :mod:`~artiq.frontend.artiq_flash`. If your core device is a Zynq device, skip straight to :ref:`writing-flash`.
 
-ARTIQ supplies the utility :mod:`~artiq.frontend.artiq_flash`, which uses OpenOCD to write the binary images into an FPGA board's flash memory. With MSYS2, OpenOCD is included with the installation by default. For Nix, make sure to include the package ``artiq.openocd-bscanspi`` in your flake (in the :ref:`example custom flake <example-flake>`, you can simply uncomment the relevant line). Alternatively, you can use the ARTIQ main flake's development shell. Nix profile installations do not include OpenOCD.
+ARTIQ supplies the utility :mod:`~artiq.frontend.artiq_flash`, which uses OpenOCD to write the binary images into an FPGA board's flash memory. With MSYS2, OpenOCD is included with the installation by default. For Nix, make sure to include the package ``artiq.openocd-bscanspi`` in your flake (in the :ref:`example custom flake <example-flake>`, you can simply uncomment the relevant line). Alternatively, you can use the ARTIQ main flake's board development shell. Nix profile installations do not include OpenOCD.
 
 Note that this is **not** ``pkgs.openocd``; the latter is OpenOCD from the Nix package collection, which does not support ARTIQ/Sinara boards.
 
 .. tip::
 
-  The development shell is an alternative, non-minimal ARTIQ environment which includes additional tools for working with ARTIQ, including OpenOCD. You can enter it with: ::
+  The board development shell is an alternative, non-minimal ARTIQ environment which includes additional tools for working with ARTIQ, including OpenOCD. You can enter it with: ::
 
-  $ nix develop git+https://github.com/m-labs/artiq.git
+  $ nix develop git+https://github.com/m-labs/artiq#boards
 
-  However, unless you want the full development environment, it's usually preferable to use a lighter custom flake, such as the example in :doc:`installing`.
+  However, unless you want more of these additional tools, it's usually preferable to use a lighter custom flake, such as the example in :doc:`installing`.
 
 Some additional steps are necessary to ensure that OpenOCD can communicate with the FPGA board:
 


### PR DESCRIPTION
It turns out contrary to what I thought 

`$ nix develop git+https://github.com/m-labs/artiq.git` 

doesn't actually work, unlike with the Zynq or boards devshells because [adding to pythonpath](https://github.com/m-labs/artiq/blob/13e9572d9ed19ac73fb3c9660307e749e13023c8/flake.nix#L509) naturally fails (silently) unless you happen to execute the command inside of the ARTIQ repo *anyway*, in which case it works fine and is probably what I did at some point to get confused.

Recommends #boards instead and adjusts some information around the various available shells in light of this. 