### PR TITLE
flake: fix missing phaser mtdds hydra job

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -551,7 +551,7 @@
     };
 
     hydraJobs = {
-      inherit (packages.x86_64-linux) artiq artiq-board-kc705-nist_clock artiq-board-efc-shuttler artiq-board-efc-songbird openocd-bscanspi;
+      inherit (packages.x86_64-linux) artiq artiq-board-kc705-nist_clock artiq-board-efc-shuttler artiq-board-efc-songbird artiq-board-phaser-mtdds openocd-bscanspi;
       gateware-sim = pkgs.stdenvNoCC.mkDerivation {
         name = "gateware-sim";
         buildInputs = [


### PR DESCRIPTION
- Add back the missing `artiq-board-phaser-mtdds` hydra job, so it build on `nixbld`
- run `nix build .#hydraJobs.artiq-board-phaser-mtdds`  and it builds successfully