### PR TITLE
compiler: use debug file from nac3ld

### DIFF
--- a/artiq/coredevice/core.py
+++ b/artiq/coredevice/core.py
@@ -240,10 +240,13 @@ class Core:
         """
         self.comm.close()
 
-    def compile(self, method, args, kwargs, embedding_map, file_output=None, target=None):
+    def compile(self, method, args, kwargs, embedding_map, output_filename=None, debug_filename=None, target=None):
         if target is not None:
             # NAC3TODO: subkernels
             raise NotImplementedError
+        
+        if (output_filename is None) != (debug_filename is None):
+            raise ValueError("both output and debug filenames should be specified or unspecified")
 
         if not self.analyzed:
             self.compiler.analyze(
@@ -261,27 +264,27 @@ class Core:
             name = ""
 
         # NAC3TODO: handle self.report_invariants
-        if file_output is None:
+        if output_filename is None and debug_filename is None:
             return self.compiler.compile_method_to_mem(obj, name, args, embedding_map)
         else:
-            self.compiler.compile_method_to_file(obj, name, args, file_output, embedding_map)
+            self.compiler.compile_method_to_file(obj, name, args, output_filename, debug_filename, embedding_map)
 
     def run(self, function, args, kwargs):
         embedding_map = EmbeddingMap()
-        kernel_library = self.compile(function, args, kwargs, embedding_map)
+        kernel_library, debug_object = self.compile(function, args, kwargs, embedding_map)
 
-        self._run_compiled(kernel_library, embedding_map)
+        self._run_compiled(kernel_library, debug_object, embedding_map)
 
         # set by NAC3
         if embedding_map.expects_return:
             return embedding_map.return_value
 
-    def _run_compiled(self, kernel_library, embedding_map):
+    def _run_compiled(self, kernel_library, debug_object, embedding_map):
         if self.first_run:
             self.comm.check_system_info()
             self.first_run = False
 
-        symbolizer = lambda addresses: symbolize(kernel_library, addresses)
+        symbolizer = lambda addresses: symbolize(debug_object, addresses)
 
         self.comm.load(kernel_library)
         self.comm.run()
@@ -459,7 +462,7 @@ class RunTool:
             os.unlink(filename)
 
 
-def symbolize(library, addresses):
+def symbolize(debug_library, addresses):
     if addresses == []:
         return []
 
@@ -470,8 +473,8 @@ def symbolize(library, addresses):
     last_inlined = None
     offset_addresses = [hex(addr - 1) for addr in addresses]
     with RunTool(["llvm-addr2line", "--addresses",  "--functions", "--inlines",
-                  "--demangle", "--exe={library}"] + offset_addresses,
-                 library=library) \
+                  "--demangle", "--exe={debug_library}"] + offset_addresses,
+                 debug_library=debug_library) \
             as results:
         lines = iter(results["__stdout__"].read().rstrip().split("\n"))
         backtrace = []

--- a/artiq/frontend/artiq_compile.py
+++ b/artiq/frontend/artiq_compile.py
@@ -32,6 +32,8 @@ def get_argparser():
 
     parser.add_argument("-o", "--output", default=None,
                         help="output file")
+    parser.add_argument("-d", "--debug", default=None,
+                        help="debug file")
     parser.add_argument("file", metavar="FILE",
                         help="file containing the experiment to compile")
     parser.add_argument("arguments", metavar="ARGUMENTS",
@@ -51,10 +53,9 @@ def main():
             dataset_mgr = DatasetManager(dataset_db)
             embedding_map = EmbeddingMap()
 
-            output = args.output
-            if output is None:
-                basename, ext = os.path.splitext(args.file)
-                output = "{}.elf".format(basename)
+            basename, ext = os.path.splitext(args.file)
+            output = "{}.elf".format(basename) if args.output is None else args.output
+            debug = "{}_debug.elf".format(basename) if args.debug is None else args.debug
 
             module = file_import(args.file, prefix="artiq_run_")
             exp = get_experiment(module, args.class_name)
@@ -65,7 +66,7 @@ def main():
 
             if not getattr(exp.run, "__artiq_kernel__", False):
                 raise ValueError("Experiment entry point must be a kernel")
-            exp_inst.core.compile(exp_inst.run, [], {}, embedding_map, file_output=output)
+            exp_inst.core.compile(exp_inst.run, [], {}, embedding_map, output_filename=output, debug_filename=debug)
         finally:
             dataset_db.close_db()
     finally:


### PR DESCRIPTION
Split from #2927.
The debug file is passed to llvm-addr2line to find call sites.
#2927 will use nac3symbolizer instead of llvm-addr2line.

An additional option is also provided to `artiq_compile`, which allows debug file name to be specified.

See [NAC3 PR 710](https://git.m-labs.hk/M-Labs/nac3/pulls/710).