### PR TITLE
scientific_spinbox: fix stepBy ignoring precision

### DIFF
--- a/artiq/gui/scientific_spinbox.py
+++ b/artiq/gui/scientific_spinbox.py
@@ -77,7 +77,10 @@ class ScientificSpinBox(QtWidgets.QDoubleSpinBox):
 
     def stepBy(self, s):
         if abs(s) < 10:  # unaccelerated buttons, keys, wheel/trackpad
-            super().stepBy(s)
+            v = self.value()
+            v += s * self.singleStep()
+            v = round(v, self.decimals())
+            self.setValue(v)
         else:  # accelerated PageUp/Down or CTRL-wheel
             v = self.value()
             v *= self._relative_step**(s/copysign(10., v))


### PR DESCRIPTION
Stepping with arrow buttons or shift scrolling on `NumberEntryFloat` does not currently respect precision.

Example:
```
precision: 1
step: 0.1
displayed: 1.4
submitted:1.3999999....
```

In the case of stepping to `0`, it may also display a small FP value (`~1e-17`), instead of `0`.

Proposed fix:
Round to appropriate decimals after each step.