### PR TITLE
compiler: remove llvmlite workaround for size optimization level

### DIFF
--- a/artiq/compiler/targets.py
+++ b/artiq/compiler/targets.py
@@ -1,6 +1,6 @@
 import os, sys, tempfile, subprocess, io
 from artiq.compiler import types, ir
-from llvmlite import ir as ll, binding as llvm, __version__ as llvmlite_version
+from llvmlite import ir as ll, binding as llvm
 
 llvm.initialize_all_targets()
 llvm.initialize_all_asmprinters()
@@ -108,22 +108,9 @@ class Target:
 
     def optimize(self, llmodule):
         llmachine = self.target_machine()
-        if tuple(int(s) for s in llvmlite_version.split(".")) > (0, 45, 0):
-            pto = llvm.create_pipeline_tuning_options(speed_level = 2, size_level=1)
-        else:
-            pto = llvm.create_pipeline_tuning_options(size_level=1)
-
-            # This combination of levels gets mapped to the -Os PassManagerBuilder default in
-            # llvmlite 0.45. The mapping is slightly nonsensical in that -Oz (which is more
-            # aggressively optimizing for size at the expense of runtime) is accessed via
-            # speed_level=size_level=2.
-            # This was fixed in an incompatible way in llvmlite 0.46 breaking this workaround
-            # here, requiring a second workaround to check the llvmlite version...
-            pto.speed_level = 1
-
+        pto = llvm.create_pipeline_tuning_options(speed_level = 2, size_level=1)
         pb = llvm.create_pass_builder(llmachine, pto)
         llpassmgr = pb.getModulePassManager()
-
         llpassmgr.run(llmodule, pb)
 
     def compile(self, module):

--- a/flake.lock
+++ b/flake.lock
@@ -87,11 +87,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767047869,
-        "narHash": "sha256-tzYsEzXEVa7op1LTnrLSiPGrcCY6948iD0EcNLWcmzo=",
+        "lastModified": 1768028080,
+        "narHash": "sha256-50aDK+8eLvsLK39TzQhKNq50/HcXyP4hyxOYoPoVxjo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "89dbf01df72eb5ebe3b24a86334b12c27d68016a",
+        "rev": "d03088749a110d52a4739348f39a63f84bb0be14",
         "type": "github"
       },
       "original": {
@@ -174,11 +174,11 @@
     "src-migen": {
       "flake": false,
       "locked": {
-        "lastModified": 1767354910,
-        "narHash": "sha256-gRAvl5cUvrjq4t7htXsDBt4F8MEbHXFZoS0jbhrEs1I=",
+        "lastModified": 1767411796,
+        "narHash": "sha256-nDk/+FsTuX/P9ujWf2eTJdMY2+r953+eq7LMlYNBH38=",
         "ref": "refs/heads/master",
-        "rev": "0efcff4cb875746dce46987d2fa476897c8c671e",
-        "revCount": 2064,
+        "rev": "673e0e8a66600f7e8dcd6345759630474d6b9c80",
+        "revCount": 2067,
         "type": "git",
         "url": "https://git.m-labs.hk/M-Labs/migen.git"
       },
@@ -208,11 +208,11 @@
     "src-pythonparser": {
       "flake": false,
       "locked": {
-        "lastModified": 1628745371,
-        "narHash": "sha256-p6TgeeaK4NEmbhimEXp31W8hVRo4DgWmcCoqZ+UdN60=",
+        "lastModified": 1767427016,
+        "narHash": "sha256-E57okn+3gwvtXnF/qF/jypNYqijCLUYOEYLF9ZCzHpE=",
         "owner": "m-labs",
         "repo": "pythonparser",
-        "rev": "5413ee5c9f8760e95c6acd5d6e88dabb831ad201",
+        "rev": "a2ace427c84ee5b1e9bd9dbc9b9337e50fc54077",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
We don't need the [version check](https://github.com/m-labs/artiq/pull/2941) and the `llvmlite v0.45` size optimization level workaround anymore since the upstream stable nixpkgs now uses `v0.46`. See: https://github.com/NixOS/nixpkgs/commit/4d10fadf1372571963f8eda62fd40fbcec679422.

Tested with `nix build .#artiq`.

Related issue: https://github.com/m-labs/artiq/issues/2924.