### PR TITLE
fix artiq_flash storage only write

### DIFF
--- a/artiq/frontend/artiq_flash.py
+++ b/artiq/frontend/artiq_flash.py
@@ -348,7 +348,8 @@ def main():
 
     for cmd, regions in cmds:
         if cmd == "write":
-            found_bins = discover_bins(binary_dir, args.srcbuild)
+            found_bins = (discover_bins(binary_dir, args.srcbuild)
+                          if binary_dir is not None else {})
             for region in regions:
                 if region == "storage":
                     path = args.storage


### PR DESCRIPTION
caused by 13e9572d

Fixes 
```
artiq_flash write=storage -f <FILE>
```
without specifying a `-d` path