### PR TITLE
eem: Clarify Urukul SYNC_IN and SYNC_OUT

### DIFF
--- a/artiq/gateware/eem.py
+++ b/artiq/gateware/eem.py
@@ -158,7 +158,7 @@ class Urukul(_EEM):
                 (7, eem, "dds_reset_sync_in", Misc("IOB=TRUE"))]
         if eem_aux is not None:
             ttls += [(0, eem_aux, "sync_clk"),
-                     (1, eem_aux, "sync_in"),
+                     (1, eem_aux, "sync_out"),
                      (2, eem_aux, "io_update_ret"),
                      (3, eem_aux, "nu_mosi3"),
                      (4, eem_aux, "sw0"),
@@ -239,7 +239,7 @@ class Urukul(_EEM):
         if dds_type == "ad9912":
             # DDS_RESET for AD9912 variant only
             target.specials += DifferentialOutput(0, pads.p, pads.n)
-        elif sync_gen_cls is not None:  # AD9910 variant and SYNC_IN from EEM
+        elif sync_gen_cls is not None:  # AD9910 variant and SYNC_IN to EEM
             sync_phy = sync_gen_cls(pad=pads.p, pad_n=pads.n, ftw_width=4)
             target.submodules += sync_phy
             target.rtio_channels.append(rtio.Channel.from_phy(sync_phy))


### PR DESCRIPTION
Differentiate Urukul's DDS_RESET/SYNC_IN on EEM0[7] from SYNC_IN on EEM1[1] by renaming the latter to SYNC_OUT in the gateware. The now SYNC_OUT signal has always been an Urukul output. The converse also applies to SYNC_IN, so apply a correction to a related comment as well.
SYNC_OUT is currently unused.

See https://git.m-labs.hk/M-Labs/urukul-pld/commit/a6da8916cd52fecc4bc1976722bee0dd34e60b1a.