### PR TITLE
efc: Avoid repeated `afe_adc_spi`s in Shuttler IO

### DIFF
--- a/artiq/gateware/targets/efc.py
+++ b/artiq/gateware/targets/efc.py
@@ -71,7 +71,7 @@ ltc2000_spi = [
     )
 ]
 
-shuttler_io = [
+shuttler_io_common = [
     ('dac_spi', 0,
         Subsignal('clk', Pins('fmc0:HB16_N')),
         Subsignal('mosi', Pins('fmc0:HB06_CC_N')),
@@ -117,13 +117,25 @@ shuttler_io = [
         Subsignal('mosi', Pins('fmc0:LA00_CC_N')),
         Subsignal('cs_n', Pins('fmc0:LA02_P fmc0:LA01_CC_N')),
         IOStandard("LVCMOS18")),
+    ('afe_adc_error_n', 0, Pins('fmc0:LA28_N'), IOStandard("LVCMOS18")),
+]
+
+shuttler_io_afe_pre_v1_3 = shuttler_io_common + [
     ('afe_adc_spi', 0,
         Subsignal('clk', Pins('fmc0:LA29_P')),
         Subsignal('mosi', Pins('fmc0:LA29_N')),
         Subsignal('miso', Pins('fmc0:LA30_N')),
         Subsignal('cs_n', Pins('fmc0:LA28_P')),
-        IOStandard("LVCMOS18")),
-    ('afe_adc_error_n', 0, Pins('fmc0:LA28_N'), IOStandard("LVCMOS18")),
+        IOStandard("LVCMOS18"))
+]
+
+shuttler_io_afe_v1_3 = shuttler_io_common + [
+    ('afe_adc_spi', 0,
+        Subsignal('clk', Pins('fmc0:LA29_N')),
+        Subsignal('mosi', Pins('fmc0:LA28_P')),
+        Subsignal('miso', Pins('fmc0:LA30_N')),
+        Subsignal('cs_n', Pins('fmc0:LA29_P')),
+        IOStandard("LVCMOS18"))
 ]
 
 class _SatelliteBase(BaseSoC, AMPSoC):
@@ -265,22 +277,11 @@ class EfcShuttler(_SatelliteBase):
         platform = self.platform
 
         if afe_hw_rev in ("v1.0", "v1.1", "v1.2"):
-            afe_adc_io = ('afe_adc_spi', 0,
-                            Subsignal('clk', Pins('fmc0:LA29_P')),
-                            Subsignal('mosi', Pins('fmc0:LA29_N')),
-                            Subsignal('miso', Pins('fmc0:LA30_N')),
-                            Subsignal('cs_n', Pins('fmc0:LA28_P')),
-                            IOStandard("LVCMOS18"))
+            shuttler_io = shuttler_io_afe_pre_v1_3
         elif afe_hw_rev == "v1.3":
-            afe_adc_io = ('afe_adc_spi', 0,
-                        Subsignal('clk', Pins('fmc0:LA29_N')),
-                        Subsignal('mosi', Pins('fmc0:LA28_P')),
-                        Subsignal('miso', Pins('fmc0:LA30_N')),
-                        Subsignal('cs_n', Pins('fmc0:LA29_P')),
-                        IOStandard("LVCMOS18"))
+            shuttler_io = shuttler_io_afe_v1_3
         else:
             raise ValueError("Unknown AFE hardware revision", afe_hw_rev)
-        shuttler_io.append(afe_adc_io)
 
         platform.add_extension(shuttler_io)
 


### PR DESCRIPTION
Having repeated `afe_adc_spi` entries for disparate Shuttler AFE HW revs caused the ADC SPI communication of Shuttler AFE v1.3 to be incoherent, and it seemed to behave the same regardless of the specified Shuttler AFE HW rev.