### PR TITLE
artiq_flash: Fix `-t` help string

### DIFF
--- a/artiq/frontend/artiq_flash.py
+++ b/artiq/frontend/artiq_flash.py
@@ -62,7 +62,7 @@ Prerequisites:
                         help="SSH host to jump through")
     parser.add_argument("-t", "--target", default="kasli",
                         help="target board, default: %(default)s, one of: "
-                             "kasli efc kc705")
+                             "kasli phaser efc1v0 efc1v1 kc705")
     parser.add_argument("-I", "--preinit-command", default=[], action="append",
                         help="add a pre-initialization OpenOCD command. "
                              "Useful for selecting a board when several are connected.")


### PR DESCRIPTION
Not all available targets were listed, and the `efc` target has changed to `efc1v0`.

Note: Not using something like `" ".join(dict.keys())`, the dictionary in the `main` function is difficult to move without moving `get_argparser` as well, which we want to keep at the top.