### PR TITLE
nac3: test_embedding: np_array -> numpy.array

### DIFF
--- a/artiq/test/coredevice/test_embedding.py
+++ b/artiq/test/coredevice/test_embedding.py
@@ -630,7 +630,7 @@ class _NumpyQuoting(EnvExperiment):
 
     @kernel
     def run(self):
-        a = np_array([10, 20])
+        a = numpy.array([10, 20])
         b = np_sqrt(4.0)
 
 


### PR DESCRIPTION
Fixes HITL tests. In any case we should move away from using the `np_` aliases.