### PR TITLE
examples: update SU-Servo coefficient memory mapping

### DIFF
--- a/artiq/examples/kasli_suservo/repository/suservo.py
+++ b/artiq/examples/kasli_suservo/repository/suservo.py
@@ -14,7 +14,7 @@ class SUServo(EnvExperiment):
 
     def p(self, d):
         mask = 1 << 18 - 1
-        for name, val in zip("ftw1 b1 pow cfg offset a1 ftw0 b0".split(), d):
+        for name, val in zip("pow b1 ftw0 cfg offset a1 ftw1 b0".split(), d):
             val = -(val & mask) + (val & ~mask)
             print("{}: {:#x} = {}".format(name, val, val))
 


### PR DESCRIPTION
As a consequence of #2882, the coefficient memory was remapped to facilitate phase tracking computation. Documentation changes for `Channel.get_profile_mu()` is already in #2882.