### PR TITLE
flake: fix PYTHONPATH validation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -520,11 +520,15 @@
           export QT_PLUGIN_PATH=${qtPaths.QT_PLUGIN_PATH}
           export QML2_IMPORT_PATH=${qtPaths.QML2_IMPORT_PATH}
           artiq_root=$(git rev-parse --show-toplevel 2>/dev/null)
-          if [[ -z "$artiq_root" ]] || ! artiq_run --version > /dev/null 2>&1; then
+          if [[ -z "$artiq_root" ]]; then
             echo "WARNING: Local ARTIQ repository not found, could not be added to PYTHONPATH."
             echo "This development shell must be run from within the ARTIQ repository."
           else
             export PYTHONPATH="$artiq_root:$PYTHONPATH"
+            if ! artiq_run --version > /dev/null 2>&1; then
+              echo "WARNING: Local repository does not contain ARTIQ source modules."
+              echo "This development shell must be run from within the ARTIQ repository."
+            fi
           fi
         '';
       };


### PR DESCRIPTION
The previous version doesn't actually add the ARTIQ modules to PYTHONPATH before running the check that they exist, so it only succeeds when `nix develop` is run in the root of the repository.  This version also succeeds when run from subdirectories. 