### PR TITLE
sinara_tester: set Almazny test frequency to at least 7GHz

### DIFF
--- a/artiq/frontend/artiq_sinara_tester.py
+++ b/artiq/frontend/artiq_sinara_tester.py
@@ -501,7 +501,7 @@ class SinaraTester(EnvExperiment):
         print("Frequencies:")
         for card_n, channels in enumerate(chunker(self.mirnies, 4)):
             for channel_n, (channel_name, channel_dev) in enumerate(channels):
-                frequency = 2000 + card_n * 250 + channel_n * 50
+                frequency = 3500 + card_n * 250 + channel_n * 50
                 print("{}\t{}MHz".format(channel_name, frequency*2))
                 self.setup_mirny(channel_dev, frequency)
         print("RF ON, attenuators are tested. Press ENTER when done.")

--- a/artiq/frontend/artiq_sinara_tester.py
+++ b/artiq/frontend/artiq_sinara_tester.py
@@ -485,7 +485,7 @@ class SinaraTester(EnvExperiment):
             setting = led << 7 | rf_en << 6 | (att_mu & 0x3F)
             for ch in almaznys:
                 ch.set_mu(setting)
-            delay(250*ms)
+            delay(1000*ms)
             if att_mu == 0:
                 att_mu = 1
             else:


### PR DESCRIPTION
Previous 4 GHz test was due to lack of test equipment. Might cause confusion.

Almazny theoretical minimum frequency is 6800 MHz, see: [AD5356 datasheet page 4](https://www.analog.com/media/en/technical-documentation/data-sheets/adf5356.pdf)

<img width="1060" height="131" alt="image" src="https://github.com/user-attachments/assets/3f07cba5-f48d-4c16-922f-2753f0513c5e" />

Slow down attenuation update for better capture on TinySA.