### PR TITLE
flake: improve `PYTHONPATH` setup validation in development shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -506,7 +506,13 @@
           export LIBARTIQ_SUPPORT=`libartiq-support`
           export QT_PLUGIN_PATH=${qtPaths.QT_PLUGIN_PATH}
           export QML2_IMPORT_PATH=${qtPaths.QML2_IMPORT_PATH}
-          export PYTHONPATH=`git rev-parse --show-toplevel`:$PYTHONPATH
+          artiq_root=$(git rev-parse --show-toplevel 2>/dev/null)
+          if [[ -z "$artiq_root" ]] || ! artiq_run --version > /dev/null 2>&1; then
+            echo "WARNING: Local ARTIQ repository not found, could not be added to PYTHONPATH."
+            echo "This development shell must be run from within the ARTIQ repository."
+          else
+            export PYTHONPATH="$artiq_root:$PYTHONPATH"
+          fi
         '';
       };
       # Lighter development shell optimized for building firmware and flashing boards.


### PR DESCRIPTION
Add warning message when the default development shell fails to properly set up `PYTHONPATH` for ARTIQ.

Closes #2898 